### PR TITLE
tests: strutil, use ck_assert

### DIFF
--- a/tests/strutil.c
+++ b/tests/strutil.c
@@ -154,7 +154,7 @@ START_TEST(test_locale)
 	fprintf(stderr, "Old locale = %s\n", old_locale);
 	/* Copy the name so it won’t be clobbered by setlocale. */
 	saved_locale = g_strdup(old_locale);
-	ck_assert_msg(saved_locale != NULL);
+	ck_assert(saved_locale != NULL);
 
 #ifdef _WIN32
 	/*


### PR DESCRIPTION
We pass no message, so use `ck_assert` instead of `ck_assert_msg`. This
results in an error with check 0.15:
```
tests/strutil.c:157:2: error: too few arguments to function '_ck_assert_failed'
  157 |  ck_assert_msg(saved_locale != NULL);
```