### PR TITLE
fx2lafw: Add support for frames

### DIFF
--- a/src/hardware/fx2lafw/api.c
+++ b/src/hardware/fx2lafw/api.c
@@ -125,6 +125,7 @@ static const uint32_t drvopts[] = {
 
 static const uint32_t devopts[] = {
 	SR_CONF_CONTINUOUS,
+	SR_CONF_LIMIT_FRAMES | SR_CONF_GET | SR_CONF_SET,
 	SR_CONF_LIMIT_SAMPLES | SR_CONF_GET | SR_CONF_SET,
 	SR_CONF_CONN | SR_CONF_GET,
 	SR_CONF_SAMPLERATE | SR_CONF_GET | SR_CONF_SET | SR_CONF_LIST,
@@ -491,6 +492,9 @@ static int config_get(uint32_t key, GVariant **data,
 			return SR_ERR;
 		*data = g_variant_new_printf("%d.%d", usb->bus, usb->address);
 		break;
+	case SR_CONF_LIMIT_FRAMES:
+		*data = g_variant_new_uint64(devc->limit_frames);
+		break;
 	case SR_CONF_LIMIT_SAMPLES:
 		*data = g_variant_new_uint64(devc->limit_samples);
 		break;
@@ -525,6 +529,9 @@ static int config_set(uint32_t key, GVariant *data,
 		if ((idx = std_u64_idx(data, devc->samplerates, devc->num_samplerates)) < 0)
 			return SR_ERR_ARG;
 		devc->cur_samplerate = devc->samplerates[idx];
+		break;
+	case SR_CONF_LIMIT_FRAMES:
+		devc->limit_frames = g_variant_get_uint64(data);
 		break;
 	case SR_CONF_LIMIT_SAMPLES:
 		devc->limit_samples = g_variant_get_uint64(data);

--- a/src/hardware/fx2lafw/protocol.h
+++ b/src/hardware/fx2lafw/protocol.h
@@ -102,6 +102,7 @@ struct dev_context {
 	int num_samplerates;
 
 	uint64_t cur_samplerate;
+	uint64_t limit_frames;
 	uint64_t limit_samples;
 	uint64_t capture_ratio;
 
@@ -110,6 +111,7 @@ struct dev_context {
 	gboolean sample_wide;
 	struct soft_trigger_logic *stl;
 
+	uint64_t num_frames;
 	unsigned int sent_samples;
 	int submitted_transfers;
 	int empty_transfer_count;


### PR DESCRIPTION
When using a number of frames that is not 1, the driver will read
samples up to its limit and then wait for another trigger. This will be
repeated until the configured number of frames has been finished.