### PR TITLE
serial: flush() after open() in the serial core.

### DIFF
--- a/src/hardware/agilent-dmm/api.c
+++ b/src/hardware/agilent-dmm/api.c
@@ -131,7 +131,6 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 	if (serial_open(serial, SERIAL_RDWR) != SR_OK)
 		return NULL;
 
-	serial_flush(serial);
 	if (serial_write_blocking(serial, "*IDN?\r\n", 7, SERIAL_WRITE_TIMEOUT_MS) < 7) {
 		sr_err("Unable to send identification string.");
 		return NULL;

--- a/src/hardware/appa-55ii/api.c
+++ b/src/hardware/appa-55ii/api.c
@@ -79,8 +79,6 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 
 	sr_info("Probing serial port %s.", conn);
 
-	serial_flush(serial);
-
 	/* Let's get a bit of data and see if we can find a packet. */
 	if (serial_stream_detect(serial, buf, &len, 25,
 			appa_55ii_packet_valid, 500) != SR_OK)

--- a/src/hardware/arachnid-labs-re-load-pro/api.c
+++ b/src/hardware/arachnid-labs-re-load-pro/api.c
@@ -99,8 +99,6 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 	if (serial_open(serial, SERIAL_RDWR) != SR_OK)
 		return NULL;
 
-	serial_flush(serial);
-
 	/*
 	 * First stop potentially running monitoring and wait for 50ms before
 	 * next command can be sent.

--- a/src/hardware/atten-pps3xxx/api.c
+++ b/src/hardware/atten-pps3xxx/api.c
@@ -113,8 +113,6 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options, int modelid)
 	if (serial_open(serial, SERIAL_RDWR) != SR_OK)
 		return NULL;
 
-	serial_flush(serial);
-
 	/* This is how the vendor software scans for hardware. */
 	memset(packet, 0, PACKET_SIZE);
 	packet[0] = 0xaa;

--- a/src/hardware/center-3xx/api.c
+++ b/src/hardware/center-3xx/api.c
@@ -67,8 +67,6 @@ static GSList *center_scan(const char *conn, const char *serialcomm, int idx)
 	if (serial_open(serial, SERIAL_RDWR) != SR_OK)
 		return NULL;
 
-	serial_flush(serial);
-
 	sr_info("Found device on port %s.", conn);
 
 	sdi = g_malloc0(sizeof(struct sr_dev_inst));

--- a/src/hardware/conrad-digi-35-cpu/api.c
+++ b/src/hardware/conrad-digi-35-cpu/api.c
@@ -75,7 +75,6 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 	if (serial_open(serial, SERIAL_RDWR) != SR_OK)
 		return NULL;
 
-	serial_flush(serial);
 	serial_close(serial);
 
 	sr_spew("Conrad DIGI 35 CPU assumed at %s.", conn);

--- a/src/hardware/gmc-mh-1x-2x/api.c
+++ b/src/hardware/gmc-mh-1x-2x/api.c
@@ -102,6 +102,7 @@ static enum model scan_model_sm(struct sr_serial_dev_inst *serial)
 	 * Try to find message consisting of device code and several
 	 * (at least 4) data bytes.
 	 */
+	serial_flush(serial);
 	for (bytecnt = 0; bytecnt < 100; bytecnt++) {
 		byte = read_byte(serial, timeout_us);
 		if ((byte == -1) || (timeout_us < g_get_monotonic_time()))
@@ -175,8 +176,6 @@ static GSList *scan_1x_2x_rs232(struct sr_dev_driver *di, GSList *options)
 		return NULL;
 	}
 
-	serial_flush(serial);
-
 	model = scan_model_sm(serial);
 
 	/*
@@ -187,10 +186,8 @@ static GSList *scan_1x_2x_rs232(struct sr_dev_driver *di, GSList *options)
 		serialcomm = SERIALCOMM_1X_RS232;
 		g_free(serial->serialcomm);
 		serial->serialcomm = g_strdup(serialcomm);
-		if (serial_set_paramstr(serial, serialcomm) == SR_OK) {
-			serial_flush(serial);
+		if (serial_set_paramstr(serial, serialcomm) == SR_OK)
 			model = scan_model_sm(serial);
-		}
 	}
 
 	if (model != METRAHIT_NONE) {

--- a/src/hardware/gwinstek-gpd/api.c
+++ b/src/hardware/gwinstek-gpd/api.c
@@ -107,7 +107,6 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 	if (serial_open(serial, SERIAL_RDWR) != SR_OK)
 		return NULL;
 
-	serial_flush(serial);
 	gpd_send_cmd(serial, "*IDN?\n");
 	if (gpd_receive_reply(serial, reply, sizeof(reply)) != SR_OK) {
 		sr_err("Device did not reply.");

--- a/src/hardware/kern-scale/api.c
+++ b/src/hardware/kern-scale/api.c
@@ -79,7 +79,6 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 	sr_info("Probing serial port %s.", conn);
 
 	devices = NULL;
-	serial_flush(serial);
 
 	sr_spew("Set O1 mode (continuous values, stable and unstable ones).");
 	if (serial_write_blocking(serial, "O1\r\n", 4, 0) < 0)

--- a/src/hardware/korad-kaxxxxp/api.c
+++ b/src/hardware/korad-kaxxxxp/api.c
@@ -124,8 +124,6 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 	if (serial_open(serial, SERIAL_RDWR) != SR_OK)
 		return NULL;
 
-	serial_flush(serial);
-
 	/* Get the device model. */
 	len = 0;
 	for (i = 0; models[i].id; i++) {

--- a/src/hardware/manson-hcs-3xxx/api.c
+++ b/src/hardware/manson-hcs-3xxx/api.c
@@ -118,8 +118,6 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 	if (serial_open(serial, SERIAL_RDWR) != SR_OK)
 		return NULL;
 
-	serial_flush(serial);
-
 	sr_info("Probing serial port %s.", conn);
 
 	/* Get the device model. */

--- a/src/hardware/mastech-ms6514/api.c
+++ b/src/hardware/mastech-ms6514/api.c
@@ -81,8 +81,6 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 
 	sr_info("Probing serial port %s.", conn);
 
-	serial_flush(serial);
-
 	/* Let's get a bit of data and see if we can find a packet. */
 	if (serial_stream_detect(serial, buf, &len, (2 * MASTECH_MS6514_FRAME_SIZE),
 			mastech_ms6514_packet_valid, 500) != SR_OK)

--- a/src/hardware/mic-985xx/api.c
+++ b/src/hardware/mic-985xx/api.c
@@ -67,8 +67,6 @@ static GSList *mic_scan(const char *conn, const char *serialcomm, int idx)
 	if (serial_open(serial, SERIAL_RDWR) != SR_OK)
 		return NULL;
 
-	serial_flush(serial);
-
 	/* TODO: Query device type. */
 	// ret = mic_cmd_get_device_info(serial);
 

--- a/src/hardware/motech-lps-30x/api.c
+++ b/src/hardware/motech-lps-30x/api.c
@@ -378,7 +378,6 @@ static GSList *do_scan(lps_modelid modelid, struct sr_dev_driver *drv, GSList *o
 		goto exit_err;
 
 	/* Query and verify model string. */
-	serial_flush(serial);
 	if (lps_cmd_reply(buf, serial, "MODEL") != SR_OK)
 		return NULL;
 

--- a/src/hardware/norma-dmm/api.c
+++ b/src/hardware/norma-dmm/api.c
@@ -99,8 +99,6 @@ static GSList *scan(struct sr_dev_driver *drv, GSList *options)
 	if (serial_open(serial, SERIAL_RDWR) != SR_OK)
 		return NULL;
 
-	serial_flush(serial);
-
 	buf = g_malloc(BUF_MAX);
 
 	snprintf(req, sizeof(req), "%s\r\n",

--- a/src/hardware/serial-dmm/api.c
+++ b/src/hardware/serial-dmm/api.c
@@ -85,7 +85,6 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 	sr_info("Probing serial port %s.", conn);
 
 	devices = NULL;
-	serial_flush(serial);
 
 	/* Request a packet if the DMM requires this. */
 	if (dmm->packet_request) {

--- a/src/hardware/serial-lcr/api.c
+++ b/src/hardware/serial-lcr/api.c
@@ -105,7 +105,6 @@ static int scan_lcr_port(const struct lcr_info *lcr,
 	 * send data periodically. So we check if the packets match the
 	 * probed device's expected format.
 	 */
-	serial_flush(serial);
 	if (lcr->packet_request) {
 		ret = lcr->packet_request(serial);
 		if (ret < 0) {

--- a/src/hardware/teleinfo/api.c
+++ b/src/hardware/teleinfo/api.c
@@ -75,8 +75,6 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 
 	sr_info("Probing serial port %s.", conn);
 
-	serial_flush(serial);
-
 	/* Let's get a bit of data and see if we can find a packet. */
 	if (serial_stream_detect(serial, buf, &len, len,
 	                         teleinfo_packet_valid, 3000) != SR_OK)

--- a/src/hardware/uni-t-ut32x/api.c
+++ b/src/hardware/uni-t-ut32x/api.c
@@ -90,7 +90,6 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 	devices = NULL;
 	serial = sr_serial_dev_inst_new(conn, serialcomm);
 	rc = serial_open(serial, SERIAL_RDWR);
-	serial_flush(serial);
 	/* Cannot query/identify the device. Successful open shall suffice. */
 	serial_close(serial);
 	if (rc != SR_OK) {

--- a/src/modbus/modbus_serial_rtu.c
+++ b/src/modbus/modbus_serial_rtu.c
@@ -57,9 +57,6 @@ static int modbus_serial_rtu_open(void *priv)
 	if (serial_open(serial, SERIAL_RDWR) != SR_OK)
 		return SR_ERR;
 
-	if (serial_flush(serial) != SR_OK)
-		return SR_ERR;
-
 	return SR_OK;
 }
 

--- a/src/scpi/scpi_serial.c
+++ b/src/scpi/scpi_serial.c
@@ -114,9 +114,6 @@ static int scpi_serial_open(struct sr_scpi_dev_inst *scpi)
 	if (serial_open(serial, SERIAL_RDWR) != SR_OK)
 		return SR_ERR;
 
-	if (serial_flush(serial) != SR_OK)
-		return SR_ERR;
-
 	sscpi->got_newline = FALSE;
 
 	return SR_OK;

--- a/src/serial.c
+++ b/src/serial.c
@@ -122,10 +122,13 @@ SR_PRIV int serial_open(struct sr_serial_dev_inst *serial, int flags)
 	if (ret != SR_OK)
 		return ret;
 
-	if (serial->serialcomm)
-		return serial_set_paramstr(serial, serial->serialcomm);
-	else
-		return SR_OK;
+	if (serial->serialcomm) {
+		ret = serial_set_paramstr(serial, serial->serialcomm);
+		if (ret != SR_OK)
+			return ret;
+	}
+
+	return serial_flush(serial);
 }
 
 /**


### PR DESCRIPTION
Quite some drivers flush the serial port after opening it. And quite
some don't although they should. Factor this out, so serial_open() will
always flush the port. The removal in the drivers was done with this
small coccinelle script:

@@
struct sr_serial_dev_inst *serial;
@@

        serial_open(serial, ...)
        ... when != serial
-       serial_flush(serial);

and then the results and the unmatched findings of serial_flush() were
audited.

Signed-off-by: Wolfram Sang <wsa@kernel.org>