### PR TITLE
Make VCD files generated by Icarus Verilog and Verilator more parseable

### DIFF
--- a/src/input/vcd.c
+++ b/src/input/vcd.c
@@ -529,14 +529,18 @@ static void parse_contents(const struct sr_input *in, char *data)
 		} else if (strchr("bB", tokens[i][0]) != NULL) {
 			bit = (tokens[i][1] == '1');
 
+			if (!tokens[++i]) {
+				sr_dbg("Identifier missing!");
+				break;
+			}
+
 			/*
 			 * Bail out if a) char after 'b' is NUL, or b) there is
-			 * a second character after 'b', or c) there is no
-			 * identifier.
+			 * a second character after 'b'
 			 */
-			if (!tokens[i][1] || tokens[i][2] || !tokens[++i]) {
+			if (!tokens[i][1] || tokens[i][2]) {
 				sr_dbg("Unexpected vector format!");
-				break;
+				continue;
 			}
 
 			process_bit(inc, tokens[i], bit);


### PR DESCRIPTION
Specifically this means:

- ignoring channels with the same identifier
  - This happens when the same channel appears in different scopes.
  - The current behavior is that the channel is listed twice but that all duplicates will stay at their initial value
- ignoring vector value changes but still parsing lines after them
  - The VCD input module currently throws away an entire chunk of data if that happens which also breaks the parsing of scalar value changes in that same chunk