### PR TITLE
Parse ASIX SIGMA/OMEGA serial number as unsigned long

### DIFF
--- a/src/hardware/asix-sigma/api.c
+++ b/src/hardware/asix-sigma/api.c
@@ -120,7 +120,7 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 	char conn_id[20];
 	char serno_txt[16];
 	char *end;
-	long serno_num, serno_pre;
+	uint32_t serno_num, serno_pre;
 	enum asix_device_type dev_type;
 	const char *dev_text;
 	struct sr_dev_inst *sdi;
@@ -192,7 +192,7 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 		 * All ASIX logic analyzers have a serial number, which
 		 * reads as a hex number, and tells the device type.
 		 */
-		ret = sr_atol_base(serno_txt, &serno_num, &end, 16);
+		ret = sr_atoul_base(serno_txt, &serno_num, &end, 16);
 		if (ret != SR_OK || !end || *end) {
 			sr_warn("Cannot interpret serial number %s.", serno_txt);
 			continue;

--- a/src/libsigrok-internal.h
+++ b/src/libsigrok-internal.h
@@ -1809,6 +1809,7 @@ SR_PRIV void *sr_resource_load(struct sr_context *ctx, int type,
 
 SR_PRIV int sr_atol(const char *str, long *ret);
 SR_PRIV int sr_atol_base(const char *str, long *ret, char **end, int base);
+SR_PRIV int sr_atoul_base(const char *str, unsigned long *ret, char **end, int base);
 SR_PRIV int sr_atoi(const char *str, int *ret);
 SR_PRIV int sr_atod(const char *str, double *ret);
 SR_PRIV int sr_atof(const char *str, float *ret);

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -146,6 +146,60 @@ SR_PRIV int sr_atol_base(const char *str, long *ret, char **end, int base)
 }
 
 /**
+ * Convert a text to a number including support for non-decimal bases.
+ * Also optionally returns the position after the number, where callers
+ * can either error out, or support application specific suffixes.
+ *
+ * @param[in] str The input text to convert.
+ * @param[out] ret The conversion result.
+ * @param[out] end The position after the number.
+ * @param[in] base The number format's base, can be 0.
+ *
+ * @retval SR_OK Conversion successful.
+ * @retval SR_ERR Conversion failed.
+ *
+ * @private
+ *
+ * This routine is more general than @ref sr_atol(), which strictly
+ * expects the input text to contain just a decimal number, and nothing
+ * else in addition. The @ref sr_atoul_base() routine accepts trailing
+ * text after the number, and supports non-decimal numbers (bin, hex),
+ * including automatic detection from prefix text.
+ */
+SR_PRIV int sr_atoul_base(const char *str, unsigned long *ret, char **end, int base)
+{
+	unsigned long num;
+	char *endptr;
+
+	/* Add "0b" prefix support which strtol(3) may be missing. */
+	while (str && isspace(*str))
+		str++;
+	if (!base && strncmp(str, "0b", strlen("0b")) == 0) {
+		str += strlen("0b");
+		base = 2;
+	}
+
+	/* Run the number conversion. Quick bail out if that fails. */
+	errno = 0;
+	endptr = NULL;
+	num = strtoul(str, &endptr, base);
+	if (!endptr || errno) {
+		if (!errno)
+			errno = EINVAL;
+		return SR_ERR;
+	}
+	*ret = num;
+
+	/* Advance to optional non-space trailing suffix. */
+	while (endptr && isspace(*endptr))
+		endptr++;
+	if (end)
+		*end = endptr;
+
+	return SR_OK;
+}
+
+/**
  * Convert a string representation of a numeric value (base 10) to an integer. The
  * conversion is strict and will fail if the complete string does not represent
  * a valid integer. The function sets errno according to the details of the


### PR DESCRIPTION
Allows for support on a 32bit arch. Current parsing as (unsigned) long overflows, rendering the LA undetectable.

Tested with an ASIX SIGMA2 on: 

    $ uname -a
    Linux raspberrypi 5.4.72-v7+ #1356 SMP Thu Oct 22 13:56:54 BST 2020 armv7l GNU/Linux