### PR TITLE
new SR_CONF_CHANNEL_GROUP meta package

### DIFF
--- a/include/libsigrok/libsigrok.h
+++ b/include/libsigrok/libsigrok.h
@@ -1113,6 +1113,9 @@ enum sr_configkey {
 	/** Number of powerline cycles for ADC integration time. */
 	SR_CONF_ADC_POWERLINE_CYCLES,
 
+	/** Specify which channel group following meta packages should be assigned to. */
+	SR_CONF_CHANNEL_GROUP,
+
 	/* Update sr_key_info_config[] (hwdriver.c) upon changes! */
 
 	/*--- Acquisition modes, sample limiting ----------------------------*/

--- a/src/hardware/scpi-pps/api.c
+++ b/src/hardware/scpi-pps/api.c
@@ -101,6 +101,9 @@ static struct sr_dev_inst *probe_device(struct sr_scpi_dev_inst *scpi,
 	devc = g_malloc0(sizeof(struct dev_context));
 	devc->device = device;
 	sr_sw_limits_init(&devc->limits);
+	devc->cur_meta_data_source = device->num_channels; /* seting this deliberately to an invalid index */
+	if (device->dialect == SCPI_DIALECT_HMP)
+		devc->hw_channel_state = g_malloc0(device->num_channels * sizeof(struct pps_hw_channel_state));
 	sdi->priv = devc;
 
 	if (device->num_channels) {
@@ -315,6 +318,8 @@ static void clear_helper(struct dev_context *devc)
 {
 	g_free(devc->channels);
 	g_free(devc->channel_groups);
+	if (devc->hw_channel_state)
+		g_free(devc->hw_channel_state);
 }
 
 static int dev_clear(const struct sr_dev_driver *di)

--- a/src/hardware/scpi-pps/protocol.h
+++ b/src/hardware/scpi-pps/protocol.h
@@ -139,6 +139,13 @@ struct pps_channel {
 	int digits;
 };
 
+struct pps_hw_channel_state {
+	gboolean ovp;
+	gboolean ocp;
+	gboolean otp;
+	int regulation;
+};
+
 struct pps_channel_instance {
 	enum sr_mq mq;
 	int command;
@@ -164,6 +171,9 @@ struct dev_context {
 
 	struct sr_channel *cur_acquisition_channel;
 	struct sr_sw_limits limits;
+
+	unsigned int cur_meta_data_source;
+	struct pps_hw_channel_state *hw_channel_state;
 };
 
 SR_PRIV extern unsigned int num_pps_profiles;

--- a/src/hwdriver.c
+++ b/src/hwdriver.c
@@ -227,6 +227,8 @@ static struct sr_key_info sr_key_info_config[] = {
 		"Probe factor", NULL},
 	{SR_CONF_ADC_POWERLINE_CYCLES, SR_T_FLOAT, "nplc",
 		"Number of ADC powerline cycles", NULL},
+	{SR_CONF_CHANNEL_GROUP, SR_T_STRING, "channel_group",
+		"Which channel group to assign following meta packages to", NULL},
 
 	/* Acquisition modes, sample limiting */
 	{SR_CONF_LIMIT_MSEC, SR_T_UINT64, "limit_time",


### PR DESCRIPTION
many meta packages can not be assigned to a specific channel(-group). but there
are many devices like multi-channel PPS that report state information per
channel.
so instead of extending those existing meta packages with a new field to
specify the channel, i propose to add this new meta package that will only
transport the "current" channel-group-name.
all following meta packages should then be interpreted to only describe
the specified channel group.
i demonstrate this here with the HMP4040 SCPI-PPS which reports these meta
packages per channel-group:

- SR_CONF_OVER_VOLTAGE_PROTECTION_ACTIVE
- SR_CONF_OVER_TEMPERATURE_PROTECTION_ACTIVE
- SR_CONF_REGULATION
- SR_CONF_ENABLED

all those packages are only sent on change event.

i also did send a PR to demonstrate how SmuView could use this additional
information to correctly display per-channel-state info.


originally this was part of PR https://github.com/sigrokproject/libsigrok/pull/57