### PR TITLE
Improve ASCII output

### DIFF
--- a/src/output/ascii.c
+++ b/src/output/ascii.c
@@ -39,7 +39,6 @@
 struct context {
 	unsigned int num_enabled_channels;
 	int spl;
-	int bit_cnt;
 	int spl_cnt;
 	int trigger;
 	uint64_t samplerate;


### PR DESCRIPTION
* Align channels, even if their names have different lengths.
* Print the trigger if less samples than width are captured.