### PR TITLE
Support for APPA 150/208/506-based meters (BENNING MM 12, APPA 506(B), Sefram 7352(B), APPA 208(B),  BENNING CM 12, APPA 155B, APPA 156B, APPA 157B, APPA 158B, etc.)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -163,6 +163,7 @@ endif
 
 # Hardware (DMM chip parsers)
 libsigrok_la_SOURCES += \
+	src/dmm/appa_b.c \
 	src/dmm/asycii.c \
 	src/dmm/bm25x.c \
 	src/dmm/bm52x.c \

--- a/src/dmm/appa_b.c
+++ b/src/dmm/appa_b.c
@@ -1,3 +1,37 @@
+/*
+ * This file is part of the libsigrok project.
+ *
+ * Copyright (C) 2020 Martin Eitzenberger <x@cymaphore.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file
+ *
+ * see also "appa_b.h"
+ * 
+ * Interface to APPA B (150/208/506) Series based Multimeters and Clamps
+ * 
+ * @TODO Calibration
+ * @TODO BTLE comm code
+ * @TODO Log download
+ * @TODO Finetuning and details
+ * @TODO Display reading strings
+ * 
+ */
+
 #include "appa_b.h"
 
 #include "config.h"
@@ -15,42 +49,79 @@
 /////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @TODO implement BLTE-Communication (same interface as serial)
+ * @TODO Implement after_open function to read device information
+ * @TODO integrate further brand information to provide support for more devices
+ */
+
 #ifdef HAVE_SERIAL_COMM
+/**
+ * Request frame from device
+ * @param serial
+ * @return @sr_error_code Status
+ */
 SR_PRIV int sr_appa_b_packet_request(struct sr_serial_dev_inst *serial)
 {
   appaBFrame_t appaFrame;
   bzero(&appaFrame, sizeof(appaFrame));
+  
   appaFrame.start = APPA_B_START;
   appaFrame.command = APPA_B_COMMAND_READ_DISPLAY;
   appaFrame.dataLength = APPA_B_DATA_LENGTH_REQUEST_READ_DISPLAY;
+  
   appaInt_t frameLen = APPA_B_GET_FRAMELEN(REQUEST_READ_DISPLAY);
-  appaByte_t checksum = appa_b_checksum(&appaFrame, frameLen);
+  appaByte_t checksum = appa_b_checksum((appaByte_t*)&appaFrame, frameLen);
+  
   if(serial_flush(serial) != SR_OK)
     return(SR_ERR_IO);
+  
   if(serial_write_nonblocking(serial, &appaFrame, frameLen) != frameLen)
     return(SR_ERR_IO);
+  
   if(serial_write_nonblocking(serial, &checksum, sizeof(checksum)) != sizeof(checksum))
     return(SR_ERR_IO);
+  
   return(SR_OK);
 }
 #endif/*HAVE_SERIAL_COMM*/
 
+/**
+ * Validate APPA-Frame
+ * @TODO validate other aspects / start code / etc.
+ * 
+ * @param buf
+ * @return TRUE if checksum is fine
+ */
 SR_PRIV gboolean sr_appa_b_packet_valid(const uint8_t *buf)
 {
   appaInt_t frameLen = APPA_B_GET_FRAMELEN(RESPONSE_READ_DISPLAY);
-  appaByte_t checksum = appa_b_checksum(buf, frameLen);
+  appaByte_t checksum = appa_b_checksum((const appaByte_t*)buf, frameLen);
   return(checksum == buf[frameLen]);
 }
 
+/**
+ * Parse APPA-Frame and assign values to virtual channels
+ * 
+ * @TODO include display reading
+ * 
+ * @param buf Buffer from Serial or BTLE
+ * @param floatval Return display reading
+ * @param analog Metadata of the reading
+ * @param info Channel information and other things
+ * @return @sr_error_code Status
+ */
 SR_PRIV int sr_appa_b_parse(const uint8_t *buf, float *floatval,
 		struct sr_datafeed_analog *analog, void *info)
 {
   struct appa_b_info* info_local = (struct appa_b_info*)info;
+  
   gboolean isSub = info_local->ch_idx == 1;
   
   const appaBFrame_t* appaFrame = (const appaBFrame_t*)buf;
   const appaBFrame_ReadDisplayResponse_t* readDisplayResponse = (const appaBFrame_ReadDisplayResponse_t*)&appaFrame->readDisplay.response;
   const appaBFrame_ReadDisplayResponse_DisplayData_t* displayData;
+  
   if(!isSub)
     displayData = (const appaBFrame_ReadDisplayResponse_DisplayData_t*)&readDisplayResponse->mainDisplayData;
   else

--- a/src/dmm/appa_b.c
+++ b/src/dmm/appa_b.c
@@ -1,0 +1,552 @@
+#include "appa_b.h"
+
+#include "config.h"
+#include <ctype.h>
+#include <glib.h>
+#include <math.h>
+#include <string.h>
+#include <strings.h>
+#include "libsigrok/libsigrok.h"
+#include "libsigrok-internal.h"
+
+#define LOG_PREFIX "appa_b"
+
+/////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////
+
+#ifdef HAVE_SERIAL_COMM
+SR_PRIV int sr_appa_b_packet_request(struct sr_serial_dev_inst *serial)
+{
+  appaBFrame_t appaFrame;
+  bzero(&appaFrame, sizeof(appaFrame));
+  appaFrame.start = APPA_B_START;
+  appaFrame.command = APPA_B_COMMAND_READ_DISPLAY;
+  appaFrame.dataLength = APPA_B_DATA_LENGTH_REQUEST_READ_DISPLAY;
+  appaInt_t frameLen = APPA_B_GET_FRAMELEN(REQUEST_READ_DISPLAY);
+  appaByte_t checksum = appa_b_checksum(&appaFrame, frameLen);
+  if(serial_flush(serial) != SR_OK)
+    return(SR_ERR_IO);
+  if(serial_write_nonblocking(serial, &appaFrame, frameLen) != frameLen)
+    return(SR_ERR_IO);
+  if(serial_write_nonblocking(serial, &checksum, sizeof(checksum)) != sizeof(checksum))
+    return(SR_ERR_IO);
+  return(SR_OK);
+}
+#endif/*HAVE_SERIAL_COMM*/
+
+SR_PRIV gboolean sr_appa_b_packet_valid(const uint8_t *buf)
+{
+  appaInt_t frameLen = APPA_B_GET_FRAMELEN(RESPONSE_READ_DISPLAY);
+  appaByte_t checksum = appa_b_checksum(buf, frameLen);
+  return(checksum == buf[frameLen]);
+}
+
+SR_PRIV int sr_appa_b_parse(const uint8_t *buf, float *floatval,
+		struct sr_datafeed_analog *analog, void *info)
+{
+  struct appa_b_info* info_local = (struct appa_b_info*)info;
+  gboolean isSub = info_local->ch_idx == 1;
+  
+  const appaBFrame_t* appaFrame = (const appaBFrame_t*)buf;
+  const appaBFrame_ReadDisplayResponse_t* readDisplayResponse = (const appaBFrame_ReadDisplayResponse_t*)&appaFrame->readDisplay.response;
+  const appaBFrame_ReadDisplayResponse_DisplayData_t* displayData;
+  if(!isSub)
+    displayData = (const appaBFrame_ReadDisplayResponse_DisplayData_t*)&readDisplayResponse->mainDisplayData;
+  else
+    displayData = (const appaBFrame_ReadDisplayResponse_DisplayData_t*)&readDisplayResponse->subDisplayData;
+  
+  appaDouble_t unitFactor = 1;
+  appaInt_t displayReadingRaw = APPA_B_DECODE_READING((*displayData));
+  appaDouble_t displayReading = (appaDouble_t)displayReadingRaw;
+  
+  switch(displayData->dot)
+  {
+    default: case APPA_B_DOT_NONE:
+      analog->spec->spec_digits = 0;
+      analog->encoding->digits = 0;
+      unitFactor /= 1;
+      break;
+    case APPA_B_DOT_9999_9:
+      analog->spec->spec_digits = 1;
+      analog->encoding->digits = 1;
+      unitFactor /= 10;
+      break;
+    case APPA_B_DOT_999_99:
+      analog->spec->spec_digits = 2;
+      analog->encoding->digits = 2;
+      unitFactor /= 100;
+      break;
+    case APPA_B_DOT_99_999:
+      analog->spec->spec_digits = 3;
+      analog->encoding->digits = 3;
+      unitFactor /= 1000;
+      break;
+    case APPA_B_DOT_9_9999:
+      analog->spec->spec_digits = 4;
+      analog->encoding->digits = 4;
+      unitFactor /= 10000;
+      break;
+  }
+  
+  switch(displayData->dataContent)
+  {
+    default: case APPA_B_DATA_CONTENT_MEASURING_DATA:
+      break;
+    case APPA_B_DATA_CONTENT_FREQUENCY:
+      break;
+    case APPA_B_DATA_CONTENT_CYCLE:
+      break;
+    case APPA_B_DATA_CONTENT_DUTY:
+      break;
+    case APPA_B_DATA_CONTENT_MEMORY_STAMP:
+      break;
+    case APPA_B_DATA_CONTENT_MEMORY_SAVE:
+      break;
+    case APPA_B_DATA_CONTENT_MEMORY_LOAD:
+      break;
+    case APPA_B_DATA_CONTENT_LOG_SAVE:
+      break;
+    case APPA_B_DATA_CONTENT_LOG_LOAD:
+      break;
+    case APPA_B_DATA_CONTENT_LOAG_RATE:
+      break;
+    case APPA_B_DATA_CONTENT_REL_DELTA:
+      break;
+    case APPA_B_DATA_CONTENT_REL_PERCENT:
+      break;
+    case APPA_B_DATA_CONTENT_REL_REFERENCE:
+      break;
+    case APPA_B_DATA_CONTENT_MAXIMUM:
+      analog->meaning->mqflags |= SR_MQFLAG_MAX;
+      break;
+    case APPA_B_DATA_CONTENT_MINIMUM:
+      analog->meaning->mqflags |= SR_MQFLAG_MIN;
+      break;
+    case APPA_B_DATA_CONTENT_AVERAGE:
+      analog->meaning->mqflags |= SR_MQFLAG_AVG;
+      break;
+    case APPA_B_DATA_CONTENT_PEAK_HOLD_MAX:
+      analog->meaning->mqflags |= SR_MQFLAG_MAX;
+      if(isSub)
+      {
+        analog->meaning->mqflags |= SR_MQFLAG_HOLD;
+      }
+      break;
+    case APPA_B_DATA_CONTENT_PEAK_HOLD_MIN:
+      analog->meaning->mqflags |= SR_MQFLAG_MIN;
+      if(isSub)
+      {
+        analog->meaning->mqflags |= SR_MQFLAG_HOLD;
+      }
+      break;
+    case APPA_B_DATA_CONTENT_DBM:
+      break;
+    case APPA_B_DATA_CONTENT_DB:
+      break;
+    case APPA_B_DATA_CONTENT_AUTO_HOLD:
+      if(isSub)
+      {
+        analog->meaning->mqflags |= SR_MQFLAG_HOLD;
+      }
+      break;
+    case APPA_B_DATA_CONTENT_SETUP:
+      break;
+    case APPA_B_DATA_CONTENT_LOG_STAMP:
+      break;
+    case APPA_B_DATA_CONTENT_LOG_MAX:
+      break;
+    case APPA_B_DATA_CONTENT_LOG_MIN:
+      break;
+    case APPA_B_DATA_CONTENT_LOG_TP:
+      break;
+    case APPA_B_DATA_CONTENT_HOLD:
+      if(isSub)
+      {
+        analog->meaning->mqflags |= SR_MQFLAG_HOLD;
+      }
+      break;
+    case APPA_B_DATA_CONTENT_CURRENT_OUTPUT:
+      break;
+    case APPA_B_DATA_CONTENT_CUR_OUT_0_20MA_PERCENT:
+      break;
+    case APPA_B_DATA_CONTENT_CUR_OUT_4_20MA_PERCENT:
+      break;
+  }
+  
+  if(readDisplayResponse->autoRange)
+  {
+    analog->meaning->mqflags |= SR_MQFLAG_AUTORANGE;
+  }
+  
+  switch(readDisplayResponse->functionCode)
+  {
+    default: case APPA_B_FUNCTIONCODE_NONE:
+      break;
+    case APPA_B_FUNCTIONCODE_AC_V:
+      analog->meaning->mqflags |= SR_MQFLAG_AC;
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_DC_V:
+      analog->meaning->mqflags |= SR_MQFLAG_DC;
+      break;
+    case APPA_B_FUNCTIONCODE_AC_MV:
+      analog->meaning->mqflags |= SR_MQFLAG_AC;
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_DC_MV:
+      analog->meaning->mqflags |= SR_MQFLAG_DC;
+      break;
+    case APPA_B_FUNCTIONCODE_OHM:
+      break;
+    case APPA_B_FUNCTIONCODE_CONTINUITY:
+      analog->meaning->mq = SR_MQ_CONTINUITY;
+      break;
+    case APPA_B_FUNCTIONCODE_DIODE:
+      analog->meaning->mqflags |= SR_MQFLAG_DIODE;
+      analog->meaning->mqflags |= SR_MQFLAG_DC;
+      break;
+    case APPA_B_FUNCTIONCODE_CAP:
+      break;
+    case APPA_B_FUNCTIONCODE_AC_A:
+      analog->meaning->mqflags |= SR_MQFLAG_AC;
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_DC_A:
+      analog->meaning->mqflags |= SR_MQFLAG_DC;
+      break;
+    case APPA_B_FUNCTIONCODE_AC_MA:
+      analog->meaning->mqflags |= SR_MQFLAG_AC;
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_DC_MA:
+      analog->meaning->mqflags |= SR_MQFLAG_DC;
+      break;
+    case APPA_B_FUNCTIONCODE_DEGC:
+      break;
+    case APPA_B_FUNCTIONCODE_DEGF:
+      break;
+    case APPA_B_FUNCTIONCODE_FREQUENCY:
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_DUTY:
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_HZ_V:
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_HZ_MV:
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_HZ_A:
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_HZ_MA:
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_AC_DC_V:
+      analog->meaning->mqflags |= SR_MQFLAG_DC;
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_AC_DC_MV:
+      analog->meaning->mqflags |= SR_MQFLAG_DC;
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_AC_DC_A:
+      analog->meaning->mqflags |= SR_MQFLAG_DC;
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_AC_DC_MA:
+      analog->meaning->mqflags |= SR_MQFLAG_DC;
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_LPF_V:
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_LPF_MV:
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_LPF_A:
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_LPF_MA:
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_AC_UA:
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      analog->meaning->mqflags |= SR_MQFLAG_AC;
+      break;
+    case APPA_B_FUNCTIONCODE_DC_UA:
+      analog->meaning->mqflags |= SR_MQFLAG_DC;
+      break;
+    case APPA_B_FUNCTIONCODE_DC_A_OUT:
+      analog->meaning->mqflags |= SR_MQFLAG_DC;
+      break;
+    case APPA_B_FUNCTIONCODE_DC_A_OUT_SLOW_LINEAR:
+      analog->meaning->mqflags |= SR_MQFLAG_DC;
+      break;
+    case APPA_B_FUNCTIONCODE_DC_A_OUT_FAST_LINEAR:
+      analog->meaning->mqflags |= SR_MQFLAG_DC;
+      break;
+    case APPA_B_FUNCTIONCODE_DC_A_OUT_SLOW_STEP:
+      analog->meaning->mqflags |= SR_MQFLAG_DC;
+      break;
+    case APPA_B_FUNCTIONCODE_DC_A_OUT_FAST_STEP:
+      analog->meaning->mqflags |= SR_MQFLAG_DC;
+      break;
+    case APPA_B_FUNCTIONCODE_LOOP_POWER:
+      analog->meaning->mqflags |= SR_MQFLAG_DC;
+      break;
+    case APPA_B_FUNCTIONCODE_250OHM_HART:
+      break;
+    case APPA_B_FUNCTIONCODE_VOLT_SENSE:
+      analog->meaning->mqflags |= SR_MQFLAG_AC;
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_PEAK_HOLD_V:
+      break;
+    case APPA_B_FUNCTIONCODE_PEAK_HOLD_MV:
+      break;
+    case APPA_B_FUNCTIONCODE_PEAK_HOLD_A:
+      break;
+    case APPA_B_FUNCTIONCODE_PEAK_HOLD_MA:
+      break;
+    case APPA_B_FUNCTIONCODE_LOZ_AC_V:
+      analog->meaning->mqflags |= SR_MQFLAG_AC;
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_LOZ_DC_V:
+      analog->meaning->mqflags |= SR_MQFLAG_DC;
+      break;
+    case APPA_B_FUNCTIONCODE_LOZ_AC_DC_V:
+      analog->meaning->mqflags |= SR_MQFLAG_DC;
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_LOZ_LPF_V:
+      break;
+    case APPA_B_FUNCTIONCODE_LOZ_HZ_V:
+      analog->meaning->mqflags |= SR_MQFLAG_AC;
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_LOZ_PEAK_HOLD_V:
+      break;
+    case APPA_B_FUNCTIONCODE_BATTERY:
+      break;
+    case APPA_B_FUNCTIONCODE_AC_W:
+      analog->meaning->mqflags |= SR_MQFLAG_AC;
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_DC_W:
+      analog->meaning->mqflags |= SR_MQFLAG_DC;
+      break;
+    case APPA_B_FUNCTIONCODE_PF:
+      analog->meaning->mqflags |= SR_MQFLAG_AC;
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_FLEX_AC_A:
+      analog->meaning->mqflags |= SR_MQFLAG_AC;
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_FLEX_LPF_A:
+      analog->meaning->mqflags |= SR_MQFLAG_AC;
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_FLEX_PEAK_HOLD_A:
+      analog->meaning->mqflags |= SR_MQFLAG_AC;
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_FLEX_HZ_A:
+      analog->meaning->mqflags |= SR_MQFLAG_AC;
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_V_HARM:
+      analog->meaning->mqflags |= SR_MQFLAG_AC;
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_INRUSH:
+      analog->meaning->mqflags |= SR_MQFLAG_AC;
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_A_HARM:
+      analog->meaning->mqflags |= SR_MQFLAG_AC;
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_FLEX_INRUSH:
+      analog->meaning->mqflags |= SR_MQFLAG_AC;
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_FLEX_A_HARM:
+      analog->meaning->mqflags |= SR_MQFLAG_AC;
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+    case APPA_B_FUNCTIONCODE_PEAK_HOLD_UA:
+      analog->meaning->mqflags |= SR_MQFLAG_AC;
+      analog->meaning->mqflags |= SR_MQFLAG_RMS;
+      break;
+  }
+  
+  switch(displayData->unit)
+  {
+    default: case APPA_B_UNIT_NONE:
+      analog->meaning->unit = SR_UNIT_UNITLESS;
+      break;
+    case APPA_B_UNIT_MV:
+      analog->meaning->unit = SR_UNIT_VOLT;
+      analog->meaning->mq = SR_MQ_VOLTAGE;
+      unitFactor /= 1000;
+      analog->encoding->digits += 3;
+      break;
+    case APPA_B_UNIT_V:
+      analog->meaning->unit = SR_UNIT_VOLT;
+      analog->meaning->mq = SR_MQ_VOLTAGE;
+      break;
+    case APPA_B_UNIT_UA:
+      analog->meaning->unit = SR_UNIT_AMPERE;
+      analog->meaning->mq = SR_MQ_CURRENT;
+      unitFactor /= 1000000;
+      analog->encoding->digits += 6;
+      break;
+    case APPA_B_UNIT_MA:
+      analog->meaning->unit = SR_UNIT_AMPERE;
+      analog->meaning->mq = SR_MQ_CURRENT;
+      unitFactor /= 1000;
+      analog->encoding->digits += 3;
+      break;
+    case APPA_B_UNIT_A:
+      analog->meaning->unit = SR_UNIT_AMPERE;
+      analog->meaning->mq = SR_MQ_CURRENT;
+      break;
+    case APPA_B_UNIT_DB: 
+      analog->meaning->unit = SR_UNIT_DECIBEL_VOLT;
+      analog->meaning->mq = SR_MQ_POWER;
+      break;
+    case APPA_B_UNIT_DBM: 
+      analog->meaning->unit = SR_UNIT_DECIBEL_MW;
+      analog->meaning->mq = SR_MQ_POWER;
+      break;
+    case APPA_B_UNIT_NF: 
+      analog->meaning->unit = SR_UNIT_FARAD;
+      analog->meaning->mq = SR_MQ_CAPACITANCE;
+      unitFactor /= 1000000000;
+      analog->encoding->digits += 9;
+      break;
+    case APPA_B_UNIT_UF: 
+      analog->meaning->unit = SR_UNIT_FARAD;
+      analog->meaning->mq = SR_MQ_CAPACITANCE;
+      unitFactor /= 1000000;
+      analog->encoding->digits += 6;
+      break;
+    case APPA_B_UNIT_MF: 
+      analog->meaning->unit = SR_UNIT_FARAD;
+      analog->meaning->mq = SR_MQ_CAPACITANCE;
+      unitFactor /= 1000;
+      analog->encoding->digits += 3;
+      break;
+    case APPA_B_UNIT_GOHM: 
+      analog->meaning->unit = SR_UNIT_OHM;
+      analog->meaning->mq = SR_MQ_RESISTANCE;
+      unitFactor *= 1000000000;
+      break;
+    case APPA_B_UNIT_MOHM: 
+      analog->meaning->unit = SR_UNIT_OHM;
+      analog->meaning->mq = SR_MQ_RESISTANCE;
+      unitFactor *= 1000000;
+      break;
+    case APPA_B_UNIT_KOHM: 
+      analog->meaning->unit = SR_UNIT_OHM;
+      analog->meaning->mq = SR_MQ_RESISTANCE;
+      unitFactor *= 1000;
+      break;
+    case APPA_B_UNIT_OHM: 
+      analog->meaning->unit = SR_UNIT_OHM;
+      analog->meaning->mq = SR_MQ_RESISTANCE;
+      break;
+    case APPA_B_UNIT_PERCENT: 
+      analog->meaning->unit = SR_UNIT_PERCENTAGE;
+      analog->meaning->mq = SR_MQ_DIFFERENCE;
+      break;
+    case APPA_B_UNIT_MHZ: 
+      analog->meaning->unit = SR_UNIT_HERTZ;
+      analog->meaning->mq = SR_MQ_FREQUENCY;
+      unitFactor *= 1000000;
+      break;
+    case APPA_B_UNIT_KHZ: 
+      analog->meaning->unit = SR_UNIT_HERTZ;
+      analog->meaning->mq = SR_MQ_FREQUENCY;
+      unitFactor *= 1000;
+      break;
+    case APPA_B_UNIT_HZ: 
+      analog->meaning->unit = SR_UNIT_HERTZ;
+      analog->meaning->mq = SR_MQ_FREQUENCY;
+      break;
+    case APPA_B_UNIT_DEGC: 
+      analog->meaning->unit = SR_UNIT_CELSIUS;
+      analog->meaning->mq = SR_MQ_TEMPERATURE;
+      break;
+    case APPA_B_UNIT_DEGF: 
+      analog->meaning->unit = SR_UNIT_FAHRENHEIT;
+      analog->meaning->mq = SR_MQ_TEMPERATURE;
+      break;
+    case APPA_B_UNIT_NS: 
+      analog->meaning->unit = SR_UNIT_SECOND;
+      analog->meaning->mq = SR_MQ_TIME;
+      unitFactor /= 1000000000;
+      analog->encoding->digits += 9;
+      break;
+    case APPA_B_UNIT_US: 
+      analog->meaning->unit = SR_UNIT_SECOND;
+      analog->meaning->mq = SR_MQ_TIME;
+      unitFactor /= 1000000;
+      analog->encoding->digits += 6;
+      break;
+    case APPA_B_UNIT_MS: 
+      analog->meaning->unit = SR_UNIT_SECOND;
+      analog->meaning->mq = SR_MQ_TIME;
+      unitFactor /= 1000;
+      analog->encoding->digits += 3;
+      break;
+    case APPA_B_UNIT_SEC: 
+      analog->meaning->unit = SR_UNIT_SECOND;
+      analog->meaning->mq = SR_MQ_TIME;
+      break;
+    case APPA_B_UNIT_MIN: 
+      analog->meaning->unit = SR_UNIT_SECOND;
+      analog->meaning->mq = SR_MQ_TIME;
+      unitFactor *= 60;
+      break;
+    case APPA_B_UNIT_KW: 
+      analog->meaning->unit = SR_UNIT_WATT;
+      analog->meaning->mq = SR_MQ_POWER;
+      unitFactor *= 1000;
+      break;
+    case APPA_B_UNIT_PF: 
+      analog->meaning->unit = SR_UNIT_UNITLESS;
+      analog->meaning->mq = SR_MQ_POWER_FACTOR;
+      break;
+  }
+  
+  displayReading *= unitFactor;  
+  
+  if(displayReadingRaw == APPA_B_WORDCODE_BATT)
+  {
+    sr_err("Battery low");
+  }
+    
+  if(displayData->overload
+      || APPA_B_IS_WORDCODE(displayReadingRaw))
+  {
+    *floatval = INFINITY;
+  }
+  else
+  {
+    *floatval = displayReading;
+  }
+  
+  info_local->ch_idx++;
+  return(SR_OK);
+}
+
+SR_PRIV const char *sr_appa_b_channel_formats[APPA_B_DISPLAY_COUNT] = {
+	"main",
+  "sub",
+};

--- a/src/dmm/appa_b.h
+++ b/src/dmm/appa_b.h
@@ -1,0 +1,569 @@
+#ifndef APPA_B__H
+#define APPA_B__H
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif/*def __cplusplus*/
+  
+#ifdef __GNUC__
+  #define APPA_B_GCC_PACKED __attribute__((packed))
+#else/*def __GNUC__*/
+  #define APPA_B_GCC_PACKED
+#endif/*def __GNUC__*/
+  
+typedef char appaChar_t;
+typedef u_int8_t appaByte_t;
+typedef u_int16_t appaWord_t;
+typedef u_int32_t appaDWord_t;
+typedef int appaInt_t;
+typedef double appaDouble_t;
+
+static const appaChar_t appaStringNa[] = "N/A";
+
+typedef enum
+{
+    APPA_B_COMMAND_READ_INFORMATION = 0x00,
+    APPA_B_COMMAND_READ_DISPLAY = 0x01,
+} appaBCommand_t;
+
+typedef enum
+{
+    APPA_B_MODEL_ID_INVALID = 0x00,
+    APPA_B_MODEL_ID_150 = 0x01,
+    APPA_B_MODEL_ID_150B = 0x02,
+    APPA_B_MODEL_ID_208 = 0x03,
+    APPA_B_MODEL_ID_208B = 0x04,
+    APPA_B_MODEL_ID_506 = 0x05,
+    APPA_B_MODEL_ID_506B = 0x06,
+} appaBModelId_t;
+
+static const appaChar_t* appaBModelTable[] =
+{
+  "N/A",
+  "APPA 150",
+  "APPA 150B",
+  "APPA 208",
+  "APPA 208B",
+  "APPA 506",
+  "APPA 506B",
+};
+#define APPA_B_MODEL_TABLE_MIN 0
+#define APPA_B_MODEL_TABLE_MAX 6
+#define APPA_B_MODEL_ID_TO_STRING(argModelId) (argModelId<APPA_B_MODEL_TABLE_MIN||argModelId>APPA_B_MODEL_TABLE_MAX?appaStringNa:appaBModelTable[argModelId])
+
+typedef enum
+{
+    APPA_B_WORDCODE_SPACE = 0x700000,
+    APPA_B_WORDCODE_FULL = 0x700001,
+    APPA_B_WORDCODE_BEEP = 0x700002,
+    APPA_B_WORDCODE_APO = 0x700003,
+    APPA_B_WORDCODE_B_LIT = 0x700004,
+    APPA_B_WORDCODE_HAZ = 0x700005,
+    APPA_B_WORDCODE_ON = 0x700006,
+    APPA_B_WORDCODE_OFF = 0x700007,
+    APPA_B_WORDCODE_RESET = 0x700008,
+    APPA_B_WORDCODE_START = 0x700009,
+    APPA_B_WORDCODE_VIEW = 0x70000a,
+    APPA_B_WORDCODE_PAUSE = 0x70000b,
+    APPA_B_WORDCODE_FUSE = 0x70000c,
+    APPA_B_WORDCODE_PROBE = 0x70000d,
+    APPA_B_WORDCODE_DEF = 0x70000e,
+    APPA_B_WORDCODE_CLR = 0x70000f,
+    APPA_B_WORDCODE_ER = 0x700010,
+    APPA_B_WORDCODE_ER1 = 0x700011,
+    APPA_B_WORDCODE_ER2 = 0x700012,
+    APPA_B_WORDCODE_ER3 = 0x700013,
+    APPA_B_WORDCODE_DASH = 0x700014,
+    APPA_B_WORDCODE_DASH1 = 0x700015,
+    APPA_B_WORDCODE_TEST = 0x700016,
+    APPA_B_WORDCODE_DASH2 = 0x700017,
+    APPA_B_WORDCODE_BATT = 0x700018,
+    APPA_B_WORDCODE_DISLT = 0x700019,
+    APPA_B_WORDCODE_NOISE = 0x70001a,
+    APPA_B_WORDCODE_FILTR = 0x70001b,
+    APPA_B_WORDCODE_PASS = 0x70001c,
+    APPA_B_WORDCODE_NULL = 0x70001d,
+    APPA_B_WORDCODE_0_20 = 0x70001e,
+    APPA_B_WORDCODE_4_20 = 0x70001f,
+    APPA_B_WORDCODE_RATE = 0x700020,
+    APPA_B_WORDCODE_SAVE = 0x700021,
+    APPA_B_WORDCODE_LOAD = 0x700022,
+    APPA_B_WORDCODE_YES = 0x700023,
+    APPA_B_WORDCODE_SEND = 0x700024,
+    APPA_B_WORDCODE_AHOLD = 0x700025,
+    APPA_B_WORDCODE_AUTO = 0x700026,
+    APPA_B_WORDCODE_CNTIN = 0x700027,
+    APPA_B_WORDCODE_CAL = 0x700028,
+    APPA_B_WORDCODE_VERSION = 0x700029,
+    APPA_B_WORDCODE_OL = 0x70002a,
+    APPA_B_WORDCODE_BAT_FULL = 0x70002b,
+    APPA_B_WORDCODE_BAT_HALF = 0x70002c,
+    APPA_B_WORDCODE_LO = 0x70002d,
+    APPA_B_WORDCODE_HI = 0x70002e,
+    APPA_B_WORDCODE_DIGIT = 0x70002f,
+    APPA_B_WORDCODE_RDY = 0x700030,
+    APPA_B_WORDCODE_DISC = 0x700031,
+    APPA_B_WORDCODE_OUTF = 0x700032,
+    APPA_B_WORDCODE_OLA = 0x700033,
+    APPA_B_WORDCODE_OLV = 0x700034,
+    APPA_B_WORDCODE_OLVA = 0x700035,
+    APPA_B_WORDCODE_BAD = 0x700036,
+    APPA_B_WORDCODE_TEMP = 0x700037,
+} appaBWordcode_t;
+
+static const appaChar_t* appaBWordcodeTable[] =
+{
+  "", /*< 0x00000 */
+  "Full", /*< 0x00001 */
+  "Beep", /*< 0x00002 */
+  "Auto Power-Off", /*< 0x00003 */
+  "Backlight", /*< 0x00004 */
+  "Hazard", /*< 0x00005 */
+  "On", /*< 0x00006 */
+  "Off", /*< 0x00007 */
+  "Reset", /*< 0x00008 */
+  "Start", /*< 0x00009 */
+  "View", /*< 0x0000a */
+  "Pause", /*< 0x0000b */
+  "Fuse", /*< 0x0000c */
+  "Probe", /*< 0x0000d */
+  "Definition", /*< 0x0000e */
+  "Clr", /*< 0x0000f */
+  "Er", /*< 0x00010 */
+  "Er1", /*< 0x00011 */
+  "Er2", /*< 0x00012 */
+  "Er3", /*< 0x00013 */
+  "-----", /*< 0x00014 */
+  "Dash1", /*< 0x00015 */
+  "Test", /*< 0x00016 */
+  "Dash2", /*< 0x00017 */
+  "Battery", /*< 0x00018 */
+  "diSLt", /*< 0x00019 */
+  "Noise", /*< 0x0001a */
+  "Filter", /*< 0x0001b */
+  "PASS", /*< 0x0001c */
+  "null", /*< 0x0001d */
+  "0 - 20", /*< 0x0001e */
+  "4 - 20", /*< 0x0001f */
+  "Rate", /*< 0x00020 */
+  "Save", /*< 0x00021 */
+  "Load", /*< 0x00022 */
+  "Yes", /*< 0x00023 */
+  "Send", /*< 0x00024 */
+  "Auto Hold", /*< 0x00025 */
+  "Auto", /*< 0x00026 */
+  "Continuity", /*< 0x00027 */
+  "CAL", /*< 0x00028 */
+  "Version", /*< 0x00029 */
+  "OL", /*< 0x0002a */
+  "FULL", /*< 0x0002b */
+  "HALF", /*< 0x0002c */
+  "Lo", /*< 0x0002d */
+  "Hi", /*< 0x0002e */
+  "Digits", /*< 0x0002f */
+  "Ready", /*< 0x00030 */
+  "dISC", /*< 0x00031 */
+  "outF", /*< 0x00032 */
+  "OLA", /*< 0x00033 */
+  "OLV", /*< 0x00034 */
+  "OLVA", /*< 0x00035 */
+  "BAD", /*< 0x00036 */
+  "Temperature", /*< 0x00037 */
+};
+#define APPA_B_WORDCODE_TABLE_MIN 0x700000
+#define APPA_B_WORDCODE_TABLE_MAX 0x700037
+#define APPA_B_WORDCODE_TO_STRING(argWordcode) (argWordcode<APPA_B_WORDCODE_TABLE_MIN||argWordcode>APPA_B_WORDCODE_TABLE_MAX?appaStringNa:appaBWordcodeTable[argWordcode-APPA_B_WORDCODE_TABLE_MIN])
+#define APPA_B_IS_WORDCODE(argWordcode) (argWordcode>=APPA_B_WORDCODE_TABLE_MIN)
+#define APPA_B_IS_WORDCODE_VALID(argWordcode) (argWordcode>=APPA_B_WORDCODE_TABLE_MIN&&argWordcode<=APPA_B_WORDCODE_TABLE_MAX)
+
+typedef enum
+{
+    APPA_B_UNIT_NONE = 0x00,
+    APPA_B_UNIT_V = 0x01,
+    APPA_B_UNIT_MV = 0x02,
+    APPA_B_UNIT_A = 0x03,
+    APPA_B_UNIT_MA = 0x04,
+    APPA_B_UNIT_DB = 0x05,
+    APPA_B_UNIT_DBM = 0x06,
+    APPA_B_UNIT_MF = 0x07,
+    APPA_B_UNIT_UF = 0x08,
+    APPA_B_UNIT_NF = 0x09,
+    APPA_B_UNIT_GOHM = 0x0a,
+    APPA_B_UNIT_MOHM = 0x0b,
+    APPA_B_UNIT_KOHM = 0x0c,
+    APPA_B_UNIT_OHM = 0x0d,
+    APPA_B_UNIT_PERCENT = 0x0e,
+    APPA_B_UNIT_MHZ = 0x0f,
+    APPA_B_UNIT_KHZ = 0x10,
+    APPA_B_UNIT_HZ = 0x11,
+    APPA_B_UNIT_DEGC = 0x12,
+    APPA_B_UNIT_DEGF = 0x13,
+    APPA_B_UNIT_SEC = 0x14,
+    APPA_B_UNIT_MS = 0x15,
+    APPA_B_UNIT_US = 0x16,
+    APPA_B_UNIT_NS = 0x17,
+    APPA_B_UNIT_UA = 0x18,
+    APPA_B_UNIT_MIN = 0x19,
+    APPA_B_UNIT_KW = 0x1a,
+    APPA_B_UNIT_PF = 0x1b,
+} appaBUnit_t;
+
+static const appaChar_t* appaBUnitTable[] =
+{
+  "", /**< 0x00 */
+  "V", /**< 0x01 */
+  "mV", /**< 0x02 */
+  "A", /**< 0x03 */
+  "mA", /**< 0x04 */
+  "dB", /**< 0x05 */
+  "dBm", /**< 0x06 */
+  "mF", /**< 0x07 */
+  "µF", /**< 0x08 */
+  "nF", /**< 0x09 */
+  "GΩ", /**< 0x0a */
+  "MΩ", /**< 0x0b */
+  "kΩ", /**< 0x0c */
+  "Ω", /**< 0x0d */
+  "%", /**< 0x0e */
+  "MHz", /**< 0x0f */
+  "kHz", /**< 0x10 */
+  "Hz", /**< 0x11 */
+  "°C", /**< 0x12 */
+  "°F", /**< 0x13 */
+  "sec", /**< 0x14 */
+  "ms", /**< 0x15 */
+  "us", /**< 0x16 */
+  "ns", /**< 0x17 */
+  "µA", /**< 0x18 */
+  "min", /**< 0x19 */
+  "kW", /**< 0x1a */
+  "PF", /**< 0x1b */
+};
+
+#define APPA_B_UNIT_TABLE_MIN 0x00
+#define APPA_B_UNIT_TABLE_MAX 0x1b
+#define APPA_B_UNIT_TO_STRING(argUnit) (argUnit<APPA_B_UNIT_TABLE_MIN||argUnit>APPA_B_UNIT_TABLE_MAX?appaStringNa:appaBUnitTable[argUnit])
+
+typedef enum
+{
+    APPA_B_DOT_NONE = 0x00,
+    APPA_B_DOT_9999_9 = 0x01,
+    APPA_B_DOT_999_99 = 0x02,
+    APPA_B_DOT_99_999 = 0x03,
+    APPA_B_DOT_9_9999 = 0x04,
+} appaBDot_t;
+
+static const double appaBDotFactor[] =
+{
+  1.0,
+  0.1,
+  0.01,
+  0.001,
+  0.0001,
+};
+
+static const int appaBDotPrecisionAfterDot[] =
+{
+  0,
+  1,
+  2,
+  3,
+  4,
+};
+
+static const int appaBDotPrecisionBeforeDot[] =
+{
+  5,
+  4,
+  3,
+  2,
+  1,
+};
+
+typedef enum
+{
+    APPA_B_NOT_OVERLOAD = 0x00,
+    APPA_B_OVERLOAD = 0x01,
+} appaBOverload_t;
+
+#define APPA_B_READING_TEXT_OL "OL"
+
+typedef enum
+{
+    APPA_B_DATA_CONTENT_MEASURING_DATA = 0x00,
+    APPA_B_DATA_CONTENT_FREQUENCY = 0x01,
+    APPA_B_DATA_CONTENT_CYCLE = 0x02,
+    APPA_B_DATA_CONTENT_DUTY = 0x03,
+    APPA_B_DATA_CONTENT_MEMORY_STAMP = 0x04,
+    APPA_B_DATA_CONTENT_MEMORY_SAVE = 0x05,
+    APPA_B_DATA_CONTENT_MEMORY_LOAD = 0x06,
+    APPA_B_DATA_CONTENT_LOG_SAVE = 0x07,
+    APPA_B_DATA_CONTENT_LOG_LOAD = 0x08,
+    APPA_B_DATA_CONTENT_LOAG_RATE = 0x09,
+    APPA_B_DATA_CONTENT_REL_DELTA = 0x0a,
+    APPA_B_DATA_CONTENT_REL_PERCENT = 0x0b,
+    APPA_B_DATA_CONTENT_REL_REFERENCE = 0x0c,
+    APPA_B_DATA_CONTENT_MAXIMUM = 0x0d,
+    APPA_B_DATA_CONTENT_MINIMUM = 0x0e,
+    APPA_B_DATA_CONTENT_AVERAGE = 0x0f,
+    APPA_B_DATA_CONTENT_PEAK_HOLD_MAX = 0x10,
+    APPA_B_DATA_CONTENT_PEAK_HOLD_MIN = 0x11,
+    APPA_B_DATA_CONTENT_DBM = 0x12,
+    APPA_B_DATA_CONTENT_DB = 0x13,
+    APPA_B_DATA_CONTENT_AUTO_HOLD = 0x14,
+    APPA_B_DATA_CONTENT_SETUP = 0x15,
+    APPA_B_DATA_CONTENT_LOG_STAMP = 0x16,
+    APPA_B_DATA_CONTENT_LOG_MAX = 0x17,
+    APPA_B_DATA_CONTENT_LOG_MIN = 0x18,
+    APPA_B_DATA_CONTENT_LOG_TP = 0x19,
+    APPA_B_DATA_CONTENT_HOLD = 0x1a,
+    APPA_B_DATA_CONTENT_CURRENT_OUTPUT = 0x1b,
+    APPA_B_DATA_CONTENT_CUR_OUT_0_20MA_PERCENT = 0x1c,
+    APPA_B_DATA_CONTENT_CUR_OUT_4_20MA_PERCENT = 0x1d,
+} appaBDataContent_t;
+
+typedef enum
+{
+    APPA_B_FUNCTIONCODE_NONE = 0x00,
+    APPA_B_FUNCTIONCODE_AC_V = 0x01,
+    APPA_B_FUNCTIONCODE_DC_V = 0x02,
+    APPA_B_FUNCTIONCODE_AC_MV = 0x03,
+    APPA_B_FUNCTIONCODE_DC_MV = 0x04,
+    APPA_B_FUNCTIONCODE_OHM = 0x05,
+    APPA_B_FUNCTIONCODE_CONTINUITY = 0x06,
+    APPA_B_FUNCTIONCODE_DIODE = 0x07,
+    APPA_B_FUNCTIONCODE_CAP = 0x08,
+    APPA_B_FUNCTIONCODE_AC_A = 0x09,
+    APPA_B_FUNCTIONCODE_DC_A = 0x0a,
+    APPA_B_FUNCTIONCODE_AC_MA = 0x0b,
+    APPA_B_FUNCTIONCODE_DC_MA = 0x0c,
+    APPA_B_FUNCTIONCODE_DEGC = 0x0d,
+    APPA_B_FUNCTIONCODE_DEGF = 0x0e,
+    APPA_B_FUNCTIONCODE_FREQUENCY = 0x0f,
+    APPA_B_FUNCTIONCODE_DUTY = 0x10,
+    APPA_B_FUNCTIONCODE_HZ_V = 0x11,
+    APPA_B_FUNCTIONCODE_HZ_MV = 0x12,
+    APPA_B_FUNCTIONCODE_HZ_A = 0x13,
+    APPA_B_FUNCTIONCODE_HZ_MA = 0x14,
+    APPA_B_FUNCTIONCODE_AC_DC_V = 0x15,
+    APPA_B_FUNCTIONCODE_AC_DC_MV = 0x16,
+    APPA_B_FUNCTIONCODE_AC_DC_A = 0x17,
+    APPA_B_FUNCTIONCODE_AC_DC_MA = 0x18,
+    APPA_B_FUNCTIONCODE_LPF_V = 0x19,
+    APPA_B_FUNCTIONCODE_LPF_MV = 0x1a,
+    APPA_B_FUNCTIONCODE_LPF_A = 0x1b,
+    APPA_B_FUNCTIONCODE_LPF_MA = 0x1c,
+    APPA_B_FUNCTIONCODE_AC_UA = 0x1d,
+    APPA_B_FUNCTIONCODE_DC_UA = 0x1e,
+    APPA_B_FUNCTIONCODE_DC_A_OUT = 0x1f,
+    APPA_B_FUNCTIONCODE_DC_A_OUT_SLOW_LINEAR = 0x20,
+    APPA_B_FUNCTIONCODE_DC_A_OUT_FAST_LINEAR = 0x21,
+    APPA_B_FUNCTIONCODE_DC_A_OUT_SLOW_STEP = 0x22,
+    APPA_B_FUNCTIONCODE_DC_A_OUT_FAST_STEP = 0x23,
+    APPA_B_FUNCTIONCODE_LOOP_POWER = 0x24,
+    APPA_B_FUNCTIONCODE_250OHM_HART = 0x25,
+    APPA_B_FUNCTIONCODE_VOLT_SENSE = 0x26,
+    APPA_B_FUNCTIONCODE_PEAK_HOLD_V = 0x27,
+    APPA_B_FUNCTIONCODE_PEAK_HOLD_MV = 0x28,
+    APPA_B_FUNCTIONCODE_PEAK_HOLD_A = 0x29,
+    APPA_B_FUNCTIONCODE_PEAK_HOLD_MA = 0x2a,
+    APPA_B_FUNCTIONCODE_LOZ_AC_V = 0x2b,
+    APPA_B_FUNCTIONCODE_LOZ_DC_V = 0x2c,
+    APPA_B_FUNCTIONCODE_LOZ_AC_DC_V = 0x2d,
+    APPA_B_FUNCTIONCODE_LOZ_LPF_V = 0x2e,
+    APPA_B_FUNCTIONCODE_LOZ_HZ_V = 0x2f,
+    APPA_B_FUNCTIONCODE_LOZ_PEAK_HOLD_V = 0x30,
+    APPA_B_FUNCTIONCODE_BATTERY = 0x31,
+    APPA_B_FUNCTIONCODE_AC_W = 0x32,
+    APPA_B_FUNCTIONCODE_DC_W = 0x33,
+    APPA_B_FUNCTIONCODE_PF = 0x34,
+    APPA_B_FUNCTIONCODE_FLEX_AC_A = 0x35,
+    APPA_B_FUNCTIONCODE_FLEX_LPF_A = 0x36,
+    APPA_B_FUNCTIONCODE_FLEX_PEAK_HOLD_A = 0x37,
+    APPA_B_FUNCTIONCODE_FLEX_HZ_A = 0x38,
+    APPA_B_FUNCTIONCODE_V_HARM = 0x39,
+    APPA_B_FUNCTIONCODE_INRUSH = 0x3a,
+    APPA_B_FUNCTIONCODE_A_HARM = 0x3b,
+    APPA_B_FUNCTIONCODE_FLEX_INRUSH = 0x3c,
+    APPA_B_FUNCTIONCODE_FLEX_A_HARM = 0x3d,
+    APPA_B_FUNCTIONCODE_PEAK_HOLD_UA = 0x3e,
+} appaBFunctioncode_t;
+
+static const appaChar_t* appaBFunctioncodeTable[] =
+{
+  "", /**< 0x00 */
+  "AC V", /**< 0x01 */
+  "DC V", /**< 0x02 */
+  "AC mV", /**< 0x03 */
+  "DC mV", /**< 0x04 */
+  "Ω", /**< 0x05 */
+  "Continuity", /**< 0x06 */
+  "Diode", /**< 0x07 */
+  "Capacitor", /**< 0x08 */
+  "AC A", /**< 0x09 */
+  "DC A", /**< 0x0a */
+  "AC mA", /**< 0x0b */
+  "DC mA", /**< 0x0c */
+  "°C", /**< 0x0d */
+  "°F", /**< 0x0e */
+  "Frequency", /**< 0x0f */
+  "Duty Cycle", /**< 0x10 */
+  "Hz V", /**< 0x11 */
+  "Hz mV", /**< 0x12 */
+  "Hz A", /**< 0x13 */
+  "Hz mA", /**< 0x14 */
+  "AC+DC V", /**< 0x15 */
+  "AC+DC mV", /**< 0x16 */
+  "AC+DC A", /**< 0x17 */
+  "AC+DC mA", /**< 0x18 */
+  "HFR V", /**< 0x19 */
+  "HFR mV", /**< 0x1a */
+  "HFR A", /**< 0x1b */
+  "HFR mA", /**< 0x1c */
+  "AC µA", /**< 0x1d */
+  "DC µA", /**< 0x1e */
+  "DC A Out", /**< 0x1f */
+  "DC A Out slow linear", /**< 0x20 */
+  "DC A Out fast linear", /**< 0x21 */
+  "DC A Out slow step", /**< 0x22 */
+  "DC A Out fast step", /**< 0x23 */
+  "Loop power", /**< 0x24 */
+  "250Ω heart", /**< 0x25 */
+  "VOLT SENSE", /**< 0x26 */
+  "PEAK HOLD V", /**< 0x27 */
+  "PEAK HOLD mV", /**< 0x28 */
+  "PEAK HOLD A", /**< 0x29 */
+  "PEAK HOLD mA", /**< 0x2a */
+  "LoZ AC V", /**< 0x2b */
+  "LoZ DC V", /**< 0x2c */
+  "LoZ AC+DC V", /**< 0x2d */
+  "LoZ HFR V", /**< 0x2e */
+  "LoZ Hz V", /**< 0x2f */
+  "LoZ PEAK HOLD V", /**< 0x30 */
+  "BATTERY", /**< 0x31 */
+  "AC W", /**< 0x32 */
+  "DC W", /**< 0x33 */
+  "PF", /**< 0x34 */
+  "Flex AC A", /**< 0x35 */
+  "Flex HFR A", /**< 0x36 */
+  "Flex PEAK HOLD A", /**< 0x37 */
+  "Flex Hz A", /**< 0x38 */
+  "V HARM", /**< 0x39 */
+  "INRUSH", /**< 0x3a */
+  "A HARM", /**< 0x3b */
+  "Flex INRUSH", /**< 0x3c */
+  "Flex A HARM", /**< 0x3d */
+  "PEAK HOLD µA", /**< 0x3e */
+};
+#define APPA_B_FUNCTIONCODE_TABLE_MIN 0x00
+#define APPA_B_FUNCTIONCODE_TABLE_MAX 0x3e
+#define APPA_B_FUNCTIONCODE_TO_STRING(argFunctioncode) (argFunctioncode<APPA_B_FUNCTIONCODE_TABLE_MIN||argFunctioncode>APPA_B_FUNCTIONCODE_TABLE_MAX?appaStringNa:appaBFunctioncodeTable[argFunctioncode])
+
+typedef enum
+{
+    APPA_B_MANUAL_TEST = 0x00,
+    APPA_B_AUTO_TEST = 0x01,
+} appaBAutotest_t;
+
+typedef enum
+{
+    APPA_B_MANUAL_RANGE = 0x00,
+    APPA_B_AUTO_RANGE = 0x01,
+} appaBAutorange_t;
+
+#define APPA_B_DATA_LENGTH_REQUEST_READ_INFORMATION 0
+#define APPA_B_DATA_LENGTH_RESPONSE_READ_INFORMATION 52
+#define APPA_B_DATA_LENGTH_REQUEST_READ_DISPLAY 0
+#define APPA_B_DATA_LENGTH_RESPONSE_READ_DISPLAY 12
+
+#define APPA_B_GET_FRAMELEN(argFrame) (APPA_B_DATA_LENGTH_##argFrame+4)
+
+#define APPA_B_START 0x5555
+
+typedef struct {} APPA_B_GCC_PACKED appaBFrame_EmptyRequest_t;
+
+typedef struct {} APPA_B_GCC_PACKED appaBFrame_EmptyResponse_t;
+
+typedef appaBFrame_EmptyRequest_t appaBFrame_ReadInformationRequest_t;
+
+typedef struct
+{
+    appaChar_t modelName[32]; /**< String 0x20 terminated */
+    appaChar_t serialNumber[16]; /**< String 0x20 terminated */
+    appaWord_t modelId; /*< appaModelId_t */
+    appaWord_t firmwareVersion; /*< Version */
+} APPA_B_GCC_PACKED appaBFrame_ReadInformationResponse_t;
+
+typedef appaBFrame_EmptyRequest_t appaBFrame_ReadDisplayRequest_t;
+
+typedef struct
+{
+
+    appaByte_t readingB0; /**< int24 Byte 0 */
+    appaByte_t readingB1; /**< int24 Byte 1 */
+    appaByte_t readingB2; /**< int24 Byte 2 */
+    appaByte_t dot:3; /**< @appaDot_t */
+    appaByte_t unit:5; /**< @appaUnit_t */
+    appaByte_t dataContent:7; /**< @appaDataContent_t */
+    appaByte_t overload:1; /**< @appaOverload_t */
+
+} APPA_B_GCC_PACKED appaBFrame_ReadDisplayResponse_DisplayData_t;
+
+#define APPA_B_DECODE_READING(argDisplayData) ((appaInt_t)(argDisplayData.readingB0|argDisplayData.readingB1<<8|argDisplayData.readingB2<<16 | ((argDisplayData.readingB2>>7==1)?0xff:0)<<24 ))
+
+typedef struct
+{
+    appaByte_t functionCode:7; /**< @appaFunctioncode_t */
+    appaByte_t autoTest:1; /**< @appaAutotest_t */
+    appaByte_t rangeCode:7; /**< @TODO Table 7.1 if required */
+    appaByte_t autoRange:1; /**< @appaAutorange_t */
+    appaBFrame_ReadDisplayResponse_DisplayData_t mainDisplayData;
+    appaBFrame_ReadDisplayResponse_DisplayData_t subDisplayData;
+} APPA_B_GCC_PACKED appaBFrame_ReadDisplayResponse_t;
+
+typedef union
+{
+    
+    struct
+    {
+        appaWord_t start; /**< 0x5555 */
+        appaByte_t command; /**< @appaCommand_t */
+        appaByte_t dataLength; /**< Length of Data */
+        
+        union
+        {
+
+          union
+          {
+              appaBFrame_ReadInformationResponse_t request;
+              appaBFrame_ReadInformationResponse_t response;
+          } readInformation;
+
+          union
+          {
+              appaBFrame_ReadDisplayRequest_t request;
+              appaBFrame_ReadDisplayResponse_t response;
+          } readDisplay;
+        };
+    };
+    
+    appaByte_t raw[0];    
+    
+} APPA_B_GCC_PACKED appaBFrame_t;
+
+appaByte_t appa_b_checksum(appaByte_t* argData, appaInt_t argSize)
+{
+  appaByte_t checksum = 0;
+  while(argSize-->0)
+    checksum+= argData[argSize];
+  return(checksum);
+}
+
+#ifdef __cplusplus
+}
+#endif/*def __cplusplus*/
+
+#endif/*def APPA_B__H*/
+

--- a/src/hardware/serial-dmm/api.c
+++ b/src/hardware/serial-dmm/api.c
@@ -160,6 +160,10 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 		dmm->channel_count = EEV121GW_DISPLAY_COUNT;
 		dmm->channel_formats = eev121gw_channel_formats;
 	}
+	if (dmm->packet_parse == sr_appa_b_parse) {
+		dmm->channel_count = APPA_B_DISPLAY_COUNT;
+		dmm->channel_formats = sr_appa_b_channel_formats;
+	}
 	if (dmm->packet_parse == sr_metex14_4packets_parse)
 		dmm->channel_count = 4;
 	if (dmm->packet_parse == sr_ms2115b_parse) {
@@ -342,6 +346,17 @@ static int dev_acquisition_start(const struct sr_dev_inst *sdi)
 		CONN, SERIALCOMM, PACKETSIZE, TIMEOUT, DELAY, \
 		OPEN, REQUEST, NULL, NULL, DETAILS, \
 		INIT, FREE, VALID, PARSE, NULL, NULL, NULL, NULL)
+
+/**
+ * Helper macro for the APPA B series of DMMs (allow brand names as driver names)
+ */
+#define DMM_APPA_B_ALIAS(ID, VENDOR, MODEL)	DMM(\
+		ID, appa_b,\
+     VENDOR, MODEL, "9600/8n1",\
+     APPA_B_PACKET_SIZE, 0, 0, sr_appa_b_packet_request,\
+		sr_appa_b_packet_valid, sr_appa_b_parse,\
+     NULL\
+	)
 
 SR_REGISTER_DEV_DRIVER_LIST(serial_dmm_drivers,
 	/*
@@ -843,6 +858,13 @@ SR_REGISTER_DEV_DRIVER_LIST(serial_dmm_drivers,
 		sr_vc96_packet_valid, sr_vc96_parse,
 		NULL
 	),
+	/* }}} */
+	/* APPA B (150/208/506) based meters {{{ */
+  DMM_APPA_B_ALIAS("appa-b", "APPA", "150/208/506-Series"),
+  DMM_APPA_B_ALIAS("benning-mm12", "BENNING", "MM 12"),
+  DMM_APPA_B_ALIAS("sefram-7352", "Sefram", "7352(B)"),
+  DMM_APPA_B_ALIAS("appa-506", "APPA", "506(B)"),
+  DMM_APPA_B_ALIAS("appa-208", "APPA", "208(B)"),
 	/* }}} */
 	/*
 	 * The list is sorted. Add new items in the respective chip's group.

--- a/src/libsigrok-internal.h
+++ b/src/libsigrok-internal.h
@@ -2591,6 +2591,35 @@ SR_PRIV gboolean sr_eev121gw_packet_valid(const uint8_t *buf);
 SR_PRIV int sr_eev121gw_3displays_parse(const uint8_t *buf, float *floatval,
 		struct sr_datafeed_analog *analog, void *info);
 
+/*--- dmm/appa_b.c APPA B (Model 150/208/506 so far) --------------------------------------------------------*/
+
+/**
+ * Packet size for display reading.
+ * @WARNING Change once calibration and other frames are in!
+ */
+#define APPA_B_PACKET_SIZE 17
+
+/**
+ * Number of visible displays supported by the interface (main/sub)
+ */
+#define APPA_B_DISPLAY_COUNT 2
+
+/**
+ * Information structure
+ */
+struct appa_b_info {
+  size_t ch_idx; /**< Channel ID (0 == main, 1 == sub) */
+};
+
+extern SR_PRIV const char *sr_appa_b_channel_formats[];
+
+#ifdef HAVE_SERIAL_COMM
+SR_PRIV int sr_appa_b_packet_request(struct sr_serial_dev_inst *serial);
+#endif
+SR_PRIV gboolean sr_appa_b_packet_valid(const uint8_t *buf);
+SR_PRIV int sr_appa_b_parse(const uint8_t *buf, float *floatval,
+		struct sr_datafeed_analog *analog, void *info);
+
 /*--- scale/kern.c ----------------------------------------------------------*/
 
 struct kern_info {


### PR DESCRIPTION
APPA B Interface (Models 150/208/506) and device driver

Brands include:

  - APPA 155B
  - APPA 156B
  - APPA 157B
  - APPA 158B
  - APPA 506(B)
  - APPA 208(B)
  - Benning MM 12
  - Benning CM 12
  - Sefram 7352(B)

Bluetooth-only models will require the BTLE-connector to be finished first
to actually work.

Some open todos, but besides the obviously not yet included calibration, logging and btle it is tested so far.