### PR TITLE
Free list returned by sr_session_dev_list()

### DIFF
--- a/bindings/cxx/classes.cpp
+++ b/bindings/cxx/classes.cpp
@@ -936,6 +936,7 @@ Session::Session(shared_ptr<Context> context, string filename) :
 		_owned_devices.emplace(sdi, move(device));
 	}
 	_context->_session = this;
+	g_slist_free(dev_list);
 }
 
 Session::~Session()
@@ -970,6 +971,7 @@ vector<shared_ptr<Device>> Session::devices()
 		auto *const sdi = static_cast<struct sr_dev_inst *>(dev->data);
 		result.push_back(get_device(sdi));
 	}
+	g_slist_free(dev_list);
 	return result;
 }
 


### PR DESCRIPTION
```
==214948== 16 bytes in 1 blocks are definitely lost in loss record 161 of 6,440
==214948==    at 0x4C2EE0B: malloc (vg_replace_malloc.c:299)
==214948==    by 0x650F435: g_malloc (in /usr/lib64/libglib-2.0.so.0.5600.3)
==214948==    by 0x6527056: g_slice_alloc (in /usr/lib64/libglib-2.0.so.0.5600.3)
==214948==    by 0x65284B0: g_slist_copy_deep (in /usr/lib64/libglib-2.0.so.0.5600.3)
==214948==    by 0x592BBA6: sr_session_dev_list (session.c:402)
==214948==    by 0x56EF7B5: sigrok::Session::Session(std::shared_ptr<sigrok::Context>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (classes.cpp:932)
```
```
==214948== 16 bytes in 1 blocks are definitely lost in loss record 162 of 6,440
==214948==    at 0x4C2EE0B: malloc (vg_replace_malloc.c:299)
==214948==    by 0x650F435: g_malloc (in /usr/lib64/libglib-2.0.so.0.5600.3)
==214948==    by 0x6527056: g_slice_alloc (in /usr/lib64/libglib-2.0.so.0.5600.3)
==214948==    by 0x65284B0: g_slist_copy_deep (in /usr/lib64/libglib-2.0.so.0.5600.3)
==214948==    by 0x592BBA6: sr_session_dev_list (session.c:402)
==214948==    by 0x56F1EB1: sigrok::Session::devices() (classes.cpp:967)
```