### PR TITLE
korad-kaxxxxp: support for Stamos S-LS-31 power supply

### DIFF
--- a/src/hardware/korad-kaxxxxp/api.c
+++ b/src/hardware/korad-kaxxxxp/api.c
@@ -65,6 +65,8 @@ static const struct korad_kaxxxxp_model models[] = {
 		"TENMA72-2540V2.0", 1, {0, 31, 0.01}, {0, 5, 0.001}},
 	{TENMA_72_2540_V21, "Tenma", "72-2540",
 		"TENMA 72-2540 V2.1", 1, {0, 31, 0.01}, {0, 5, 0.001}},
+	{STAMOS_SLS31_V20, "Stamos Soldering", "S-LS-31",
+		"S-LS-31 V2.0", 1, {0, 31, 0.01}, {0, 5.1, 0.001}},
 	ALL_ZERO
 };
 

--- a/src/hardware/korad-kaxxxxp/protocol.h
+++ b/src/hardware/korad-kaxxxxp/protocol.h
@@ -41,6 +41,7 @@ enum {
 	RND_320K30PV,
 	TENMA_72_2540_V20,
 	TENMA_72_2540_V21,
+	STAMOS_SLS31_V20,
 	/* Support for future devices with this protocol. */
 };
 


### PR DESCRIPTION
This is another rebranded Korad device.
See http://www.stamos-welding.com/mains-adapter-s-ls-31 for specs