### PR TITLE
Modbus: Close device after scan

### DIFF
--- a/src/modbus/modbus.c
+++ b/src/modbus/modbus.c
@@ -51,13 +51,14 @@ static struct sr_dev_inst *sr_modbus_scan_resource(const char *resource,
 		return NULL;
 	};
 
-	if ((sdi = probe_device(modbus)))
-		return sdi;
+	sdi = probe_device(modbus);
 
 	sr_modbus_close(modbus);
-	sr_modbus_free(modbus);
 
-	return NULL;
+	if(!sdi)
+		sr_modbus_free(modbus);
+
+	return sdi;
 }
 
 /**


### PR DESCRIPTION
Following up in #53, this change unbreaks my RDTech DPS and should fix a similar issue for the Maynuo M97. Since `sr_modbus_probe` opens the underlying device, I think it can also close it without mentioning any of this in the documentation.