### PR TITLE
gwinstek-gpd: Add support to GPD-3303S and to old HW revision units.

### DIFF
--- a/src/hardware/gwinstek-gpd/api.c
+++ b/src/hardware/gwinstek-gpd/api.c
@@ -72,7 +72,7 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 	GSList *l;
 	struct sr_serial_dev_inst *serial;
 	struct sr_dev_inst *sdi;
-	char reply[50];
+	char reply[100];
 	unsigned int i;
 	struct dev_context *devc;
 	char channel[10];
@@ -170,8 +170,16 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 	if (sscanf(reply, "%1u%1u%1u%1u%1u%1u%1u%1u", &cc_cv_ch1,
 			&cc_cv_ch2, &track1, &track2, &beep,
 			&devc->output_enabled, &baud1, &baud2) != 8) {
-		sr_err("Invalid reply to STATUS: '%s'.", reply);
-		goto error;
+		/* old firmware (< 2.00?) responds with different format */
+		if (sscanf(reply, "%1u %1u %1u %1u %1u X %1u X", &cc_cv_ch1,
+			   &cc_cv_ch2, &track1, &track2, &beep,
+			   &devc->output_enabled) != 6) {
+			sr_err("Invalid reply to STATUS: '%s'.", reply);
+			goto error;
+		}
+		/* ignore remaining two lines of status message */
+		gpd_receive_reply(serial, reply, sizeof(reply));
+		gpd_receive_reply(serial, reply, sizeof(reply));
 	}
 
 	for (i = 0; i < model->num_channels; ++i) {

--- a/src/hardware/gwinstek-gpd/api.c
+++ b/src/hardware/gwinstek-gpd/api.c
@@ -60,6 +60,16 @@ static const struct gpd_model models[] = {
 			{ { 0, 30, 0.001 }, { 0, 3, 0.001 } },
 		},
 	},
+	{ GPD_3303S, "GPD-3303S",
+		CHANMODE_INDEPENDENT,
+		2,
+		{
+			/* Channel 1 */
+			{ { 0, 32, 0.001 }, { 0, 3.2, 0.001 } },
+			/* Channel 2 */
+			{ { 0, 32, 0.001 }, { 0, 3.2, 0.001 } },
+		},
+	},
 };
 
 static GSList *scan(struct sr_dev_driver *di, GSList *options)

--- a/src/hardware/gwinstek-gpd/protocol.c
+++ b/src/hardware/gwinstek-gpd/protocol.c
@@ -51,7 +51,7 @@ SR_PRIV int gpd_receive_reply(struct sr_serial_dev_inst *serial, char *buf,
 {
 	int l_recv = 0, bufpos = 0, retc, l_startpos = 0, lines = 1;
 	gint64 start, remaining;
-	const int timeout_ms = 100;
+	const int timeout_ms = 250;
 
 	if (!serial || !buf || (buflen <= 0))
 		return SR_ERR_ARG;
@@ -69,7 +69,7 @@ SR_PRIV int gpd_receive_reply(struct sr_serial_dev_inst *serial, char *buf,
 		if (bufpos == 0 && buf[bufpos] == '\n')
 			continue;
 
-		if (buf[bufpos] == '\n') {
+		if (buf[bufpos] == '\n' || buf[bufpos] == '\r') {
 			buf[bufpos] = '\0';
 			sr_dbg("Received line '%s'.", &buf[l_startpos]);
 			buf[bufpos] = '\n';

--- a/src/hardware/gwinstek-gpd/protocol.c
+++ b/src/hardware/gwinstek-gpd/protocol.c
@@ -175,6 +175,7 @@ SR_PRIV int gpd_receive_data(int fd, int revents, void *cb_data)
 			}
 
 			devc->reply_pending = FALSE;
+			sr_sw_limits_update_samples_read(&devc->limits, 1);
 		}
 	} else {
 		if (!devc->reply_pending) {

--- a/src/hardware/gwinstek-gpd/protocol.h
+++ b/src/hardware/gwinstek-gpd/protocol.h
@@ -29,6 +29,7 @@
 
 enum {
 	GPD_2303S,
+	GPD_3303S,
 };
 
 /* Maximum number of output channels handled by this driver. */


### PR DESCRIPTION
Add support for GPD-3303S model. 

Also, add support for old HW revision units (GW Instek apparently redesigned hardware at some point without changin model numbers), that behave slightly differently.