### PR TITLE
RFC: Support multiple channels in Fluke 28x DMMs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -313,6 +313,7 @@ if HW_FLUKE_DMM
 src_libdrivers_la_SOURCES += \
 	src/hardware/fluke-dmm/protocol.h \
 	src/hardware/fluke-dmm/protocol.c \
+	src/hardware/fluke-dmm/fluke-28x.c \
 	src/hardware/fluke-dmm/api.c
 endif
 if HW_FTDI_LA

--- a/src/hardware/fluke-dmm/api.c
+++ b/src/hardware/fluke-dmm/api.c
@@ -53,11 +53,11 @@ static const char *scan_conn[] = {
 };
 
 static const struct flukedmm_profile supported_flukedmm[] = {
-	{ FLUKE_187, "187", 100, 1000 },
-	{ FLUKE_189, "189", 100, 1000 },
-	{ FLUKE_287, "287", 100, 1000 },
-	{ FLUKE_190, "199B", 1000, 3500 },
-	{ FLUKE_289, "289", 100, 1000 },
+	{ FLUKE_187, "187", "QM\r", 100, 1000 },
+	{ FLUKE_189, "189", "QM\r", 100, 1000 },
+	{ FLUKE_287, "287", "QDDA\r", 100, 1000 },
+	{ FLUKE_190, "199B", "QM\r", 1000, 3500 },
+	{ FLUKE_289, "289", "QDDA\r", 100, 1000 },
 };
 
 static GSList *fluke_scan(struct sr_dev_driver *di, const char *conn,
@@ -204,6 +204,7 @@ static int dev_acquisition_start(const struct sr_dev_inst *sdi)
 {
 	struct dev_context *devc;
 	struct sr_serial_dev_inst *serial;
+	const char *poll_cmd;
 
 	devc = sdi->priv;
 
@@ -214,8 +215,9 @@ static int dev_acquisition_start(const struct sr_dev_inst *sdi)
 	serial_source_add(sdi->session, serial, G_IO_IN, 50,
 			fluke_receive_data, (void *)sdi);
 
-	if (serial_write_blocking(serial, "QM\r", 3, SERIAL_WRITE_TIMEOUT_MS) < 0) {
-		sr_err("Unable to send QM.");
+	poll_cmd = devc->profile->poll_cmd;
+	if (serial_write_blocking(serial, poll_cmd, strlen(poll_cmd), SERIAL_WRITE_TIMEOUT_MS) < 0) {
+		sr_err("Unable to send poll command.");
 		return SR_ERR;
 	}
 	devc->cmd_sent_at = g_get_monotonic_time() / 1000;

--- a/src/hardware/fluke-dmm/api.c
+++ b/src/hardware/fluke-dmm/api.c
@@ -52,13 +52,47 @@ static const char *scan_conn[] = {
 	NULL
 };
 
-static const struct flukedmm_profile supported_flukedmm[] = {
-	{ FLUKE_187, "187", "QM\r", 100, 1000 },
-	{ FLUKE_189, "189", "QM\r", 100, 1000 },
-	{ FLUKE_287, "287", "QDDA\r", 100, 1000 },
-	{ FLUKE_190, "199B", "QM\r", 1000, 3500 },
-	{ FLUKE_289, "289", "QDDA\r", 100, 1000 },
+static const char *ch_single[] = { "P1", NULL };
+
+/* See fluke-28x.c for an enum corresponding to these names. */
+static const char *ch_28x[] = {
+	"Live",
+	"Rel. Live",
+	"Prim",
+	"Sec",
+	"Bargraph",
+	"Minimum",
+	"Maximum",
+	"Average",
+	"Rel. Ref.",
+	"dB Ref.",
+	"Temp. Off.",
+	NULL,
 };
+
+static const struct flukedmm_profile supported_flukedmm[] = {
+	{ FLUKE_187, "187", ch_single, "QM\r", 100, 1000 },
+	{ FLUKE_189, "189", ch_single, "QM\r", 100, 1000 },
+	{ FLUKE_190, "199B", ch_single, "QM\r", 1000, 3500 },
+	{ FLUKE_287, "287", ch_28x, "QDDA\r", 100, 1000 },
+	{ FLUKE_289, "289", ch_28x, "QDDA\r", 100, 1000 },
+	{ 0, NULL, NULL, NULL, 0, 0},
+};
+
+static const struct flukedmm_profile *find_profile(const char *model)
+{
+	int i;
+
+	if (strncmp("FLUKE", model, 5))
+		return NULL;
+
+	for (i = 0; supported_flukedmm[i].model; i++) {
+		if (!strcmp(supported_flukedmm[i].modelname, model + 6))
+			return &supported_flukedmm[i];
+	}
+
+	return NULL;
+}
 
 static GSList *fluke_scan(struct sr_dev_driver *di, const char *conn,
 		const char *serialcomm)
@@ -67,8 +101,10 @@ static GSList *fluke_scan(struct sr_dev_driver *di, const char *conn,
 	struct dev_context *devc;
 	struct sr_serial_dev_inst *serial;
 	GSList *devices;
-	int retry, len, i, s;
+	int retry, len, s;
 	char buf[128], *b, **tokens;
+	const char **ch_name;
+	const struct flukedmm_profile *profile;
 
 	serial = sr_serial_dev_inst_new(conn, serialcomm);
 
@@ -108,28 +144,25 @@ static GSList *fluke_scan(struct sr_dev_driver *di, const char *conn,
 		else
 			/* Fluke 199B, at least, uses semicolon. */
 			tokens = g_strsplit(buf, ";", 3);
-		if (!strncmp("FLUKE", tokens[0], 5)
-				&& tokens[1] && tokens[2]) {
-			for (i = 0; supported_flukedmm[i].model; i++) {
-				if (strcmp(supported_flukedmm[i].modelname, tokens[0] + 6))
-					continue;
-				/* Skip leading spaces in version number. */
-				for (s = 0; tokens[1][s] == ' '; s++);
-				sdi = g_malloc0(sizeof(struct sr_dev_inst));
-				sdi->status = SR_ST_INACTIVE;
-				sdi->vendor = g_strdup("Fluke");
-				sdi->model = g_strdup(tokens[0] + 6);
-				sdi->version = g_strdup(tokens[1] + s);
-				devc = g_malloc0(sizeof(struct dev_context));
-				sr_sw_limits_init(&devc->limits);
-				devc->profile = &supported_flukedmm[i];
-				sdi->inst_type = SR_INST_SERIAL;
-				sdi->conn = serial;
-				sdi->priv = devc;
-				sr_channel_new(sdi, 0, SR_CHANNEL_ANALOG, TRUE, "P1");
-				devices = g_slist_append(devices, sdi);
-				break;
-			}
+
+		profile = find_profile(tokens[0]);
+		if (profile && tokens[1] && tokens[2]) {
+			/* Skip leading spaces in version number. */
+			for (s = 0; tokens[1][s] == ' '; s++);
+			sdi = g_malloc0(sizeof(struct sr_dev_inst));
+			sdi->status = SR_ST_INACTIVE;
+			sdi->vendor = g_strdup("Fluke");
+			sdi->model = g_strdup(tokens[0] + 6);
+			sdi->version = g_strdup(tokens[1] + s);
+			devc = g_malloc0(sizeof(struct dev_context));
+			sr_sw_limits_init(&devc->limits);
+			devc->profile = profile;
+			sdi->inst_type = SR_INST_SERIAL;
+			sdi->conn = serial;
+			sdi->priv = devc;
+			for (ch_name = profile->channels; *ch_name; ch_name++)
+				sr_channel_new(sdi, 0, SR_CHANNEL_ANALOG, TRUE, *ch_name);
+			devices = g_slist_append(devices, sdi);
 		}
 		g_strfreev(tokens);
 		if (devices)

--- a/src/hardware/fluke-dmm/fluke-28x.c
+++ b/src/hardware/fluke-dmm/fluke-28x.c
@@ -1,0 +1,249 @@
+/*
+ * This file is part of the libsigrok project.
+ *
+ * Copyright (C) 2019-2020 Andreas Sandberg <andreas@sandberg.pp.se>
+ * Copyright (C) 2012 Bert Vermeulen <bert@biot.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+#include <stdlib.h>
+#include <math.h>
+#include <string.h>
+#include <libsigrok/libsigrok.h>
+#include "libsigrok-internal.h"
+#include "protocol.h"
+
+enum measurement_state {
+	MEAS_S_INVALID = 0,
+	MEAS_S_NORMAL,
+	MEAS_S_BLANK,
+	MEAS_S_DISCHARGE,
+	MEAS_S_OL,
+	MEAS_S_OL_MINUS,
+	MEAS_S_OPEN_TC,
+};
+
+struct state_mapping {
+	const char *name;
+	enum measurement_state state;
+};
+
+static struct state_mapping state_map[] = {
+	{ "INVALID", MEAS_S_INVALID },
+	{ "NORMAL", MEAS_S_NORMAL },
+	{ "BLANK", MEAS_S_BLANK },
+	{ "DISCHARGE", MEAS_S_DISCHARGE },
+	{ "OL", MEAS_S_OL },
+	{ "OL_MINUS", MEAS_S_OL_MINUS },
+	{ "OPEN_TC", MEAS_S_OPEN_TC },
+};
+
+enum measurement_attribute {
+	MEAS_A_INVALID = 0,
+	MEAS_A_NONE,
+	MEAS_A_OPEN_CIRCUIT,
+	MEAS_A_SHORT_CIRCUIT,
+	MEAS_A_GLITCH_CIRCUIT,
+	MEAS_A_GOOD_DIODE,
+	MEAS_A_LO_OHMS,
+	MEAS_A_NEGATIVE_EDGE,
+	MEAS_A_POSITIVE_EDGE,
+	MEAS_A_HIGH_CURRENT,
+};
+
+struct attribute_mapping {
+	const char *name;
+	enum measurement_attribute attribute;
+};
+
+static struct attribute_mapping attribute_map[] = {
+	{ "NONE", MEAS_A_NONE },
+	{ "OPEN_CIRCUIT", MEAS_A_OPEN_CIRCUIT },
+	{ "SHORT_CIRCUIT", MEAS_A_SHORT_CIRCUIT },
+	{ "GLITCH_CIRCUIT", MEAS_A_GLITCH_CIRCUIT },
+	{ "GOOD_DIODE", MEAS_A_GOOD_DIODE },
+	{ "LO_OHMS", MEAS_A_LO_OHMS },
+	{ "NEGATIVE_EDGE", MEAS_A_NEGATIVE_EDGE },
+	{ "POSITIVE_EDGE", MEAS_A_POSITIVE_EDGE },
+	{ "HIGH_CURRENT", MEAS_A_HIGH_CURRENT },
+};
+
+struct unit_mapping {
+	const char *name;
+	enum sr_mq mq;
+	enum sr_unit unit;
+	enum sr_mqflag mqflags;
+};
+
+static struct unit_mapping unit_map[] = {
+	{ "VDC", SR_MQ_VOLTAGE, SR_UNIT_VOLT, SR_MQFLAG_DC },
+	{ "VAC", SR_MQ_VOLTAGE, SR_UNIT_VOLT, SR_MQFLAG_AC | SR_MQFLAG_RMS },
+	{ "ADC", SR_MQ_CURRENT, SR_UNIT_AMPERE, SR_MQFLAG_DC },
+	{ "AAC", SR_MQ_CURRENT, SR_UNIT_AMPERE, SR_MQFLAG_AC | SR_MQFLAG_RMS },
+	{ "VAC_PLUS_DC", SR_MQ_VOLTAGE, SR_UNIT_VOLT, 0 },
+	{ "AAC_PLUS_DC", SR_MQ_VOLTAGE, SR_UNIT_VOLT, 0 },
+	/* Used in peak */
+	{ "V", SR_MQ_VOLTAGE, SR_UNIT_VOLT, 0 },
+	/* Used in peak */
+	{ "A", SR_MQ_VOLTAGE, SR_UNIT_AMPERE, 0 },
+	{ "OHM", SR_MQ_RESISTANCE, SR_UNIT_OHM, 0 },
+	{ "SIE", SR_MQ_CONDUCTANCE, SR_UNIT_SIEMENS, 0 },
+	{ "Hz", SR_MQ_FREQUENCY, SR_UNIT_HERTZ, 0 },
+	{ "S", SR_MQ_PULSE_WIDTH, SR_UNIT_SECOND, 0 },
+	{ "F", SR_MQ_CAPACITANCE, SR_UNIT_FARAD, 0 },
+	{ "CEL", SR_MQ_TEMPERATURE, SR_UNIT_CELSIUS, 0 },
+	{ "FAR", SR_MQ_TEMPERATURE, SR_UNIT_FAHRENHEIT, 0 },
+	{ "PCT", SR_MQ_DUTY_CYCLE, SR_UNIT_PERCENTAGE, 0 },
+	{ "dBm", SR_MQ_VOLTAGE, SR_UNIT_DECIBEL_MW, SR_MQFLAG_AC | SR_MQFLAG_RMS },
+	{ "dBV", SR_MQ_VOLTAGE, SR_UNIT_DECIBEL_VOLT, SR_MQFLAG_AC | SR_MQFLAG_RMS },
+};
+
+static const struct unit_mapping *parse_unit(const char *name)
+{
+	unsigned int i;
+
+	if (!name)
+		return NULL;
+
+	for (i = 0; i < ARRAY_SIZE(unit_map); i++) {
+		if (!strcmp(unit_map[i].name, name))
+			return &unit_map[i];
+	}
+
+	sr_warn("Unknown unit '%s'", name);
+	return NULL;
+}
+
+static enum measurement_state parse_measurement_state(const char *name)
+{
+	unsigned int i;
+
+	if (!name)
+		return MEAS_S_INVALID;
+
+	for (i = 0; i < ARRAY_SIZE(state_map); i++) {
+		if (!strcmp(state_map[i].name, name))
+			return state_map[i].state;
+	}
+
+	sr_warn("Unknown measurement state '%s'", name);
+	return MEAS_S_INVALID;
+}
+
+
+static enum measurement_attribute parse_attribute(const char *name)
+{
+	unsigned int i;
+
+	if (!name)
+		return MEAS_A_INVALID;
+
+	for (i = 0; i < ARRAY_SIZE(attribute_map); i++) {
+		if (!strcmp(attribute_map[i].name, name))
+			return attribute_map[i].attribute;
+	}
+
+	sr_warn("Unknown measurement attribute '%s'", name);
+	return MEAS_A_INVALID;
+}
+
+SR_PRIV void fluke_handle_qm_28x(const struct sr_dev_inst *sdi, char **tokens)
+{
+	struct dev_context *devc;
+	struct sr_datafeed_packet packet;
+	struct sr_datafeed_analog analog;
+	struct sr_analog_encoding encoding;
+	struct sr_analog_meaning meaning;
+	struct sr_analog_spec spec;
+
+	float fvalue;
+	const struct unit_mapping *unit;
+	enum measurement_state state;
+	enum measurement_attribute attr;
+
+	devc = sdi->priv;
+
+	/* We should have received four values:
+	 * value, unit, state, attribute
+	 */
+	if (sr_atof_ascii(tokens[0], &fvalue) != SR_OK || fvalue == 0.0) {
+		sr_err("Invalid float '%s'.", tokens[0]);
+		return;
+	}
+
+	unit = parse_unit(tokens[1]);
+	if (!unit) {
+		sr_err("Invalid unit '%s'.", tokens[1]);
+		return;
+	}
+
+	state = parse_measurement_state(tokens[2]);
+	attr = parse_attribute(tokens[3]);
+
+	/* TODO: Use proper 'digits' value for this device (and its modes). */
+	sr_analog_init(&analog, &encoding, &meaning, &spec, 2);
+	analog.data = &fvalue;
+	analog.meaning->channels = sdi->channels;
+	analog.num_samples = 1;
+	analog.meaning->mq = unit->mq;
+	analog.meaning->mqflags = unit->mqflags;
+	analog.meaning->unit = unit->unit;
+
+	if (unit->mq == SR_MQ_RESISTANCE) {
+		switch (attr) {
+		case MEAS_A_NONE:
+			/* Normal reading */
+			break;
+		case MEAS_A_OPEN_CIRCUIT:
+			analog.meaning->mq = SR_MQ_CONTINUITY;
+			analog.meaning->unit = SR_UNIT_BOOLEAN;
+			fvalue = 0.0;
+			break;
+		case MEAS_A_SHORT_CIRCUIT:
+			analog.meaning->mq = SR_MQ_CONTINUITY;
+			analog.meaning->unit = SR_UNIT_BOOLEAN;
+			fvalue = 1.0;
+			break;
+		default:
+			analog.meaning->mq = 0;
+			break;
+		};
+	}
+
+	switch (state) {
+	case MEAS_S_NORMAL:
+		break;
+
+	case MEAS_S_OL:
+	case MEAS_S_OL_MINUS:
+	case MEAS_S_OPEN_TC:
+		if (analog.meaning->mq != SR_MQ_CONTINUITY)
+			fvalue = NAN;
+		break;
+
+	default:
+		analog.meaning->mq = 0;
+		break;
+	}
+
+	if (analog.meaning->mq != 0) {
+		/* Got a measurement. */
+		packet.type = SR_DF_ANALOG;
+		packet.payload = &analog;
+		sr_session_send(sdi, &packet);
+		sr_sw_limits_update_samples_read(&devc->limits, 1);
+	}
+}

--- a/src/hardware/fluke-dmm/fluke-28x.c
+++ b/src/hardware/fluke-dmm/fluke-28x.c
@@ -81,6 +81,41 @@ static struct attribute_mapping attribute_map[] = {
 	{ "HIGH_CURRENT", MEAS_A_HIGH_CURRENT },
 };
 
+enum reading_id {
+	READING_LIVE = 0,
+	READING_REL_LIVE,
+	READING_PRIMARY,
+	READING_SECONDARY,
+	READING_BARGRAPH,
+	READING_MINIMUM,
+	READING_MAXIMUM,
+	READING_AVERAGE,
+	READING_REL_REFERENCE,
+	READING_DB_REF,
+	READING_TEMP_OFFSET,
+
+	READING_INVALID,
+};
+
+struct reading_id_mapping {
+	const char *name;
+	enum reading_id id;
+};
+
+static struct reading_id_mapping reading_id_map[] = {
+	{ "LIVE", READING_LIVE },
+	{ "PRIMARY", READING_PRIMARY },
+	{ "SECONDARY", READING_SECONDARY },
+	{ "REL_LIVE", READING_REL_LIVE },
+	{ "BARGRAPH", READING_BARGRAPH },
+	{ "MINIMUM", READING_MINIMUM },
+	{ "MAXIMUM", READING_MAXIMUM },
+	{ "AVERAGE", READING_AVERAGE },
+	{ "REL_REFERENCE", READING_REL_REFERENCE },
+	{ "DB_REF", READING_DB_REF },
+	{ "TEMP_OFFSET", READING_TEMP_OFFSET },
+};
+
 struct unit_mapping {
 	const char *name;
 	enum sr_mq mq;
@@ -110,6 +145,79 @@ static struct unit_mapping unit_map[] = {
 	{ "dBm", SR_MQ_VOLTAGE, SR_UNIT_DECIBEL_MW, SR_MQFLAG_AC | SR_MQFLAG_RMS },
 	{ "dBV", SR_MQ_VOLTAGE, SR_UNIT_DECIBEL_VOLT, SR_MQFLAG_AC | SR_MQFLAG_RMS },
 };
+
+enum range_state {
+	RANGE_INVALID = 0,
+	RANGE_AUTO,
+	RANGE_MANUAL,
+};
+
+enum lightning_state {
+	LIGHTNING_INVALID = 0,
+	LIGHTNING_ON,
+	LIGHTNING_OFF,
+};
+
+enum measurement_mode {
+	MODE_INVALID = 0,
+	MODE_AUTO_HOLD,
+	MODE_HOLD,
+	MODE_LOW_PASS_FILTER,
+	MODE_MIN_MAX_AVG,
+	MODE_RECORD,
+	MODE_REL,
+	MODE_REL_PERCENT,
+};
+
+struct measurement_mode_mapping {
+	const char *name;
+	enum measurement_mode mode;
+	enum sr_mqflag flags;
+};
+
+struct measurement_mode_mapping measurement_mode_map[] = {
+	{ "AUTO_HOLD", MODE_AUTO_HOLD, SR_MQFLAG_HOLD },
+	{ "HOLD", MODE_HOLD, SR_MQFLAG_HOLD },
+	{ "LOW_PASS_FILTER", MODE_LOW_PASS_FILTER, 0 },
+	{ "MIN_MAX_AVG", MODE_MIN_MAX_AVG, 0 },
+	{ "RECORD", MODE_RECORD, 0 },
+	{ "REL", MODE_REL, SR_MQFLAG_RELATIVE },
+	{ "REL_PERCENT", MODE_REL_PERCENT, SR_MQFLAG_RELATIVE },
+};
+
+struct qdda_reading {
+	enum reading_id id;
+	float value;
+	const struct unit_mapping *unit;
+	int unit_exp;
+	int decimals;
+	int display_digits;
+	enum measurement_state state;
+	enum measurement_attribute attr;
+	double ts;
+};
+
+struct qdda_range {
+	enum range_state state;
+	const struct unit_mapping *unit;
+	int number;
+	int unit_exp;
+};
+
+struct qdda_message {
+	const char *prim_fun;
+	const char *sec_fun;
+	struct qdda_range range;
+	enum lightning_state lightning;
+	double min_max_start;
+	int num_modes;
+	const struct measurement_mode_mapping **modes;
+	int num_readings;
+	struct qdda_reading *readings;
+};
+
+#define QDDA_MIN_FIELDS 10
+#define QDDA_READING_FIELDS 9
 
 static const struct unit_mapping *parse_unit(const char *name)
 {
@@ -160,7 +268,151 @@ static enum measurement_attribute parse_attribute(const char *name)
 	return MEAS_A_INVALID;
 }
 
-SR_PRIV void fluke_handle_qm_28x(const struct sr_dev_inst *sdi, char **tokens)
+
+static enum range_state parse_range_state(const char *state)
+{
+	if (!strcmp("AUTO", state)) {
+		return RANGE_AUTO;
+	} else if (!strcmp("MANUAL", state)) {
+		return RANGE_MANUAL;
+	} else {
+		sr_warn("Unknown range state '%s'", state);
+		return RANGE_INVALID;
+	}
+}
+
+static enum lightning_state parse_lightning_state(const char *state)
+{
+	if (!strcmp("ON", state)) {
+		return LIGHTNING_ON;
+	} else if (!strcmp("OFF", state)) {
+		return LIGHTNING_OFF;
+	} else {
+		sr_warn("Unknown lightning state '%s'", state);
+		return LIGHTNING_INVALID;
+	}
+}
+
+static const struct measurement_mode_mapping *parse_mode(const char *name)
+{
+	unsigned int i;
+
+	if (!name)
+		return NULL;
+
+	for (i = 0; i < ARRAY_SIZE(measurement_mode_map); i++) {
+		if (!strcmp(measurement_mode_map[i].name, name))
+			return &measurement_mode_map[i];
+	}
+
+	sr_warn("Unknown measurement mode '%s'", name);
+	return NULL;
+}
+
+static enum reading_id parse_reading_id(const char *name)
+{
+	unsigned int i;
+
+	if (!name)
+		return READING_INVALID;
+
+	for (i = 0; i < ARRAY_SIZE(reading_id_map); i++) {
+		if (!strcmp(reading_id_map[i].name, name))
+			return reading_id_map[i].id;
+	}
+
+	sr_warn("Unknown reading id '%s'", name);
+	return READING_INVALID;
+}
+
+static struct qdda_message *parse_qdda(char **tokens, int tokenc)
+{
+	struct qdda_message *msg;
+	struct qdda_reading *r;
+	int cur;
+	int i;
+
+	if (tokenc < QDDA_MIN_FIELDS) {
+		sr_err("Too few fields in QDDA response. Got %i, expected %i.",
+		       tokenc, QDDA_MIN_FIELDS);
+		return NULL;
+	}
+
+	cur = 0;
+	msg = g_malloc(sizeof(struct qdda_message));
+	msg->modes = NULL;
+	msg->readings = NULL;
+
+	msg->prim_fun = tokens[cur++];
+	msg->sec_fun = tokens[cur++];
+	msg->range.state = parse_range_state(tokens[cur++]);
+	msg->range.unit = parse_unit(tokens[cur++]);
+	if (!msg->range.unit ||
+	    sr_atoi(tokens[cur++], &msg->range.number) != SR_OK ||
+	    sr_atoi(tokens[cur++], &msg->range.unit_exp) != SR_OK)
+		goto parse_error;
+	msg->lightning = parse_lightning_state(tokens[cur++]);
+	if (sr_atod(tokens[cur++], &msg->min_max_start) != SR_OK ||
+	    sr_atoi(tokens[cur++], &msg->num_modes) != SR_OK)
+		goto parse_error;
+
+	if (tokenc - cur < msg->num_modes) {
+		sr_err("Too few fields for QDDA response after mode count.");
+		goto err_out;
+	}
+	msg->modes = g_malloc(msg->num_modes * sizeof(void *));
+	for (i = 0; i < msg->num_modes; i++) {
+		msg->modes[i] = parse_mode(tokens[cur++]);
+		if (!msg->modes[i])
+			goto parse_error;
+	}
+
+	if (sr_atoi(tokens[cur++], &msg->num_readings) != SR_OK)
+		goto parse_error;
+	if (tokenc - cur < msg->num_readings * QDDA_READING_FIELDS) {
+		sr_err("Too few fields for QDDA response after readings count.");
+		goto err_out;
+	}
+	msg->readings = g_malloc(msg->num_readings * sizeof(struct qdda_reading));
+	for (i = 0; i < msg->num_readings; i++) {
+		r = &msg->readings[i];
+
+		r->id = parse_reading_id(tokens[cur++]);
+		if (sr_atof(tokens[cur++], &r->value) != SR_OK)
+			goto parse_error;
+		r->unit = parse_unit(tokens[cur++]);
+		if (!r->unit ||
+		    sr_atoi(tokens[cur++], &r->unit_exp) != SR_OK ||
+		    sr_atoi(tokens[cur++], &r->decimals) != SR_OK ||
+		    sr_atoi(tokens[cur++], &r->display_digits) != SR_OK)
+			goto parse_error;
+
+		r->state = parse_measurement_state(tokens[cur++]);
+		r->attr = parse_attribute(tokens[cur++]);
+		if (sr_atod(tokens[cur++], &r->ts) != SR_OK)
+		    goto parse_error;
+	}
+
+	if (cur != tokenc) {
+		sr_warn("Unexpected number of QDDA fields. Parsed %i, expected %i.",
+			cur, tokenc);
+	}
+
+	return msg;
+
+parse_error:
+	sr_err("Fatal error when parsing QDDA reply");
+err_out:
+	if (msg->modes)
+		g_free(msg->modes);
+	if (msg->readings)
+		g_free(msg->readings);
+	g_free(msg);
+	return NULL;
+}
+
+SR_PRIV void fluke_handle_qdda_28x(const struct sr_dev_inst *sdi,
+				   char **tokens, int num_tokens)
 {
 	struct dev_context *devc;
 	struct sr_datafeed_packet packet;
@@ -169,81 +421,40 @@ SR_PRIV void fluke_handle_qm_28x(const struct sr_dev_inst *sdi, char **tokens)
 	struct sr_analog_meaning meaning;
 	struct sr_analog_spec spec;
 
-	float fvalue;
-	const struct unit_mapping *unit;
-	enum measurement_state state;
-	enum measurement_attribute attr;
+	int i;
+	struct qdda_message *qdda;
+	enum sr_mqflag flags;
 
 	devc = sdi->priv;
 
-	/* We should have received four values:
-	 * value, unit, state, attribute
-	 */
-	if (sr_atof_ascii(tokens[0], &fvalue) != SR_OK || fvalue == 0.0) {
-		sr_err("Invalid float '%s'.", tokens[0]);
+	sr_dbg("Parsing QDDA response with %i tokens", num_tokens);
+	qdda = parse_qdda(tokens, num_tokens);
+	if (!qdda)
 		return;
-	}
 
-	unit = parse_unit(tokens[1]);
-	if (!unit) {
-		sr_err("Invalid unit '%s'.", tokens[1]);
-		return;
-	}
+	// Device flags shared across all readings
+	flags = qdda->range.state == RANGE_AUTO ? SR_MQFLAG_AUTORANGE : 0;
+	for (i = 0; i < qdda->num_modes; i++)
+		flags |= qdda->modes[i]->flags;
 
-	state = parse_measurement_state(tokens[2]);
-	attr = parse_attribute(tokens[3]);
+	// TODO: qdda->state
+	// TODO: qdda->attribute
+	// TODO: Continuity measurements (prim./sec. func)
 
-	/* TODO: Use proper 'digits' value for this device (and its modes). */
-	sr_analog_init(&analog, &encoding, &meaning, &spec, 2);
-	analog.data = &fvalue;
+	sr_analog_init(&analog, &encoding, &meaning, &spec,
+		       qdda->readings[0].decimals - qdda->readings[0].unit_exp);
+	analog.data = &qdda->readings[0].value;
 	analog.meaning->channels = sdi->channels;
 	analog.num_samples = 1;
-	analog.meaning->mq = unit->mq;
-	analog.meaning->mqflags = unit->mqflags;
-	analog.meaning->unit = unit->unit;
+	analog.meaning->mq = qdda->readings[0].unit->mq;
+	analog.meaning->mqflags = qdda->readings[0].unit->mqflags;
+	analog.meaning->unit = qdda->readings[0].unit->unit;
+	packet.type = SR_DF_ANALOG;
+	packet.payload = &analog;
+	sr_session_send(sdi, &packet);
+	sr_sw_limits_update_samples_read(&devc->limits, 1);
 
-	if (unit->mq == SR_MQ_RESISTANCE) {
-		switch (attr) {
-		case MEAS_A_NONE:
-			/* Normal reading */
-			break;
-		case MEAS_A_OPEN_CIRCUIT:
-			analog.meaning->mq = SR_MQ_CONTINUITY;
-			analog.meaning->unit = SR_UNIT_BOOLEAN;
-			fvalue = 0.0;
-			break;
-		case MEAS_A_SHORT_CIRCUIT:
-			analog.meaning->mq = SR_MQ_CONTINUITY;
-			analog.meaning->unit = SR_UNIT_BOOLEAN;
-			fvalue = 1.0;
-			break;
-		default:
-			analog.meaning->mq = 0;
-			break;
-		};
-	}
-
-	switch (state) {
-	case MEAS_S_NORMAL:
-		break;
-
-	case MEAS_S_OL:
-	case MEAS_S_OL_MINUS:
-	case MEAS_S_OPEN_TC:
-		if (analog.meaning->mq != SR_MQ_CONTINUITY)
-			fvalue = NAN;
-		break;
-
-	default:
-		analog.meaning->mq = 0;
-		break;
-	}
-
-	if (analog.meaning->mq != 0) {
-		/* Got a measurement. */
-		packet.type = SR_DF_ANALOG;
-		packet.payload = &analog;
-		sr_session_send(sdi, &packet);
-		sr_sw_limits_update_samples_read(&devc->limits, 1);
-	}
+	g_free(qdda->modes);
+	g_free(qdda->readings);
+	g_free(qdda);
 }

--- a/src/hardware/fluke-dmm/fluke-28x.c
+++ b/src/hardware/fluke-dmm/fluke-28x.c
@@ -81,6 +81,7 @@ static struct attribute_mapping attribute_map[] = {
 	{ "HIGH_CURRENT", MEAS_A_HIGH_CURRENT },
 };
 
+/* This enum corresponds to the channel names in api.c. */
 enum reading_id {
 	READING_LIVE = 0,
 	READING_REL_LIVE,
@@ -94,6 +95,7 @@ enum reading_id {
 	READING_DB_REF,
 	READING_TEMP_OFFSET,
 
+	READING_CH_MAX,
 	READING_INVALID,
 };
 
@@ -411,6 +413,18 @@ err_out:
 	return NULL;
 }
 
+static struct qdda_reading *get_reading(struct qdda_message *qdda, enum reading_id id)
+{
+	int i;
+
+	for (i = 0; i < qdda->num_readings; i++) {
+		if (qdda->readings[i].id == id)
+			return &qdda->readings[i];
+	}
+
+	return NULL;
+}
+
 SR_PRIV void fluke_handle_qdda_28x(const struct sr_dev_inst *sdi,
 				   char **tokens, int num_tokens)
 {
@@ -420,9 +434,12 @@ SR_PRIV void fluke_handle_qdda_28x(const struct sr_dev_inst *sdi,
 	struct sr_analog_encoding encoding;
 	struct sr_analog_meaning meaning;
 	struct sr_analog_spec spec;
+	GSList *l_ch;
+	GSList ch_only;
 
 	int i;
 	struct qdda_message *qdda;
+	struct qdda_reading *reading;
 	enum sr_mqflag flags;
 
 	devc = sdi->priv;
@@ -440,19 +457,33 @@ SR_PRIV void fluke_handle_qdda_28x(const struct sr_dev_inst *sdi,
 	// TODO: qdda->state
 	// TODO: qdda->attribute
 	// TODO: Continuity measurements (prim./sec. func)
+	sr_dbg("Got %i readings", qdda->num_readings);
+	l_ch = sdi->channels;
+	for (i = 0; i < READING_CH_MAX; i++) {
+		reading = get_reading(qdda, i);
+		if (!reading || !((struct sr_channel *)l_ch->data)->enabled) {
+			l_ch = l_ch->next;
+			continue;
+		}
 
-	sr_analog_init(&analog, &encoding, &meaning, &spec,
-		       qdda->readings[0].decimals - qdda->readings[0].unit_exp);
-	analog.data = &qdda->readings[0].value;
-	analog.meaning->channels = sdi->channels;
-	analog.num_samples = 1;
-	analog.meaning->mq = qdda->readings[0].unit->mq;
-	analog.meaning->mqflags = qdda->readings[0].unit->mqflags;
-	analog.meaning->unit = qdda->readings[0].unit->unit;
-	packet.type = SR_DF_ANALOG;
-	packet.payload = &analog;
-	sr_session_send(sdi, &packet);
-	sr_sw_limits_update_samples_read(&devc->limits, 1);
+		ch_only.next = NULL;
+		ch_only.data = l_ch->data;
+
+		sr_analog_init(&analog, &encoding, &meaning, &spec,
+			       reading->decimals - reading->unit_exp);
+		analog.data = &reading->value;
+		analog.meaning->channels = &ch_only;
+		analog.num_samples = 1;
+		analog.meaning->mq = reading->unit->mq;
+		analog.meaning->mqflags = flags | reading->unit->mqflags;
+		analog.meaning->unit = reading->unit->unit;
+		packet.type = SR_DF_ANALOG;
+		packet.payload = &analog;
+		sr_session_send(sdi, &packet);
+		sr_sw_limits_update_samples_read(&devc->limits, 1);
+
+		l_ch = l_ch->next;
+	}
 
 	g_free(qdda->modes);
 	g_free(qdda->readings);

--- a/src/hardware/fluke-dmm/protocol.h
+++ b/src/hardware/fluke-dmm/protocol.h
@@ -40,6 +40,8 @@ enum {
 struct flukedmm_profile {
 	int model;
 	const char *modelname;
+	/* Which poll command to use */
+	const char *poll_cmd;
 	/* How often to poll, in ms. */
 	int poll_period;
 	/* If no response received, how long to wait before retrying. */
@@ -61,7 +63,7 @@ struct dev_context {
 	enum sr_mqflag mqflags;
 };
 
-SR_PRIV void fluke_handle_qm_28x(const struct sr_dev_inst *sdi, char **tokens);
+SR_PRIV void fluke_handle_qdda_28x(const struct sr_dev_inst *sdi, char **tokens, int num_tokens);
 
 SR_PRIV int fluke_receive_data(int fd, int revents, void *cb_data);
 

--- a/src/hardware/fluke-dmm/protocol.h
+++ b/src/hardware/fluke-dmm/protocol.h
@@ -22,7 +22,7 @@
 
 #define LOG_PREFIX "fluke-dmm"
 
-#define FLUKEDMM_BUFSIZE 256
+#define FLUKEDMM_BUFSIZE 512
 
 /* Always USB-serial, 1ms is plenty. */
 #define SERIAL_WRITE_TIMEOUT_MS 1

--- a/src/hardware/fluke-dmm/protocol.h
+++ b/src/hardware/fluke-dmm/protocol.h
@@ -61,6 +61,8 @@ struct dev_context {
 	enum sr_mqflag mqflags;
 };
 
+SR_PRIV void fluke_handle_qm_28x(const struct sr_dev_inst *sdi, char **tokens);
+
 SR_PRIV int fluke_receive_data(int fd, int revents, void *cb_data);
 
 #endif

--- a/src/hardware/fluke-dmm/protocol.h
+++ b/src/hardware/fluke-dmm/protocol.h
@@ -40,6 +40,7 @@ enum {
 struct flukedmm_profile {
 	int model;
 	const char *modelname;
+	const char **channels;
 	/* Which poll command to use */
 	const char *poll_cmd;
 	/* How often to poll, in ms. */


### PR DESCRIPTION
This is a pull request to get early feedback on a set of changes that add support for logging all of the channels (live, primary, secondary, etc.) reported by the Fluke 28x series of DMMs. The channel names in this pull request are not final and currently only reflect the names in the protocol specification.