### PR TITLE
Hardware: added support for KORAD KD3005P

### DIFF
--- a/src/hardware/korad-kaxxxxp/api.c
+++ b/src/hardware/korad-kaxxxxp/api.c
@@ -54,6 +54,9 @@ static const struct korad_kaxxxxp_model models[] = {
 	/* Sometimes the KA3005P has an extra 0x01 after the ID. */
 	{KORAD_KA3005P_0X01, "Korad", "KA3005P",
 		"KORADKA3005PV2.0\x01", 1, {0, 31, 0.01}, {0, 5, 0.001}},
+	/* KORAD_KD3005P */
+	{KORAD_KD3005P, "Korad", "KD3005P",
+		"KORAD KD3005P V2.0", 1, {0, 31, 0.01}, {0, 5, 0.001}},
 	ALL_ZERO
 };
 

--- a/src/hardware/korad-kaxxxxp/protocol.h
+++ b/src/hardware/korad-kaxxxxp/protocol.h
@@ -35,6 +35,7 @@ enum {
 	VELLEMAN_LABPS3005D,
 	KORAD_KA3005P,
 	KORAD_KA3005P_0X01,
+	KORAD_KD3005P,
 	/* Support for future devices with this protocol. */
 };
 


### PR DESCRIPTION
I've added the device identifier for my kd3005P.

It's electrical capabilities are identical to the ka3005p.