### PR TITLE
Add FT4232H recognition

### DIFF
--- a/src/hardware/ftdi-la/api.c
+++ b/src/hardware/ftdi-la/api.c
@@ -68,6 +68,17 @@ static const struct ftdi_chip_desc ft2232h_tumpa_desc = {
 	}
 };
 
+static const struct ftdi_chip_desc ft4232h_desc = {
+	.vendor = 0x0403,
+	.product = 0x6011,
+	.samplerate_div = 20,
+	.channel_names = {
+		"ADBUS0", "ADBUS1", "ADBUS2", "ADBUS3",	"ADBUS4", "ADBUS5", "ADBUS6", "ADBUS7",
+		/* TODO: BDBUS[0..7], CDBUS[0..7], DDBUS[0..7] channels. */
+		NULL
+	}
+};
+
 static const struct ftdi_chip_desc ft232r_desc = {
 	.vendor = 0x0403,
 	.product = 0x6001,
@@ -91,6 +102,7 @@ static const struct ftdi_chip_desc ft232h_desc = {
 static const struct ftdi_chip_desc *chip_descs[] = {
 	&ft2232h_desc,
 	&ft2232h_tumpa_desc,
+	&ft4232h_desc,
 	&ft232r_desc,
 	&ft232h_desc,
 	NULL,


### PR DESCRIPTION
$ lsusb -d 0403:6011
Bus 001 Device 010: ID 0403:6011 Future Technology Devices International, Ltd FT4232H Quad HS USB-UART/FIFO IC
$ sigrok-cli --driver=ftdi-la:conn=0403.6011 --scan
The following devices were found:
ftdi-la - FTDI Quad RS232-HS with 8 channels: ADBUS0 ADBUS1 ADBUS2 ADBUS3 ADBUS4 ADBUS5 ADBUS6 ADBUS7
