### PR TITLE
Unbreak libsigrok fx2lafw on FreeBSD

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -753,7 +753,9 @@ SR_API const char *sr_dev_inst_connid_get(const struct sr_dev_inst *sdi)
 			if (b != usb->bus || a != usb->address)
 				continue;
 
-			usb_get_port_path(devlist[i], connection_id, sizeof(connection_id));
+			if (usb_get_port_path(devlist[i], connection_id, sizeof(connection_id)) < 0)
+				continue;
+
 			((struct sr_dev_inst *)sdi)->connection_id = g_strdup(connection_id);
 			break;
 		}

--- a/src/hardware/chronovu-la/api.c
+++ b/src/hardware/chronovu-la/api.c
@@ -192,9 +192,9 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 			continue;
 		}
 
-		usb_get_port_path(devlist[i], connection_id, sizeof(connection_id));
-
 		libusb_close(hdl);
+
+		usb_get_port_path(devlist[i], connection_id, sizeof(connection_id));
 
 		if (!strcmp(product, "ChronoVu LA8"))
 			model = 0;

--- a/src/hardware/chronovu-la/api.c
+++ b/src/hardware/chronovu-la/api.c
@@ -194,7 +194,8 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 
 		libusb_close(hdl);
 
-		usb_get_port_path(devlist[i], connection_id, sizeof(connection_id));
+		if (usb_get_port_path(devlist[i], connection_id, sizeof(connection_id)) < 0)
+			continue;
 
 		if (!strcmp(product, "ChronoVu LA8"))
 			model = 0;

--- a/src/hardware/dreamsourcelab-dslogic/api.c
+++ b/src/hardware/dreamsourcelab-dslogic/api.c
@@ -214,9 +214,9 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 			continue;
 		}
 
-		usb_get_port_path(devlist[i], connection_id, sizeof(connection_id));
-
 		libusb_close(hdl);
+
+		usb_get_port_path(devlist[i], connection_id, sizeof(connection_id));
 
 		prof = NULL;
 		for (j = 0; supported_device[j].vid; j++) {

--- a/src/hardware/dreamsourcelab-dslogic/api.c
+++ b/src/hardware/dreamsourcelab-dslogic/api.c
@@ -216,7 +216,8 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 
 		libusb_close(hdl);
 
-		usb_get_port_path(devlist[i], connection_id, sizeof(connection_id));
+		if (usb_get_port_path(devlist[i], connection_id, sizeof(connection_id)) < 0)
+			continue;
 
 		prof = NULL;
 		for (j = 0; supported_device[j].vid; j++) {

--- a/src/hardware/dreamsourcelab-dslogic/protocol.c
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.c
@@ -568,7 +568,9 @@ SR_PRIV int dslogic_dev_open(struct sr_dev_inst *sdi, struct sr_dev_driver *di)
 		if ((sdi->status == SR_ST_INITIALIZING) ||
 				(sdi->status == SR_ST_INACTIVE)) {
 			/* Check device by its physical USB bus/port address. */
-			usb_get_port_path(devlist[i], connection_id, sizeof(connection_id));
+			if (usb_get_port_path(devlist[i], connection_id, sizeof(connection_id)) < 0)
+				continue;
+
 			if (strcmp(sdi->connection_id, connection_id))
 				/* This is not the one. */
 				continue;

--- a/src/hardware/fx2lafw/api.c
+++ b/src/hardware/fx2lafw/api.c
@@ -265,7 +265,8 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 
 		libusb_close(hdl);
 
-		usb_get_port_path(devlist[i], connection_id, sizeof(connection_id));
+		if (usb_get_port_path(devlist[i], connection_id, sizeof(connection_id)) < 0)
+			continue;
 
 		prof = NULL;
 		for (j = 0; supported_fx2[j].vid; j++) {

--- a/src/hardware/fx2lafw/api.c
+++ b/src/hardware/fx2lafw/api.c
@@ -263,9 +263,9 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 			continue;
 		}
 
-		usb_get_port_path(devlist[i], connection_id, sizeof(connection_id));
-
 		libusb_close(hdl);
+
+		usb_get_port_path(devlist[i], connection_id, sizeof(connection_id));
 
 		prof = NULL;
 		for (j = 0; supported_fx2[j].vid; j++) {

--- a/src/hardware/fx2lafw/protocol.c
+++ b/src/hardware/fx2lafw/protocol.c
@@ -174,7 +174,9 @@ SR_PRIV int fx2lafw_dev_open(struct sr_dev_inst *sdi, struct sr_dev_driver *di)
 			/*
 			 * Check device by its physical USB bus/port address.
 			 */
-			usb_get_port_path(devlist[i], connection_id, sizeof(connection_id));
+			if (usb_get_port_path(devlist[i], connection_id, sizeof(connection_id)) < 0)
+				continue;
+
 			if (strcmp(sdi->connection_id, connection_id))
 				/* This is not the one. */
 				continue;

--- a/src/hardware/hantek-6xxx/api.c
+++ b/src/hardware/hantek-6xxx/api.c
@@ -217,7 +217,8 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 
 		libusb_get_device_descriptor(devlist[i], &des);
 
-		usb_get_port_path(devlist[i], connection_id, sizeof(connection_id));
+		if (usb_get_port_path(devlist[i], connection_id, sizeof(connection_id)) < 0)
+			continue;
 
 		prof = NULL;
 		for (j = 0; dev_profiles[j].orig_vid; j++) {

--- a/src/hardware/hantek-6xxx/protocol.c
+++ b/src/hardware/hantek-6xxx/protocol.c
@@ -46,7 +46,9 @@ SR_PRIV int hantek_6xxx_open(struct sr_dev_inst *sdi)
 			/*
 			 * Check device by its physical USB bus/port address.
 			 */
-			usb_get_port_path(devlist[i], connection_id, sizeof(connection_id));
+			if (usb_get_port_path(devlist[i], connection_id, sizeof(connection_id)) < 0)
+				continue;
+
 			if (strcmp(sdi->connection_id, connection_id))
 				/* This is not the one. */
 				continue;

--- a/src/hardware/hantek-dso/api.c
+++ b/src/hardware/hantek-dso/api.c
@@ -315,7 +315,8 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 
 		libusb_get_device_descriptor(devlist[i], &des);
 
-		usb_get_port_path(devlist[i], connection_id, sizeof(connection_id));
+		if (usb_get_port_path(devlist[i], connection_id, sizeof(connection_id)) < 0)
+			continue;
 
 		prof = NULL;
 		for (j = 0; dev_profiles[j].orig_vid; j++) {

--- a/src/hardware/hantek-dso/protocol.c
+++ b/src/hardware/hantek-dso/protocol.c
@@ -130,7 +130,9 @@ SR_PRIV int dso_open(struct sr_dev_inst *sdi)
 			/*
 			 * Check device by its physical USB bus/port address.
 			 */
-			usb_get_port_path(devlist[i], connection_id, sizeof(connection_id));
+			if (usb_get_port_path(devlist[i], connection_id, sizeof(connection_id)) < 0)
+				continue;
+
 			if (strcmp(sdi->connection_id, connection_id))
 				/* This is not the one. */
 				continue;

--- a/src/hardware/lecroy-logicstudio/api.c
+++ b/src/hardware/lecroy-logicstudio/api.c
@@ -134,7 +134,8 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 		if (des.idVendor != LOGICSTUDIO16_VID)
 			continue;
 
-		usb_get_port_path(devlist[i], connection_id, sizeof(connection_id));
+		if (usb_get_port_path(devlist[i], connection_id, sizeof(connection_id)) < 0)
+			continue;
 
 		usb = NULL;
 
@@ -210,7 +211,8 @@ static int open_device(struct sr_dev_inst *sdi)
 			des.idProduct != LOGICSTUDIO16_PID_HAVE_FIRMWARE)
 			continue;
 
-		usb_get_port_path(devlist[i], connection_id, sizeof(connection_id));
+		if (usb_get_port_path(devlist[i], connection_id, sizeof(connection_id)) < 0)
+			continue;
 
 		/*
 		 * Check if this device is the same one that we associated

--- a/src/hardware/saleae-logic-pro/api.c
+++ b/src/hardware/saleae-logic-pro/api.c
@@ -240,7 +240,8 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 		if (des.idVendor != 0x21a9 || des.idProduct != 0x1006)
 			continue;
 
-		usb_get_port_path(devlist[i], connection_id, sizeof(connection_id));
+		if (usb_get_port_path(devlist[i], connection_id, sizeof(connection_id)) < 0)
+			continue;
 
 		sdi = g_malloc0(sizeof(struct sr_dev_inst));
 		sdi->status = SR_ST_INITIALIZING;

--- a/src/hardware/saleae-logic16/api.c
+++ b/src/hardware/saleae-logic16/api.c
@@ -188,7 +188,8 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 
 		libusb_get_device_descriptor(devlist[i], &des);
 
-		usb_get_port_path(devlist[i], connection_id, sizeof(connection_id));
+		if (usb_get_port_path(devlist[i], connection_id, sizeof(connection_id)) < 0)
+			continue;
 
 		if (des.idVendor != LOGIC16_VID || des.idProduct != LOGIC16_PID)
 			continue;
@@ -266,7 +267,9 @@ static int logic16_dev_open(struct sr_dev_inst *sdi)
 			/*
 			 * Check device by its physical USB bus/port address.
 			 */
-			usb_get_port_path(devlist[i], connection_id, sizeof(connection_id));
+			if (usb_get_port_path(devlist[i], connection_id, sizeof(connection_id)) < 0)
+				continue;
+
 			if (strcmp(sdi->connection_id, connection_id))
 				/* This is not the one. */
 				continue;

--- a/src/hardware/testo/api.c
+++ b/src/hardware/testo/api.c
@@ -109,7 +109,8 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 		if (strncmp(manufacturer, "testo", 5))
 			continue;
 
-		usb_get_port_path(devlist[i], connection_id, sizeof(connection_id));
+		if (usb_get_port_path(devlist[i], connection_id, sizeof(connection_id)) < 0)
+			continue;
 
 		/* Hardcode the 435 for now. */
 		if (strcmp(product, "testo 435/635/735"))

--- a/src/hardware/victor-dmm/api.c
+++ b/src/hardware/victor-dmm/api.c
@@ -69,7 +69,8 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 		if (des.idVendor != VICTOR_VID || des.idProduct != VICTOR_PID)
 			continue;
 
-		usb_get_port_path(devlist[i], connection_id, sizeof(connection_id));
+		if (usb_get_port_path(devlist[i], connection_id, sizeof(connection_id)) < 0)
+			continue;
 
 		sdi = g_malloc0(sizeof(struct sr_dev_inst));
 		sdi->status = SR_ST_INACTIVE;

--- a/src/hardware/zeroplus-logic-cube/api.c
+++ b/src/hardware/zeroplus-logic-cube/api.c
@@ -196,7 +196,8 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 
 		libusb_close(hdl);
 
-		usb_get_port_path(devlist[i], connection_id, sizeof(connection_id));
+		if (usb_get_port_path(devlist[i], connection_id, sizeof(connection_id)) < 0)
+			continue;
 
 		prof = NULL;
 		for (j = 0; j < zeroplus_models[j].vid; j++) {


### PR DESCRIPTION
These patches where sent to the sigrok-devel@ mailing-list but I got no feedback. Since sending patches over a mailing list is a good way to forget about them, and because pull-requests to this repository seems to be merged, please allow me to submit it again :wink:. Thanks!

-----------

After updating sigrok and pulseview on FreeBSD, I could not use my fx2lafw device anymore.  After investigating the issue, I found out the culprit: when `usb_get_port_path()` is called while the device is open, the function fails, but since the return value is never tested, the uninitialized memory that was supposed to receive the path is copied and considered valid, and execution continues.                                                                                                   

As a consequence, when attempting to compare the device path and uninitialized memory later on, no match is found.

Here are two commits, the first one ensure the device is closed before calling `usb_get_port_path()` (I could only test with the fx2lafw driver, but some drivers had the wrong order and where changed too).  The second patch test the return value of usb_get_port_path() so that errors are not ignored anymore.