### PR TITLE
rigol-ds: Add initial Rigol MSO5000 support.

### DIFF
--- a/contrib/60-libsigrok.rules
+++ b/contrib/60-libsigrok.rules
@@ -206,6 +206,9 @@ ATTRS{idVendor}=="1ab1", ATTRS{idProduct}=="0641", ENV{ID_SIGROK}="1"
 # Rigol DP800 series
 ATTRS{idVendor}=="1ab1", ATTRS{idProduct}=="0e11", ENV{ID_SIGROK}="1"
 
+# Rigol MSO5000 series
+ATTRS{idVendor}=="1ab1", ATTRS{idProduct}=="0515", ENV{ID_SIGROK}="1"
+
 # Rohde&Schwarz HMO series mixed-signal oscilloscope (previously branded Hameg) VCP/USBTMC mode
 ATTRS{idVendor}=="0aad", ATTRS{idProduct}=="0117", ENV{ID_SIGROK}="1"
 ATTRS{idVendor}=="0aad", ATTRS{idProduct}=="0118", ENV{ID_SIGROK}="1"

--- a/src/hardware/rigol-ds/protocol.c
+++ b/src/hardware/rigol-ds/protocol.c
@@ -370,6 +370,7 @@ SR_PRIV int rigol_ds_capture_start(const struct sr_dev_inst *sdi)
 		break;
 	case PROTOCOL_V3:
 	case PROTOCOL_V4:
+	case PROTOCOL_V5:
 		if (rigol_ds_config_set(sdi, ":WAV:FORM BYTE") != SR_OK)
 			return SR_ERR;
 		if (devc->data_source == DATA_SOURCE_LIVE) {
@@ -382,7 +383,7 @@ SR_PRIV int rigol_ds_capture_start(const struct sr_dev_inst *sdi)
 			if (devc->model->series->protocol == PROTOCOL_V3) {
 				if (rigol_ds_config_set(sdi, ":WAV:MODE RAW") != SR_OK)
 					return SR_ERR;
-			} else if (devc->model->series->protocol == PROTOCOL_V4) {
+			} else if (devc->model->series->protocol >= PROTOCOL_V4) {
 				num_channels = 0;
 
 				/* Channels 3 and 4 are multiplexed with D0-7 and D8-15 */
@@ -477,6 +478,7 @@ SR_PRIV int rigol_ds_channel_start(const struct sr_dev_inst *sdi)
 		}
 		break;
 	case PROTOCOL_V4:
+	case PROTOCOL_V5:
 		if (ch->type == SR_CHANNEL_ANALOG) {
 			if (rigol_ds_config_set(sdi, ":WAV:SOUR CHAN%d",
 					ch->index + 1) != SR_OK)
@@ -736,7 +738,7 @@ SR_PRIV int rigol_ds_receive(int fd, int revents, void *cb_data)
 		// TODO: For the MSO1000Z series, we need a way to express that
 		// this data is in fact just for a single channel, with the valid
 		// data for that channel in the LSB of each byte.
-		logic.unitsize = devc->model->series->protocol == PROTOCOL_V4 ? 1 : 2;
+		logic.unitsize = devc->model->series->protocol >= PROTOCOL_V4 ? 1 : 2;
 		logic.data = devc->buffer;
 		packet.type = SR_DF_LOGIC;
 		packet.payload = &logic;
@@ -849,9 +851,12 @@ SR_PRIV int rigol_ds_get_dev_cfg(const struct sr_dev_inst *sdi)
 		sr_dbg("Logic analyzer %s, current digital channel state:",
 				devc->la_enabled ? "enabled" : "disabled");
 		for (i = 0; i < ARRAY_SIZE(devc->digital_channels); i++) {
-			cmd = g_strdup_printf(
-				devc->model->series->protocol >= PROTOCOL_V3 ?
-					":LA:DIG%d:DISP?" : ":DIG%d:TURN?", i);
+			if (devc->model->series->protocol >= PROTOCOL_V5)
+				cmd = g_strdup_printf(":LA:DISP? D%d", i);
+			else if (devc->model->series->protocol >= PROTOCOL_V3)
+				cmd = g_strdup_printf(":LA:DIG%d:DISP?", i);
+			else
+				cmd = g_strdup_printf(":DIG%d:TURN?", i);
 			res = sr_scpi_get_bool(sdi->conn, cmd, &devc->digital_channels[i]);
 			g_free(cmd);
 			if (res != SR_OK)

--- a/src/hardware/rigol-ds/protocol.h
+++ b/src/hardware/rigol-ds/protocol.h
@@ -42,6 +42,7 @@ enum protocol_version {
 	PROTOCOL_V2, /* DS1000 */
 	PROTOCOL_V3, /* DS2000, DSO1000 */
 	PROTOCOL_V4, /* DS1000Z */
+	PROTOCOL_V5, /* MSO5000 */
 };
 
 enum data_format {

--- a/src/scpi/scpi_usbtmc_libusb.c
+++ b/src/scpi/scpi_usbtmc_libusb.c
@@ -107,6 +107,7 @@ static struct usbtmc_blacklist blacklist_remote[] = {
 	{ 0x1ab1, 0x0588 }, /* Rigol DS1000 series */
 	{ 0x1ab1, 0x04b0 }, /* Rigol DS2000 series */
 	{ 0x1ab1, 0x04b1 }, /* Rigol DS4000 series */
+	{ 0x1ab1, 0x0515 }, /* Rigol MSO5000 series */
 	{ 0x0957, 0x0588 }, /* Agilent DSO1000 series (rebadged Rigol DS1000) */
 	{ 0x0b21, 0xffff }, /* All Yokogawa devices */
 	{ 0xf4ec, 0xffff }, /* All Siglent SDS devices */


### PR DESCRIPTION
This adds basic support for the Rigol MSO5000 series. It has
the same problems as the DS4000 series: Live capture provides
one digital channel per byte. Buffered memory returns the data
compressed (one byte has 8 digital channels), but the banks are
read separately. It's not possible to read uint16.