### PR TITLE
FT2232H recognition of TUMPA boards

### DIFF
--- a/src/hardware/ftdi-la/api.c
+++ b/src/hardware/ftdi-la/api.c
@@ -61,7 +61,7 @@ static const struct ftdi_chip_desc ft2232h_tumpa_desc = {
 	.vendor = 0x0403,
 	.product = 0x8A98,
 	.samplerate_div = 20,
-    /* 20 PIN JTAG Header */
+	/* 20 PIN JTAG Header */
 	.channel_names = {
 		"TCK", "TDI", "TDO", "TMS", "RST", "nTRST", "DBGRQ", "RTCK",
 		NULL

--- a/src/hardware/ftdi-la/api.c
+++ b/src/hardware/ftdi-la/api.c
@@ -57,6 +57,17 @@ static const struct ftdi_chip_desc ft2232h_desc = {
 	}
 };
 
+static const struct ftdi_chip_desc ft2232h_tumpa_desc = {
+	.vendor = 0x0403,
+	.product = 0x8A98,
+	.samplerate_div = 20,
+    /* 20 PIN JTAG Header */
+	.channel_names = {
+		"TCK", "TDI", "TDO", "TMS", "RST", "nTRST", "DBGRQ", "RTCK",
+		NULL
+	}
+};
+
 static const struct ftdi_chip_desc ft232r_desc = {
 	.vendor = 0x0403,
 	.product = 0x6001,
@@ -79,6 +90,7 @@ static const struct ftdi_chip_desc ft232h_desc = {
 
 static const struct ftdi_chip_desc *chip_descs[] = {
 	&ft2232h_desc,
+	&ft2232h_tumpa_desc,
 	&ft232r_desc,
 	&ft232h_desc,
 	NULL,


### PR DESCRIPTION
Using the channel names from the FT2232H 'TUMPA' (TIAO USB Multi-Protocol Adapter) [manual](http://www.tiaowiki.com/w/TIAO_USB_Multi_Protocol_Adapter_User%27s_Manual) : 

```
$ echo $LD_LIBRARY_PATH
/usr/local/lib:
$ lsusb -d 0403:8a98
Bus 001 Device 005: ID 0403:8a98 Future Technology Devices International, Ltd TIAO Multi-Protocol Adapter
$ sigrok-cli --driver=ftdi-la:conn=0403.8a98 --scan
The following devices were found:
ftdi-la - TIAO TIAO USB Multi-Protocol Adapter with 8 channels: TCK TDI TDO TMS RST nTRST DBGRQ RTCK
```