### PR TITLE
rigol-ds: Support for reading segmented data and some bug fixes

### DIFF
--- a/src/hardware/rigol-ds/api.c
+++ b/src/hardware/rigol-ds/api.c
@@ -293,6 +293,8 @@ static const struct rigol_ds_model supported_models[] = {
 
 static struct sr_dev_driver rigol_ds_driver_info;
 
+static int analog_frame_size(const struct sr_dev_inst *);
+
 static void clear_helper(struct dev_context *devc)
 {
 	unsigned int i;

--- a/src/hardware/rigol-ds/protocol.c
+++ b/src/hardware/rigol-ds/protocol.c
@@ -756,12 +756,8 @@ SR_PRIV int rigol_ds_receive(int fd, int revents, void *cb_data)
 			if (devc->data_source != DATA_SOURCE_LIVE)
 				rigol_ds_set_wait_event(devc, WAIT_BLOCK);
 		}
-		/* End acquisition when data for all channels is acquired. */
 		if (!sr_scpi_read_complete(scpi) && !devc->channel_entry->next) {
 			sr_err("Read should have been completed");
-			std_session_send_df_frame_end(sdi);
-			sr_dev_acquisition_stop(sdi);
-			return TRUE;
 		}
 		devc->num_block_read = 0;
 	} else {
@@ -795,7 +791,7 @@ SR_PRIV int rigol_ds_receive(int fd, int revents, void *cb_data)
 		/* Done with this frame. */
 		std_session_send_df_frame_end(sdi);
 
-		if (++devc->num_frames == devc->limit_frames) {
+		if (++devc->num_frames == devc->limit_frames || devc->data_source == DATA_SOURCE_MEMORY) {
 			/* Last frame, stop capture. */
 			sr_dev_acquisition_stop(sdi);
 		} else {

--- a/src/hardware/rigol-ds/protocol.c
+++ b/src/hardware/rigol-ds/protocol.c
@@ -432,7 +432,7 @@ SR_PRIV int rigol_ds_capture_start(const struct sr_dev_inst *sdi)
 				return SR_ERR;
 			rigol_ds_set_wait_event(devc, WAIT_STOP);
 			if (devc->data_source == DATA_SOURCE_SEGMENTED &&
-					devc->model->series->protocol == PROTOCOL_V4)
+					devc->model->series->protocol <= PROTOCOL_V4)
 				if (rigol_ds_config_set(sdi, "FUNC:WREP:FCUR %d", devc->num_frames + 1) != SR_OK)
 					return SR_ERR;
 		}

--- a/src/hardware/rigol-ds/protocol.c
+++ b/src/hardware/rigol-ds/protocol.c
@@ -338,6 +338,8 @@ SR_PRIV int rigol_ds_capture_start(const struct sr_dev_inst *sdi)
 	if (!(devc = sdi->priv))
 		return SR_ERR;
 
+	const gboolean first_frame = (devc->num_frames == 0);
+
 	uint64_t limit_frames = devc->limit_frames;
 	if (devc->num_frames_segmented != 0 && devc->num_frames_segmented < limit_frames)
 		limit_frames = devc->num_frames_segmented;
@@ -374,17 +376,17 @@ SR_PRIV int rigol_ds_capture_start(const struct sr_dev_inst *sdi)
 	case PROTOCOL_V3:
 	case PROTOCOL_V4:
 	case PROTOCOL_V5:
-		if (rigol_ds_config_set(sdi, ":WAV:FORM BYTE") != SR_OK)
+		if (first_frame && rigol_ds_config_set(sdi, ":WAV:FORM BYTE") != SR_OK)
 			return SR_ERR;
 		if (devc->data_source == DATA_SOURCE_LIVE) {
-			if (rigol_ds_config_set(sdi, ":WAV:MODE NORM") != SR_OK)
+			if (first_frame && rigol_ds_config_set(sdi, ":WAV:MODE NORM") != SR_OK)
 				return SR_ERR;
 			devc->analog_frame_size = devc->model->series->live_samples;
 			devc->digital_frame_size = devc->model->series->live_samples;
 			rigol_ds_set_wait_event(devc, WAIT_TRIGGER);
 		} else {
 			if (devc->model->series->protocol == PROTOCOL_V3) {
-				if (rigol_ds_config_set(sdi, ":WAV:MODE RAW") != SR_OK)
+				if (first_frame && rigol_ds_config_set(sdi, ":WAV:MODE RAW") != SR_OK)
 					return SR_ERR;
 			} else if (devc->model->series->protocol >= PROTOCOL_V4) {
 				num_channels = 0;
@@ -404,7 +406,7 @@ SR_PRIV int rigol_ds_capture_start(const struct sr_dev_inst *sdi)
 				}
 
 				buffer_samples = devc->model->series->buffer_samples;
-				if (buffer_samples == 0)
+				if (first_frame && buffer_samples == 0)
 				{
 					/* The DS4000 series does not have a fixed memory depth, it
 					 * can be chosen from the menu and also varies with number
@@ -414,7 +416,7 @@ SR_PRIV int rigol_ds_capture_start(const struct sr_dev_inst *sdi)
 					devc->analog_frame_size = devc->digital_frame_size =
 							buffer_samples;
 				}
-				else
+				else if(first_frame)
 				{
 					/* The DS1000Z series has a fixed memory depth which we
 					 * need to divide correctly according to the number of
@@ -428,7 +430,7 @@ SR_PRIV int rigol_ds_capture_start(const struct sr_dev_inst *sdi)
 				}
 			}
 
-			if (rigol_ds_config_set(sdi, ":SING") != SR_OK)
+			if (devc->data_source == DATA_SOURCE_LIVE && rigol_ds_config_set(sdi, ":SINGL") != SR_OK)
 				return SR_ERR;
 			rigol_ds_set_wait_event(devc, WAIT_STOP);
 			if (devc->data_source == DATA_SOURCE_SEGMENTED &&
@@ -454,6 +456,8 @@ SR_PRIV int rigol_ds_channel_start(const struct sr_dev_inst *sdi)
 	ch = devc->channel_entry->data;
 
 	sr_dbg("Starting reading data from channel %d", ch->index + 1);
+
+	const gboolean first_frame = (devc->num_frames == 0);
 
 	switch (devc->model->series->protocol) {
 	case PROTOCOL_V1:
@@ -496,7 +500,7 @@ SR_PRIV int rigol_ds_channel_start(const struct sr_dev_inst *sdi)
 				return SR_ERR;
 		}
 
-		if (rigol_ds_config_set(sdi,
+		if (first_frame && rigol_ds_config_set(sdi,
 					devc->data_source == DATA_SOURCE_LIVE ?
 						":WAV:MODE NORM" :":WAV:MODE RAW") != SR_OK)
 			return SR_ERR;
@@ -511,15 +515,15 @@ SR_PRIV int rigol_ds_channel_start(const struct sr_dev_inst *sdi)
 	if (devc->model->series->protocol >= PROTOCOL_V3 &&
 			ch->type == SR_CHANNEL_ANALOG) {
 		/* Vertical increment. */
-		if (sr_scpi_get_float(sdi->conn, ":WAV:YINC?",
+		if (first_frame && sr_scpi_get_float(sdi->conn, ":WAV:YINC?",
 				&devc->vert_inc[ch->index]) != SR_OK)
 			return SR_ERR;
 		/* Vertical origin. */
-		if (sr_scpi_get_float(sdi->conn, ":WAV:YOR?",
+		if (first_frame && sr_scpi_get_float(sdi->conn, ":WAV:YOR?",
 			&devc->vert_origin[ch->index]) != SR_OK)
 			return SR_ERR;
 		/* Vertical reference. */
-		if (sr_scpi_get_int(sdi->conn, ":WAV:YREF?",
+		if (first_frame && sr_scpi_get_int(sdi->conn, ":WAV:YREF?",
 				&devc->vert_reference[ch->index]) != SR_OK)
 			return SR_ERR;
 	} else if (ch->type == SR_CHANNEL_ANALOG) {
@@ -621,6 +625,8 @@ SR_PRIV int rigol_ds_receive(int fd, int revents, void *cb_data)
 	if (!(revents == G_IO_IN || revents == 0))
 		return TRUE;
 
+	const gboolean first_frame = (devc->num_frames == 0);
+
 	switch (devc->wait_event) {
 	case WAIT_NONE:
 		break;
@@ -654,10 +660,10 @@ SR_PRIV int rigol_ds_receive(int fd, int revents, void *cb_data)
 
 	if (devc->num_block_bytes == 0) {
 		if (devc->model->series->protocol >= PROTOCOL_V4) {
-			if (rigol_ds_config_set(sdi, ":WAV:START %d",
+			if (first_frame && rigol_ds_config_set(sdi, ":WAV:START %d",
 					devc->num_channel_bytes + 1) != SR_OK)
 				return TRUE;
-			if (rigol_ds_config_set(sdi, ":WAV:STOP %d",
+			if (first_frame && rigol_ds_config_set(sdi, ":WAV:STOP %d",
 					MIN(devc->num_channel_bytes + ACQ_BLOCK_SIZE,
 						devc->analog_frame_size)) != SR_OK)
 				return TRUE;

--- a/src/hardware/rigol-ds/protocol.c
+++ b/src/hardware/rigol-ds/protocol.c
@@ -493,6 +493,11 @@ SR_PRIV int rigol_ds_channel_start(const struct sr_dev_inst *sdi)
 					devc->data_source == DATA_SOURCE_LIVE ?
 						":WAV:MODE NORM" :":WAV:MODE RAW") != SR_OK)
 			return SR_ERR;
+
+		if (devc->data_source != DATA_SOURCE_LIVE) {
+			if (rigol_ds_config_set(sdi, ":WAV:RES") != SR_OK)
+				return SR_ERR;
+		}
 		break;
 	}
 
@@ -651,9 +656,12 @@ SR_PRIV int rigol_ds_receive(int fd, int revents, void *cb_data)
 				return TRUE;
 		}
 
-		if (devc->model->series->protocol >= PROTOCOL_V3)
+		if (devc->model->series->protocol >= PROTOCOL_V3) {
+			if (rigol_ds_config_set(sdi, ":WAV:BEG") != SR_OK)
+				return TRUE;
 			if (sr_scpi_send(sdi->conn, ":WAV:DATA?") != SR_OK)
 				return TRUE;
+		}
 
 		if (sr_scpi_read_begin(scpi) != SR_OK)
 			return TRUE;

--- a/src/hardware/rigol-ds/protocol.h
+++ b/src/hardware/rigol-ds/protocol.h
@@ -144,6 +144,8 @@ struct dev_context {
 
 	/* Number of frames received in total. */
 	uint64_t num_frames;
+	/* Number of frames available from the Segmented data source */
+	uint64_t num_frames_segmented;
 	/* GSList entry for the current channel. */
 	GSList *channel_entry;
 	/* Number of bytes received for current channel. */

--- a/src/hardware/rigol-ds/protocol.h
+++ b/src/hardware/rigol-ds/protocol.h
@@ -129,6 +129,7 @@ struct dev_context {
 	gboolean digital_channels[MAX_DIGITAL_CHANNELS];
 	gboolean la_enabled;
 	float timebase;
+	float sample_rate;
 	float attenuation[MAX_ANALOG_CHANNELS];
 	float vdiv[MAX_ANALOG_CHANNELS];
 	int vert_reference[MAX_ANALOG_CHANNELS];


### PR DESCRIPTION
Bug fixes:
- Reading was being stopped after the first frame ("End acquisition when data for all channels is acquired."). I removed that and now check the limit later.
- Sample rate can now be determined for all data sources, not only Live. It is read and stored at the start of data acquisition so it only has to be read once.
- Data transfers were missing "WAV:RES" and "WAV:BEG" calls, so sometimes the wrong data would be returned

Improvements:
- Support for reading segmented data for v3, v4, v5 protocols. Version 4 was tested, the other two should work but I don't have a matching scope to check.
- Some commands are now only called for the first frame, greatly reducing overhead for smaller transfers and many frames. For my test case of 5 frames, this halves the time needed to read 5x 14 kSa from 18 to 9 seconds.