### PR TITLE
Fix IPDBG LA driver on windows

### DIFF
--- a/src/hardware/ipdbg-la/api.c
+++ b/src/hardware/ipdbg-la/api.c
@@ -262,13 +262,15 @@ static int dev_acquisition_stop(struct sr_dev_inst *sdi)
 	struct ipdbg_la_tcp *tcp = sdi->conn;
 	struct dev_context *devc = sdi->priv;
 
-	uint8_t byte;
+	const size_t bufsize = 1024;
+	uint8_t buffer[bufsize];
 
 	if (devc->num_transfers > 0) {
 		while (devc->num_transfers <
 			(devc->limit_samples_max * devc->data_width_bytes)) {
-			ipdbg_la_tcp_receive(tcp, &byte);
-			devc->num_transfers++;
+			int recd = ipdbg_la_tcp_receive(tcp, buffer, bufsize);
+			if (recd > 0)
+				devc->num_transfers += recd;
 		}
 	}
 

--- a/src/hardware/ipdbg-la/protocol.h
+++ b/src/hardware/ipdbg-la/protocol.h
@@ -58,7 +58,8 @@ SR_PRIV struct ipdbg_la_tcp *ipdbg_la_tcp_new(void);
 SR_PRIV void ipdbg_la_tcp_free(struct ipdbg_la_tcp *tcp);
 SR_PRIV int ipdbg_la_tcp_open(struct ipdbg_la_tcp *tcp);
 SR_PRIV int ipdbg_la_tcp_close(struct ipdbg_la_tcp *tcp);
-SR_PRIV int ipdbg_la_tcp_receive(struct ipdbg_la_tcp *tcp, uint8_t *buf);
+SR_PRIV int ipdbg_la_tcp_receive(struct ipdbg_la_tcp *tcp,
+	uint8_t *buf, size_t bufsize);
 
 SR_PRIV int ipdbg_la_convert_trigger(const struct sr_dev_inst *sdi);
 


### PR DESCRIPTION
The IPDBG LA driver is not working on windows.
First patch is working on windows but unusable slow.
Second patch improves speed.
Tested on linux fedora 29 and windows 7
