### PR TITLE
Include missing header file

### DIFF
--- a/bindings/cxx/include/libsigrokcxx/libsigrokcxx.hpp
+++ b/bindings/cxx/include/libsigrokcxx/libsigrokcxx.hpp
@@ -78,6 +78,7 @@ G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 #include <glibmm.h>
 G_GNUC_END_IGNORE_DEPRECATIONS
 
+#include <functional>
 #include <stdexcept>
 #include <memory>
 #include <vector>


### PR DESCRIPTION
Including the `functional` header is necessary in order to use `std::function` in the definition of `LogCallbackFunction` when compiling with gcc 7.3.0.