### PR TITLE
std: avoid doube close

### DIFF
--- a/src/std.c
+++ b/src/std.c
@@ -424,7 +424,7 @@ SR_PRIV int std_dev_clear_with_callback(const struct sr_dev_driver *driver,
 			ret = SR_ERR_BUG;
 			continue;
 		}
-		if (driver->dev_close)
+		if (driver->dev_close && sdi->status == SR_ST_ACTIVE)
 			driver->dev_close(sdi);
 
 		if (sdi->conn) {


### PR DESCRIPTION
I want to fix this double-close issue I see with my OLS:

First close at the end of a 'scan':

sr: [00:00.045171] openbench-logic-sniffer: Got metadata key 0x00, metadata ends.
sr: [00:00.045178] openbench-logic-sniffer: Disabling demux mode.
sr: [00:00.045186] serial: Closing serial port /dev/ttyACM0.

Second one as part of hwdriver cleanup:

sr: [00:00.046088] hwdriver: Cleaning up all drivers.
sr: [00:00.046108] serial: Closing serial port /dev/ttyACM0.
sr: [00:00.046116] serial-libsp: Cannot close unopened serial port /dev/ttyACM0.

So, before closing a second time, check if the device is not idle.

I am optimistic this could fix bugs #1151 and #1275, too.

Signed-off-by: Wolfram Sang <wsa@kernel.org>