### PR TITLE
Add UNI-T UT804 DMM definitions for serial and usb

### DIFF
--- a/src/hardware/serial-dmm/api.c
+++ b/src/hardware/serial-dmm/api.c
@@ -647,6 +647,12 @@ SR_REGISTER_DEV_DRIVER_LIST(serial_dmm_drivers,
 		sr_ut71x_packet_valid, sr_ut71x_parse, NULL
 	),
 	DMM(
+		"uni-t-ut804-ser", ut71x,
+		"UNI-T", "UT804", "2400/7o1/rts=0/dtr=1",
+		UT71X_PACKET_SIZE, 0, 0, NULL,
+		sr_ut71x_packet_valid, sr_ut71x_parse, NULL
+	),
+	DMM(
 		"voltcraft-vc920-ser", ut71x,
 		"Voltcraft", "VC-920 (UT-D02 cable)", "2400/7o1/rts=0/dtr=1",
 		UT71X_PACKET_SIZE, 0, 0, NULL,

--- a/src/hardware/uni-t-dmm/api.c
+++ b/src/hardware/uni-t-dmm/api.c
@@ -268,6 +268,11 @@ SR_REGISTER_DEV_DRIVER_LIST(uni_t_dmm_drivers,
 		sr_ut71x_packet_valid, sr_ut71x_parse, NULL
 	),
 	DMM(
+		"uni-t-ut804", ut71x,
+		"UNI-T", "UT804", 2400, UT71X_PACKET_SIZE,
+		sr_ut71x_packet_valid, sr_ut71x_parse, NULL
+	),
+	DMM(
 		"voltcraft-vc820", fs9721,
 		"Voltcraft", "VC-820", 2400,
 		FS9721_PACKET_SIZE,


### PR DESCRIPTION
The UT804 has basically the same hardware than the UT71x series, just a larger display and huge mostly empty plastic shell. Protocol is the same as described in the wiki and matches what UNI-T claims it talks: https://www.uni-trend.com.cn/uploadfile/2019/1021/20191021050157366.pdf

This was tested on the bench with a UT804 and a Raspberry Pi.