### PR TITLE
scpi: accept numbers like 4.0000E3 as integer value

### DIFF
--- a/src/scpi/scpi.c
+++ b/src/scpi/scpi.c
@@ -724,6 +724,7 @@ SR_PRIV int sr_scpi_get_int(struct sr_scpi_dev_inst *scpi,
 			    const char *command, int *scpi_response)
 {
 	int ret;
+	struct sr_rational ret_rational;
 	char *response;
 
 	response = NULL;
@@ -732,10 +733,14 @@ SR_PRIV int sr_scpi_get_int(struct sr_scpi_dev_inst *scpi,
 	if (ret != SR_OK && !response)
 		return ret;
 
-	if (sr_atoi(response, scpi_response) == SR_OK)
+	ret = sr_parse_rational(response, &ret_rational);
+	if ((ret == SR_OK) && (ret_rational.p % ret_rational.q) == 0) {
+		*scpi_response = ret_rational.p / ret_rational.q;
 		ret = SR_OK;
-	else
+	} else {
+		sr_dbg("rational=%" PRId64 "/%" PRIu64 , ret_rational.p, ret_rational.q);
 		ret = SR_ERR_DATA;
+	}
 
 	g_free(response);
 


### PR DESCRIPTION
MSO5000 returns memory depth value in that format, e.g.
sr: [04:21.491949] scpi_vxi: Successfully sent SCPI command: 'ACQ:MDEP?'.
sr: [04:21.501463] scpi: Got response: '4.0000E+03', length 10.

I am not sure if it is acceptable to change the implementation of "sr_scpi_get_int" to get it working with Rigol MSO5000 or if it would be better to extend the scpi-API.
