### PR TITLE
openbench-logic-sniffer: improve error messages when scanning ID

### DIFF
--- a/src/hardware/openbench-logic-sniffer/api.c
+++ b/src/hardware/openbench-logic-sniffer/api.c
@@ -91,10 +91,10 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 	struct sr_dev_inst *sdi;
 	struct sr_serial_dev_inst *serial;
 	GSList *l;
-	int ret;
+	int num_read;
 	unsigned int i;
 	const char *conn, *serialcomm;
-	char buf[8];
+	char buf[4] = { 0, 0, 0, 0 };
 
 	conn = serialcomm = NULL;
 	for (l = options; l; l = l->next) {
@@ -136,19 +136,22 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 	g_usleep(RESPONSE_DELAY_US);
 
 	if (serial_has_receive_data(serial) == 0) {
-		sr_dbg("Didn't get any reply.");
+		sr_dbg("Didn't get any ID reply.");
 		return NULL;
 	}
 
-	ret = serial_read_blocking(serial, buf, 4, serial_timeout(serial, 4));
-	if (ret != 4) {
-		sr_err("Invalid reply (expected 4 bytes, got %d).", ret);
+	num_read = serial_read_blocking(serial, buf, 4, serial_timeout(serial, 4));
+	if (num_read < 0) {
+		sr_err("Getting ID reply failed (%d).", num_read);
 		return NULL;
 	}
 
 	if (strncmp(buf, "1SLO", 4) && strncmp(buf, "1ALS", 4)) {
-		sr_err("Invalid reply (expected '1SLO' or '1ALS', got "
-		       "'%c%c%c%c').", buf[0], buf[1], buf[2], buf[3]);
+		GString *id = sr_hexdump_new((uint8_t *)buf, num_read);
+
+		sr_err("Invalid ID reply (got %s).", id->str);
+
+		sr_hexdump_free(id);
 		return NULL;
 	}
 


### PR DESCRIPTION
- always say 'ID' when the ID command failed
- print hexdump of a faulty ID because on a stalled device we may get
  0x00 bytes which would terminate the string early.

Introduce a new 'num_read' variable to avoid that in a future change
'ret' might get reused and destroy the parameter needed for hexdump.

Signed-off-by: Wolfram Sang <wsa@kernel.org>