### PR TITLE
Add random analog signal generation to the demo device

### DIFF
--- a/src/hardware/demo/api.c
+++ b/src/hardware/demo/api.c
@@ -32,7 +32,7 @@
 #define DEFAULT_NUM_LOGIC_CHANNELS		8
 #define DEFAULT_LOGIC_PATTERN			PATTERN_SIGROK
 
-#define DEFAULT_NUM_ANALOG_CHANNELS		4
+#define DEFAULT_NUM_ANALOG_CHANNELS		5
 
 /* Note: No spaces allowed because of sigrok-cli. */
 static const char *logic_pattern_str[] = {

--- a/src/hardware/demo/protocol.h
+++ b/src/hardware/demo/protocol.h
@@ -95,6 +95,7 @@ enum analog_pattern_type {
 	PATTERN_SINE,
 	PATTERN_TRIANGLE,
 	PATTERN_SAWTOOTH,
+	PATTERN_ANALOG_RANDOM
 };
 
 static const char *analog_pattern_str[] = {
@@ -102,6 +103,7 @@ static const char *analog_pattern_str[] = {
 	"sine",
 	"triangle",
 	"sawtooth",
+	"random"
 };
 
 struct analog_pattern {


### PR DESCRIPTION
This PR adds ability to generate random signal with the demo device. I have also increased the demo device analog channel count from 4 to 5 to being able to demonstrate this capability by default. 