### PR TITLE
scpi-dmm: Add GW-Instek 825X & 906X series bench meter support

### DIFF
--- a/contrib/60-libsigrok.rules
+++ b/contrib/60-libsigrok.rules
@@ -106,6 +106,9 @@ ATTRS{idVendor}=="2a0e", ATTRS{idProduct}=="0020", ENV{ID_SIGROK}="1"
 # DreamSourceLab DSLogic Basic
 ATTRS{idVendor}=="2a0e", ATTRS{idProduct}=="0021", ENV{ID_SIGROK}="1"
 
+# GW-Instek GDM-9061 (USBTMC mode)
+ATTRS{idVendor}=="2184", ATTRS{idProduct}=="0059", ENV{ID_SIGROK}="1"
+
 # HAMEG HO720
 ATTRS{idVendor}=="0403", ATTRS{idProduct}=="ed72", ENV{ID_SIGROK}="1"
 

--- a/src/hardware/scpi-dmm/api.c
+++ b/src/hardware/scpi-dmm/api.c
@@ -88,6 +88,17 @@ static const struct scpi_command cmdset_gwinstek[] = {
 	ALL_ZERO,
 };
 
+static const struct scpi_command cmdset_gwinstek_906x[] = {
+	{ DMM_CMD_SETUP_REMOTE, "SYST:REM", },
+	{ DMM_CMD_SETUP_FUNC, "CONF:%s", },
+	{ DMM_CMD_QUERY_FUNC, "CONF?", },
+	{ DMM_CMD_START_ACQ, "*CLS;SYST:REM", },
+	{ DMM_CMD_STOP_ACQ, "SYST:LOC", },
+	{ DMM_CMD_QUERY_VALUE, "VAL1?", },
+	{ DMM_CMD_QUERY_PREC, "SENS:DET:RATE?", },
+	ALL_ZERO,
+};
+
 static const struct mqopt_item mqopts_agilent_34405a[] = {
 	{ SR_MQ_VOLTAGE, SR_MQFLAG_DC, "VOLT:DC", "VOLT ", NO_DFLT_PREC, },
 	{ SR_MQ_VOLTAGE, SR_MQFLAG_AC, "VOLT:AC", "VOLT:AC ", NO_DFLT_PREC, },
@@ -131,6 +142,21 @@ static const struct mqopt_item mqopts_gwinstek_gdm8200a[] = {
 	{ SR_MQ_TIME, 0, "PER", "14", NO_DFLT_PREC, },
 };
 
+static const struct mqopt_item mqopts_gwinstek_gdm906x[] = {
+	{ SR_MQ_VOLTAGE, SR_MQFLAG_DC, "VOLT:DC", "VOLT ", NO_DFLT_PREC, },
+	{ SR_MQ_VOLTAGE, SR_MQFLAG_AC, "VOLT:AC", "VOLT:AC", NO_DFLT_PREC, },
+	{ SR_MQ_CURRENT, SR_MQFLAG_DC, "CURR:DC", "CURR ", NO_DFLT_PREC, },
+	{ SR_MQ_CURRENT, SR_MQFLAG_AC, "CURR:AC", "CURR:AC", NO_DFLT_PREC, },
+	{ SR_MQ_RESISTANCE, 0, "RES", "RES", NO_DFLT_PREC, },
+	{ SR_MQ_RESISTANCE, SR_MQFLAG_FOUR_WIRE, "FRES", "FRES", NO_DFLT_PREC, },
+	{ SR_MQ_CONTINUITY, 0, "CONT", "CONT", -1, },
+	{ SR_MQ_VOLTAGE, SR_MQFLAG_DC | SR_MQFLAG_DIODE, "DIOD", "DIOD", -4, },
+	{ SR_MQ_TEMPERATURE, 0, "TEMP", "TEMP", NO_DFLT_PREC, },
+	{ SR_MQ_FREQUENCY, 0, "FREQ", "FREQ", NO_DFLT_PREC, },
+	{ SR_MQ_TIME, 0, "PER", "PER", NO_DFLT_PREC, },
+	{ SR_MQ_CAPACITANCE, 0, "CAP", "CAP", NO_DFLT_PREC, },
+};
+
 SR_PRIV const struct scpi_dmm_model models[] = {
 	{
 		"Agilent", "34405A",
@@ -167,6 +193,20 @@ SR_PRIV const struct scpi_dmm_model models[] = {
 		scpi_dmm_get_meas_gwinstek,
 		ARRAY_AND_SIZE(devopts_generic),
 		1000 * 2500,
+	},
+	{
+		"GWInstek", "GDM9060",
+		1, 6, cmdset_gwinstek_906x, ARRAY_AND_SIZE(mqopts_gwinstek_gdm906x),
+		scpi_dmm_get_meas_agilent,
+		ARRAY_AND_SIZE(devopts_generic),
+		0,
+	},
+	{
+		"GWInstek", "GDM9061",
+		1, 6, cmdset_gwinstek_906x, ARRAY_AND_SIZE(mqopts_gwinstek_gdm906x),
+		scpi_dmm_get_meas_agilent,
+		ARRAY_AND_SIZE(devopts_generic),
+		0,
 	},
 };
 

--- a/src/hardware/scpi-dmm/api.c
+++ b/src/hardware/scpi-dmm/api.c
@@ -77,6 +77,17 @@ static const struct scpi_command cmdset_hp[] = {
 	ALL_ZERO,
 };
 
+static const struct scpi_command cmdset_gwinstek[] = {
+	{ DMM_CMD_SETUP_REMOTE, "SYST:REM", },
+	{ DMM_CMD_SETUP_FUNC, "CONF:%s", },
+	{ DMM_CMD_QUERY_FUNC, "CONF:STAT:FUNC?", },
+	{ DMM_CMD_START_ACQ, "*CLS;SYST:REM", },
+	{ DMM_CMD_STOP_ACQ, "SYST:LOC", },
+	{ DMM_CMD_QUERY_VALUE, "VAL1?", },
+	{ DMM_CMD_QUERY_PREC, "SENS:DET:RATE?", },
+	ALL_ZERO,
+};
+
 static const struct mqopt_item mqopts_agilent_34405a[] = {
 	{ SR_MQ_VOLTAGE, SR_MQFLAG_DC, "VOLT:DC", "VOLT ", NO_DFLT_PREC, },
 	{ SR_MQ_VOLTAGE, SR_MQFLAG_AC, "VOLT:AC", "VOLT:AC ", NO_DFLT_PREC, },
@@ -103,6 +114,23 @@ static const struct mqopt_item mqopts_agilent_34401a[] = {
 	{ SR_MQ_TIME, 0, "PER", "PER ", NO_DFLT_PREC, },
 };
 
+static const struct mqopt_item mqopts_gwinstek_gdm8200a[] = {
+	{ SR_MQ_VOLTAGE, SR_MQFLAG_DC, "VOLT:DC", "01", NO_DFLT_PREC, },
+	{ SR_MQ_VOLTAGE, SR_MQFLAG_AC, "VOLT:AC", "02", NO_DFLT_PREC, },
+	{ SR_MQ_CURRENT, SR_MQFLAG_DC, "CURR:DC", "03", NO_DFLT_PREC, },
+	{ SR_MQ_CURRENT, SR_MQFLAG_AC, "CURR:AC", "04", NO_DFLT_PREC, },
+	{ SR_MQ_CURRENT, SR_MQFLAG_DC, "CURR:DC", "05", NO_DFLT_PREC, }, /* mA */
+	{ SR_MQ_CURRENT, SR_MQFLAG_AC, "CURR:AC", "06", NO_DFLT_PREC, }, /* mA */
+	{ SR_MQ_RESISTANCE, 0, "RES", "07", NO_DFLT_PREC, },
+	{ SR_MQ_RESISTANCE, SR_MQFLAG_FOUR_WIRE, "FRES", "16", NO_DFLT_PREC, },
+	{ SR_MQ_CONTINUITY, 0, "CONT", "13", -1, },
+	{ SR_MQ_VOLTAGE, SR_MQFLAG_DC | SR_MQFLAG_DIODE, "DIOD", "17", -4, },
+	{ SR_MQ_TEMPERATURE, 0, "TEMP", "09", NO_DFLT_PREC, }, /* Celsius */
+	{ SR_MQ_TEMPERATURE, 0, "TEMP", "15", NO_DFLT_PREC, }, /* Fahrenheit */
+	{ SR_MQ_FREQUENCY, 0, "FREQ", "08", NO_DFLT_PREC, },
+	{ SR_MQ_TIME, 0, "PER", "14", NO_DFLT_PREC, },
+};
+
 SR_PRIV const struct scpi_dmm_model models[] = {
 	{
 		"Agilent", "34405A",
@@ -125,6 +153,20 @@ SR_PRIV const struct scpi_dmm_model models[] = {
 		ARRAY_AND_SIZE(devopts_generic),
 		/* 34401A: typ. 1020ms for AC readings (default is 1000ms). */
 		1000 * 1500,
+	},
+	{
+		"GW", "GDM8251A",
+		1, 6, cmdset_gwinstek, ARRAY_AND_SIZE(mqopts_gwinstek_gdm8200a),
+		scpi_dmm_get_meas_gwinstek,
+		ARRAY_AND_SIZE(devopts_generic),
+		1000 * 2500,
+	},
+	{
+		"GW", "GDM8255A",
+		1, 6, cmdset_gwinstek, ARRAY_AND_SIZE(mqopts_gwinstek_gdm8200a),
+		scpi_dmm_get_meas_gwinstek,
+		ARRAY_AND_SIZE(devopts_generic),
+		1000 * 2500,
 	},
 };
 
@@ -187,6 +229,7 @@ static struct sr_dev_inst *probe_device(struct sr_scpi_dev_inst *scpi)
 	devc->num_channels = model->num_channels;
 	devc->cmdset = model->cmdset;
 	devc->model = model;
+	devc->precision = NULL;
 
 	for (i = 0; i < devc->num_channels; i++) {
 		channel_name = g_strdup_printf("P%zu", i + 1);
@@ -337,6 +380,7 @@ static int dev_acquisition_start(const struct sr_dev_inst *sdi)
 	int ret;
 	const struct mqopt_item *item;
 	const char *command;
+	char *response;
 
 	scpi = sdi->conn;
 	devc = sdi->priv;
@@ -345,6 +389,26 @@ static int dev_acquisition_start(const struct sr_dev_inst *sdi)
 		&devc->start_acq_mq.curr_mqflag, NULL, &item);
 	if (ret != SR_OK)
 		return ret;
+
+	/*
+	 * Query for current precision if DMM supports the command
+	 */
+	command = sr_scpi_cmd_get(devc->cmdset, DMM_CMD_QUERY_PREC);
+	if (command && *command) {
+		scpi_dmm_cmd_delay(scpi);
+		ret = sr_scpi_get_string(scpi, command, &response);
+		if (ret == SR_OK) {
+			g_strstrip(response);
+			if (devc->precision)
+				g_free(devc->precision);
+			devc->precision=g_strdup(response);
+			g_free(response);
+			sr_dbg("%s: Precision: '%s'", __func__, devc->precision);
+		} else {
+			sr_info("%s: Precision query ('%s') failed: %d",
+				__func__, command, ret);
+		}
+	}
 
 	command = sr_scpi_cmd_get(devc->cmdset, DMM_CMD_START_ACQ);
 	if (command && *command) {
@@ -384,6 +448,11 @@ static int dev_acquisition_stop(struct sr_dev_inst *sdi)
 	sr_scpi_source_remove(sdi->session, scpi);
 
 	std_session_send_df_end(sdi);
+
+	if (devc->precision) {
+		g_free(devc->precision);
+		devc->precision = NULL;
+	}
 
 	return SR_OK;
 }

--- a/src/hardware/scpi-dmm/protocol.h
+++ b/src/hardware/scpi-dmm/protocol.h
@@ -83,6 +83,7 @@ struct dev_context {
 		struct sr_analog_meaning meaning[SCPI_DMM_MAX_CHANNELS];
 		struct sr_analog_spec spec[SCPI_DMM_MAX_CHANNELS];
 	} run_acq_info;
+	gchar *precision;
 };
 
 SR_PRIV void scpi_dmm_cmd_delay(struct sr_scpi_dev_inst *scpi);
@@ -96,6 +97,7 @@ SR_PRIV int scpi_dmm_get_mq(const struct sr_dev_inst *sdi,
 SR_PRIV int scpi_dmm_set_mq(const struct sr_dev_inst *sdi,
 	enum sr_mq mq, enum sr_mqflag flag);
 SR_PRIV int scpi_dmm_get_meas_agilent(const struct sr_dev_inst *sdi, size_t ch);
+SR_PRIV int scpi_dmm_get_meas_gwinstek(const struct sr_dev_inst *sdi, size_t ch);
 SR_PRIV int scpi_dmm_receive_data(int fd, int revents, void *cb_data);
 
 #endif

--- a/src/scpi/scpi.c
+++ b/src/scpi/scpi.c
@@ -1117,8 +1117,8 @@ SR_PRIV int sr_scpi_get_hw_id(struct sr_scpi_dev_inst *scpi,
 	 */
 	tokens = g_strsplit(response, ",", 0);
 	num_tokens = g_strv_length(tokens);
-	if (num_tokens < 4) {
-		sr_dbg("IDN response not according to spec: %80.s.", response);
+	if (num_tokens < 3) {
+		sr_dbg("IDN response not according to spec: '%s'", response);
 		g_strfreev(tokens);
 		g_free(response);
 		return SR_ERR_DATA;
@@ -1134,8 +1134,13 @@ SR_PRIV int sr_scpi_get_hw_id(struct sr_scpi_dev_inst *scpi,
 		hw_info->manufacturer = g_strstrip(g_strdup(idn_substr + 4));
 
 	hw_info->model = g_strstrip(g_strdup(tokens[1]));
-	hw_info->serial_number = g_strstrip(g_strdup(tokens[2]));
-	hw_info->firmware_version = g_strstrip(g_strdup(tokens[3]));
+	if (num_tokens < 4) {
+		hw_info->serial_number = g_strdup("Unknown");
+		hw_info->firmware_version = g_strstrip(g_strdup(tokens[2]));
+	} else {
+		hw_info->serial_number = g_strstrip(g_strdup(tokens[2]));
+		hw_info->firmware_version = g_strstrip(g_strdup(tokens[3]));
+	}
 
 	g_strfreev(tokens);
 

--- a/src/scpi/scpi_serial.c
+++ b/src/scpi/scpi_serial.c
@@ -46,6 +46,7 @@ static const struct {
 	{ 0x0aad, 0x0117, "115200/8n1" },        /* R&S HMO series, previously branded as Hameg HMO */
 	{ 0x0aad, 0x0118, "115200/8n1" },        /* R&S HMO series, previously branded as Hameg HMO */
 	{ 0x0aad, 0x0119, "115200/8n1" },        /* R&S HMO series, previously branded as Hameg HMO */
+	{ 0x2184, 0x0058, "115200/8n1" },        /* GW-Instek GDM-9061 (USBCDC mode) */
 };
 
 static GSList *scpi_serial_scan(struct drv_context *drvc)

--- a/src/scpi/scpi_serial.c
+++ b/src/scpi/scpi_serial.c
@@ -190,7 +190,12 @@ static int scpi_serial_read_data(void *priv, char *buf, int maxlen)
 	if (ret > 0) {
 		if (buf[ret - 1] == '\n') {
 			sscpi->got_newline = TRUE;
-			sr_spew("Received terminator");
+			sr_spew("Received NL terminator");
+		} else if (ret > 1 &&
+			   buf[ret - 2] == '\n' && buf[ret - 1] == '\r') {
+			sscpi->got_newline = TRUE;
+			sr_spew("Received NL+CR terminator");
+			ret--;
 		} else {
 			sscpi->got_newline = FALSE;
 		}


### PR DESCRIPTION
This patch adds support to GW-Instek GDM-8251A and GDM-8255A bench multimeters.

I was initially going to go with standalone driver, but noticed existing scpi-dmm driver was already implemented with excellent framework for meters using SCPI commands.

However, GW-Instek seems to interpret SCPI/IEEE488.2 differently from some other vendors like HP/Agilent/Keysight, so small change is included to "scpi" code to relax the SCPI protocol implementation (support NL+CR in addition to NL as terminator for response message) and parsing response to *IDN? command when device omits serial number...

After studying existing code and specs, I believe the change to scpi_serial_read_data() does not break any existing SCPI device support: 462c3a754727d59e1f927b17ec7613c1673c4acf

Since currently "scpi" code does not work with any device that behaves like GW-Instek devices that terminate responses with NL+CR (instead of just plain NL that HP/Agilent devices send). Since if any device sends anything but NL/LF character at the end of the response message, it doesn't work. Symptom being this:

```
sr: scpi: Timed out waiting for SCPI response.
```

Another change to "scpi" was to support devices that omit serial number in response to *IDN? commmand: 39a6fb0aeaa5daeefc72e742b36ff960edd902a5
(this won't have any effect on devices that respond fully SCPI compliant way to *IDN? command)

Do you feel this is good/proper way to modify the "scpi" code to allow support of vendors that interpret the spec slightly differently? Or would it be perhaps better to make these changes conditional, so driver could toggle flag (in scpi driver context) to enable more relaxed/flexible protocol interpretation (if desired)? Then drivers like scpi-dmm/scpi-pps could first scan for device using "strict" SCPI implementation, and if no devices found could try again with the relaxed SCPI implementation enabled?

Or would you recommend just going the route of standalone driver for these GW-Instek devices? (I'm also looking adding support to GPD-3303S power supply that would benefit from this change, allowing it to be supported by scpi-pps driver instead of needing standalone driver as well...)

(this replaces: https://github.com/sigrokproject/libsigrok/pull/70)