### PR TITLE
scpi-pps: Add Siglent SPD3303 series PSU support 

### DIFF
--- a/contrib/60-libsigrok.rules
+++ b/contrib/60-libsigrok.rules
@@ -246,9 +246,11 @@ ATTRS{idVendor}=="21a9", ATTRS{idProduct}=="1001", ENV{ID_SIGROK}="1"
 ATTRS{idVendor}=="21a9", ATTRS{idProduct}=="1006", ENV{ID_SIGROK}="1"
 
 # Siglent USBTMC devices.
+# 0483:7540: E.g. SPD3303X-E psu
 # f4ec:ee3a: E.g. SDS1052DL+ scope
 # f4ec:ee38: E.g. SDS1104X-E scope
 # f4ed:ee3a: E.g. SDS1202X-E scope or SDG1010 waveform generator
+ATTRS{idVendor}=="0483", ATTRS{idProduct}=="7540", ENV{ID_SIGROK}="1"
 ATTRS{idVendor}=="f4ec", ATTRS{idProduct}=="ee3a", ENV{ID_SIGROK}="1"
 ATTRS{idVendor}=="f4ed", ATTRS{idProduct}=="ee3a", ENV{ID_SIGROK}="1"
 

--- a/src/hardware/scpi-pps/api.c
+++ b/src/hardware/scpi-pps/api.c
@@ -173,6 +173,12 @@ static struct sr_dev_inst *probe_device(struct sr_scpi_dev_inst *scpi,
 	sr_scpi_hw_info_free(hw_info);
 	hw_info = NULL;
 
+	if (devc->device->dialect == SCPI_DIALECT_SIGLENT) {
+		scpi->quirks |= SCPI_QUIRK_CMD_OMIT_LF;
+		scpi->quirks |= SCPI_QUIRK_OPC_UNSUPPORTED;
+		scpi->quirks |= SCPI_QUIRK_SLOW_CHANNEL_SELECT;
+	}
+
 	/* Don't send SCPI_CMD_LOCAL for HP 66xxB using SCPI over GPIB. */
 	if (!(devc->device->dialect == SCPI_DIALECT_HP_66XXB &&
 			scpi->transport == SCPI_TRANSPORT_LIBGPIB))
@@ -333,6 +339,7 @@ static int config_get(uint32_t key, GVariant **data,
 	int cmd, ret;
 	const char *s;
 	int reg;
+	long regl;
 
 	if (!sdi)
 		return SR_ERR_ARG;
@@ -363,7 +370,10 @@ static int config_get(uint32_t key, GVariant **data,
 	cmd = -1;
 	switch (key) {
 	case SR_CONF_ENABLED:
-		gvtype = G_VARIANT_TYPE_BOOLEAN;
+		if (devc->device->dialect == SCPI_DIALECT_SIGLENT)
+			gvtype = G_VARIANT_TYPE_STRING;
+		else
+			gvtype = G_VARIANT_TYPE_BOOLEAN;
 		cmd = SCPI_CMD_GET_OUTPUT_ENABLED;
 		break;
 	case SR_CONF_VOLTAGE:
@@ -438,6 +448,10 @@ static int config_get(uint32_t key, GVariant **data,
 		gvtype = G_VARIANT_TYPE_STRING;
 		cmd = SCPI_CMD_GET_OUTPUT_REGULATION;
 		break;
+	case SR_CONF_CHANNEL_CONFIG:
+		gvtype = G_VARIANT_TYPE_STRING;
+		cmd = SCPI_CMD_GET_CHANNEL_CONFIG;
+		break;
 	default:
 		return sr_sw_limits_config_get(&devc->limits, key, data);
 	}
@@ -452,12 +466,27 @@ static int config_get(uint32_t key, GVariant **data,
 	}
 
 	ret = sr_scpi_cmd_resp(sdi, devc->device->commands,
-		channel_group_cmd, channel_group_name, data, gvtype, cmd);
-	g_free(channel_group_name);
+		channel_group_cmd, channel_group_name, data, gvtype, cmd,
+		channel_group_name);
 
 	/*
 	 * Handle special cases
 	 */
+
+	if (cmd == SCPI_CMD_GET_OUTPUT_ENABLED) {
+		if (devc->device->dialect == SCPI_DIALECT_SIGLENT) {
+			s = g_variant_get_string(*data, NULL);
+			sr_atol_base(s, &regl, NULL, 16);
+			g_variant_unref(*data);
+			if (channel_group_name) {
+				sr_atoi(channel_group_name, &reg);
+			} else {
+				reg=1;
+			}
+			regl = (regl >> (reg+3));
+			*data = g_variant_new_boolean(regl & 0x01);
+		}
+	}
 
 	if (cmd == SCPI_CMD_GET_OUTPUT_REGULATION) {
 		if (devc->device->dialect == SCPI_DIALECT_PHILIPS) {
@@ -503,6 +532,22 @@ static int config_get(uint32_t key, GVariant **data,
 				*data = g_variant_new_string("CC-");
 			else
 				*data = g_variant_new_string("UR");
+		}
+		if (devc->device->dialect == SCPI_DIALECT_SIGLENT) {
+			/* evaluate status register */
+			s = g_variant_get_string(*data, NULL);
+			sr_atol_base(s, &regl, NULL, 16);
+			g_variant_unref(*data);
+			if (channel_group_name) {
+				sr_atoi(channel_group_name, &reg);
+			} else {
+				reg=1;
+			}
+			regl = (regl >> (reg-1));
+			if (regl & 0x01)
+				*data = g_variant_new_string("CC");
+			else
+				*data = g_variant_new_string("CV");
 		}
 
 		s = g_variant_get_string(*data, NULL);
@@ -565,6 +610,25 @@ static int config_get(uint32_t key, GVariant **data,
 		}
 	}
 
+	if (cmd == SCPI_CMD_GET_CHANNEL_CONFIG) {
+		if (devc->device->dialect == SCPI_DIALECT_SIGLENT) {
+			/* evaluate status register */
+			s = g_variant_get_string(*data, NULL);
+			sr_atol_base(s, &regl, NULL, 16);
+			g_variant_unref(*data);
+
+			regl = (regl >> 2) & 0x03;
+			if (regl == 0x02)
+				*data = g_variant_new_string("Parallel");
+			else if (regl == 0x03)
+				*data = g_variant_new_string("Series");
+			else
+				*data = g_variant_new_string("Independent");
+		}
+	}
+
+	g_free(channel_group_name);
+
 	return ret;
 }
 
@@ -575,6 +639,7 @@ static int config_set(uint32_t key, GVariant *data,
 	double d;
 	int channel_group_cmd;
 	char *channel_group_name;
+	const char *s;
 	int ret;
 
 	if (!sdi)
@@ -594,17 +659,26 @@ static int config_set(uint32_t key, GVariant *data,
 		if (g_variant_get_boolean(data))
 			ret = sr_scpi_cmd(sdi, devc->device->commands,
 					channel_group_cmd, channel_group_name,
-					SCPI_CMD_SET_OUTPUT_ENABLE);
+					SCPI_CMD_SET_OUTPUT_ENABLE,
+				        channel_group_name);
 		else
 			ret = sr_scpi_cmd(sdi, devc->device->commands,
 					channel_group_cmd, channel_group_name,
-					SCPI_CMD_SET_OUTPUT_DISABLE);
+					SCPI_CMD_SET_OUTPUT_DISABLE,
+					channel_group_name);
 		break;
 	case SR_CONF_VOLTAGE_TARGET:
 		d = g_variant_get_double(data);
-		ret = sr_scpi_cmd(sdi, devc->device->commands,
-				channel_group_cmd, channel_group_name,
-				SCPI_CMD_SET_VOLTAGE_TARGET, d);
+		if (devc->device->dialect == SCPI_DIALECT_SIGLENT) {
+			ret = sr_scpi_cmd(sdi, devc->device->commands,
+					  channel_group_cmd, channel_group_name,
+					  SCPI_CMD_SET_VOLTAGE_TARGET,
+					  channel_group_name, d);
+		} else {
+			ret = sr_scpi_cmd(sdi, devc->device->commands,
+					  channel_group_cmd, channel_group_name,
+					  SCPI_CMD_SET_VOLTAGE_TARGET, d);
+		}
 		break;
 	case SR_CONF_OUTPUT_FREQUENCY_TARGET:
 		d = g_variant_get_double(data);
@@ -614,9 +688,16 @@ static int config_set(uint32_t key, GVariant *data,
 		break;
 	case SR_CONF_CURRENT_LIMIT:
 		d = g_variant_get_double(data);
-		ret = sr_scpi_cmd(sdi, devc->device->commands,
-				channel_group_cmd, channel_group_name,
-				SCPI_CMD_SET_CURRENT_LIMIT, d);
+		if (devc->device->dialect == SCPI_DIALECT_SIGLENT) {
+			ret = sr_scpi_cmd(sdi, devc->device->commands,
+					  channel_group_cmd, channel_group_name,
+					  SCPI_CMD_SET_CURRENT_LIMIT,
+					  channel_group_name, d);
+		} else {
+			ret = sr_scpi_cmd(sdi, devc->device->commands,
+					  channel_group_cmd, channel_group_name,
+					  SCPI_CMD_SET_CURRENT_LIMIT, d);
+		}
 		break;
 	case SR_CONF_OVER_VOLTAGE_PROTECTION_ENABLED:
 		if (g_variant_get_boolean(data))
@@ -659,6 +740,20 @@ static int config_set(uint32_t key, GVariant *data,
 			ret = sr_scpi_cmd(sdi, devc->device->commands,
 					channel_group_cmd, channel_group_name,
 					SCPI_CMD_SET_OVER_TEMPERATURE_PROTECTION_DISABLE);
+		break;
+	case SR_CONF_CHANNEL_CONFIG:
+		s = g_variant_get_string(data, NULL);
+		if (devc->device->dialect == SCPI_DIALECT_SIGLENT) {
+			if (!strncmp(s, "Parallel", 8))
+				s = "2";
+			else if (!strncmp(s, "Series", 6))
+				s = "1";
+			else
+				s = "0";
+		}
+		ret = sr_scpi_cmd(sdi, devc->device->commands,
+				  channel_group_cmd, channel_group_name,
+				  SCPI_CMD_SET_CHANNEL_CONFIG, s);
 		break;
 	default:
 		ret = sr_sw_limits_config_set(&devc->limits, key, data);

--- a/src/hardware/scpi-pps/protocol.c
+++ b/src/hardware/scpi-pps/protocol.c
@@ -92,7 +92,8 @@ SR_PRIV int scpi_pps_receive_data(int fd, int revents, void *cb_data)
 	}
 
 	ret = sr_scpi_cmd_resp(sdi, devc->device->commands,
-		channel_group_cmd, channel_group_name, &gvdata, gvtype, cmd);
+	        channel_group_cmd, channel_group_name, &gvdata, gvtype, cmd,
+		channel_group_name);
 
 	if (ret != SR_OK)
 		return ret;

--- a/src/hardware/scpi-pps/protocol.h
+++ b/src/hardware/scpi-pps/protocol.h
@@ -66,6 +66,8 @@ enum pps_scpi_cmds {
 	SCPI_CMD_GET_OVER_CURRENT_PROTECTION_ACTIVE,
 	SCPI_CMD_GET_OVER_CURRENT_PROTECTION_THRESHOLD,
 	SCPI_CMD_SET_OVER_CURRENT_PROTECTION_THRESHOLD,
+	SCPI_CMD_GET_CHANNEL_CONFIG,
+	SCPI_CMD_SET_CHANNEL_CONFIG,
 };
 
 /* Defines the SCPI dialect */
@@ -74,6 +76,7 @@ enum pps_scpi_dialect {
 	SCPI_DIALECT_HP_COMP,
 	SCPI_DIALECT_HP_66XXB,
 	SCPI_DIALECT_PHILIPS,
+	SCPI_DIALECT_SIGLENT,
 };
 
 /*
@@ -163,6 +166,8 @@ struct dev_context {
 
 	struct sr_channel *cur_acquisition_channel;
 	struct sr_sw_limits limits;
+
+	uint32_t priv_status; /* device specific status data */
 };
 
 SR_PRIV extern unsigned int num_pps_profiles;

--- a/src/scpi.h
+++ b/src/scpi.h
@@ -75,6 +75,22 @@ enum scpi_transport_layer {
 	SCPI_TRANSPORT_VXI,
 };
 
+/* Support for "quirks" in various devices that don't fully
+ * comply with the SCPI specification.
+ */
+enum scpi_quirks {
+	/* Device doesn't expect NL/LF character after a command.
+	 * (disable automatically adding NL when sending commands) */
+	SCPI_QUIRK_CMD_OMIT_LF         = (1 << 0),
+	/* Device doesn't support OPC? command. */
+	SCPI_QUIRK_OPC_UNSUPPORTED     = (1 << 1),
+	/* Device needs delay after a channel change. */
+	SCPI_QUIRK_SLOW_CHANNEL_SELECT = (1 << 2),
+	/* Device requires delay after sending command or it won't respond.
+	 * (seen on some Siglent PSUs when using USBTMC interface) */
+	SCPI_QUIRK_DELAY_AFTER_CMD     = (1 << 3),
+};
+
 struct scpi_command {
 	int command;
 	const char *string;
@@ -113,6 +129,7 @@ struct sr_scpi_dev_inst {
 	uint64_t firmware_version;
 	GMutex scpi_mutex;
 	char *actual_channel_name;
+	uint32_t quirks;
 };
 
 SR_PRIV GSList *sr_scpi_scan(struct drv_context *drvc, GSList *options,

--- a/src/scpi/scpi.c
+++ b/src/scpi/scpi.c
@@ -157,8 +157,10 @@ static int scpi_send_variadic(struct sr_scpi_dev_inst *scpi,
 	/* Allocate buffer and write out command. */
 	buf = g_malloc0(len + 2);
 	sr_vsprintf_ascii(buf, format, args);
-	if (buf[len - 1] != '\n')
-		buf[len] = '\n';
+	if (!(scpi->quirks & SCPI_QUIRK_CMD_OMIT_LF)) {
+		if (buf[len - 1] != '\n')
+			buf[len] = '\n';
+	}
 
 	/* Send command. */
 	ret = scpi->send(scpi->priv, buf);
@@ -279,6 +281,8 @@ static int scpi_get_data(struct sr_scpi_dev_inst *scpi,
 		if (scpi_send(scpi, command) != SR_OK)
 			return SR_ERR;
 	}
+	if (scpi->quirks & SCPI_QUIRK_DELAY_AFTER_CMD)
+		g_usleep(100*1000);
 
 	/* Initiate SCPI read operation. */
 	if (sr_scpi_read_begin(scpi) != SR_OK)
@@ -819,6 +823,11 @@ SR_PRIV int sr_scpi_get_opc(struct sr_scpi_dev_inst *scpi)
 	unsigned int i;
 	gboolean opc;
 
+	if (scpi->quirks & SCPI_QUIRK_OPC_UNSUPPORTED) {
+		g_usleep(SCPI_READ_RETRY_TIMEOUT_US);
+		return SR_OK;
+	}
+
 	for (i = 0; i < SCPI_READ_RETRIES; i++) {
 		opc = FALSE;
 		sr_scpi_get_bool(scpi, SCPI_CMD_OPC, &opc);
@@ -1266,6 +1275,8 @@ SR_PRIV int sr_scpi_cmd(const struct sr_dev_inst *sdi,
 		ret = scpi_send(scpi, channel_cmd, channel_name);
 		if (ret != SR_OK)
 			return ret;
+		if (scpi->quirks & SCPI_QUIRK_SLOW_CHANNEL_SELECT)
+			g_usleep(100 * 1000);
 	}
 
 	va_start(args, command);
@@ -1311,6 +1322,8 @@ SR_PRIV int sr_scpi_cmd_resp(const struct sr_dev_inst *sdi,
 		ret = scpi_send(scpi, channel_cmd, channel_name);
 		if (ret != SR_OK)
 			return ret;
+		if (scpi->quirks & SCPI_QUIRK_SLOW_CHANNEL_SELECT)
+			g_usleep(100*1000);
 	}
 
 	va_start(args, command);

--- a/src/scpi/scpi_usbtmc_libusb.c
+++ b/src/scpi/scpi_usbtmc_libusb.c
@@ -120,6 +120,12 @@ static struct usbtmc_blacklist whitelist_usb_reset[] = {
 	ALL_ZERO
 };
 
+/* Devices that require (long) delay after sending a command. */
+static struct usbtmc_blacklist blacklist_slow[] = {
+	{ 0x0483, 0x7540 }, /* All Siglent SPD3303 devices */
+	ALL_ZERO
+};
+
 static GSList *scpi_usbtmc_libusb_scan(struct drv_context *drvc)
 {
 	struct libusb_device **devlist;
@@ -411,6 +417,11 @@ static int scpi_usbtmc_libusb_open(struct sr_scpi_dev_inst *scpi)
 	       uscpi->usb488_dev_cap & USB488_DEV_CAP_DT1         ? "DT1"  : "DT0");
 
 	scpi_usbtmc_remote(uscpi);
+
+	/* Check for "broken" devices needing delay after issuing a command... */
+	if (check_usbtmc_blacklist(blacklist_slow, des.idVendor, des.idProduct)) {
+		scpi->quirks |= SCPI_QUIRK_DELAY_AFTER_CMD;
+	}
 
 	return SR_OK;
 }


### PR DESCRIPTION
This adds support to Siglent SPD3303C / SPD3303X / SPD3303X-E programmable DC power supplies.
Functionality was tested both via LAN (tcp-raw) and USB (USBTMC) using sigrok-cli and SmuView.

Siglent SCPI implementation is "problematic" so I implemented "quirks" in SCPI framework to allow supporting
instruments (vendors) that can't seem to follow SCPI/IEEE488.2 specifications...
This way SCPI behavior doesn't need to change for devices that comply with SCPI, but framework still can be used
with devices that require "tweaks": 9cf9a57acfcdb6230a8d176da10f7f80a95cca3b

(replaces https://github.com/sigrokproject/libsigrok/pull/75)