### PR TITLE
Add support for YiXingDianZi MDSO in hantek-6xxx driver.

### DIFF
--- a/contrib/60-libsigrok.rules
+++ b/contrib/60-libsigrok.rules
@@ -272,6 +272,9 @@ ATTRS{idVendor}=="04fc", ATTRS{idProduct}=="0201", ENV{ID_SIGROK}="1"
 # Victor 86C
 ATTRS{idVendor}=="1244", ATTRS{idProduct}=="d237", ENV{ID_SIGROK}="1"
 
+# YiXingDianZi MDSO
+ATTRS{idVendor}=="d4a2", ATTRS{idProduct}=="5660", ENV{ID_SIGROK}="1"
+
 # ZEROPLUS Logic Cube LAP-C series
 # There are various devices in the ZEROPLUS Logic Cube series:
 # 0c12:7002: LAP-16128U

--- a/src/hardware/hantek-6xxx/api.c
+++ b/src/hardware/hantek-6xxx/api.c
@@ -89,6 +89,11 @@ static const struct hantek_6xxx_profile dev_profiles[] = {
 		"Hantek", "6022BL", "fx2lafw-hantek-6022bl.fw",
 		ARRAY_AND_SIZE(dc_coupling), FALSE,
 	},
+	{
+		0xd4a2, 0x5660, 0x1d50, 0x608e, 0x0004,
+		"YiXingDianZi", "MDSO", "fx2lafw-yixingdianzi-mdso.fw",
+		ARRAY_AND_SIZE(dc_coupling), FALSE,
+	},
 	ALL_ZERO
 };
 


### PR DESCRIPTION
Basic support for YiXingDianZi (Noname/OEM) MDSO.
It works, but V/div on '10' range is incorrect and fixing this require some rewrite of whole hantek-6xxx driver.