### PR TITLE
warn only if salea fpga (clone) is unsupported

### DIFF
--- a/src/hardware/saleae-logic16/protocol.c
+++ b/src/hardware/saleae-logic16/protocol.c
@@ -428,8 +428,7 @@ static int prime_fpga(const struct sr_dev_inst *sdi)
 		return ret;
 
 	if (version != 0x10 && version != 0x13 && version != 0x40 && version != 0x41) {
-		sr_err("Unsupported FPGA version: 0x%02x.", version);
-		return SR_ERR;
+		sr_warn("Unsupported FPGA version: 0x%02x.", version);
 	}
 
 	return SR_OK;


### PR DESCRIPTION
don't exit with error if the salea fpga is detected as unsupported. just issue a warning with the detected version and continue. i have such a clone and it works with the original salea software and with sigrok despite the fact, it's FPGA version is 0xff.
