### PR TITLE
ols: Fix bug, extend external clock support, prepare for advanced triggers

### DIFF
--- a/src/hardware/openbench-logic-sniffer/api.c
+++ b/src/hardware/openbench-logic-sniffer/api.c
@@ -36,7 +36,7 @@ static const uint32_t devopts[] = {
 	SR_CONF_SAMPLERATE | SR_CONF_GET | SR_CONF_SET | SR_CONF_LIST,
 	SR_CONF_TRIGGER_MATCH | SR_CONF_LIST,
 	SR_CONF_CAPTURE_RATIO | SR_CONF_GET | SR_CONF_SET,
-	SR_CONF_EXTERNAL_CLOCK | SR_CONF_SET,
+	SR_CONF_EXTERNAL_CLOCK | SR_CONF_GET | SR_CONF_SET,
 	SR_CONF_CLOCK_EDGE | SR_CONF_GET | SR_CONF_SET | SR_CONF_LIST,
 	SR_CONF_PATTERN_MODE | SR_CONF_GET | SR_CONF_SET | SR_CONF_LIST,
 	SR_CONF_SWAP | SR_CONF_SET,
@@ -228,6 +228,10 @@ static int config_get(uint32_t key, GVariant **data,
 		break;
 	case SR_CONF_RLE:
 		*data = g_variant_new_boolean(devc->capture_flags & CAPTURE_FLAG_RLE ? TRUE : FALSE);
+		break;
+	case SR_CONF_EXTERNAL_CLOCK:
+		*data = g_variant_new_boolean(
+			devc->capture_flags & CAPTURE_FLAG_CLOCK_EXTERNAL ? TRUE : FALSE);
 		break;
 	case SR_CONF_CLOCK_EDGE:
 		*data = g_variant_new_string(external_clock_edges[

--- a/src/hardware/openbench-logic-sniffer/api.c
+++ b/src/hardware/openbench-logic-sniffer/api.c
@@ -497,10 +497,12 @@ static int dev_acquisition_start(const struct sr_dev_inst *sdi)
 			devc->capture_flags & CAPTURE_FLAG_RLE ? "on" : "off",
 			devc->capture_flags & CAPTURE_FLAG_NOISE_FILTER ? "on": "off",
 			devc->capture_flags & CAPTURE_FLAG_DEMUX ? "on" : "off");
+
 	/*
 	 * Enable/disable OLS channel groups in the flag register according
 	 * to the channel mask. 1 means "disable channel".
 	 */
+	devc->capture_flags &= ~0x3c;
 	devc->capture_flags |= ~(ols_changrp_mask << 2) & 0x3c;
 
 	/* RLE mode is always zero, for now. */

--- a/src/hardware/openbench-logic-sniffer/protocol.c
+++ b/src/hardware/openbench-logic-sniffer/protocol.c
@@ -463,7 +463,8 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 					}
 				}
 				memcpy(devc->sample, devc->tmp_sample, 4);
-				sr_spew("Expanded sample: 0x%.8x.", sample);
+				sr_spew("Expanded sample: 0x%.2hhx%.2hhx%.2hhx%.2hhx ",
+					devc->sample[3], devc->sample[2], devc->sample[1], devc->sample[0]);
 			}
 
 			/*

--- a/src/hardware/openbench-logic-sniffer/protocol.c
+++ b/src/hardware/openbench-logic-sniffer/protocol.c
@@ -20,6 +20,13 @@
 #include <config.h>
 #include "protocol.h"
 
+
+struct ols_basic_trigger_desc {
+	uint32_t trigger_mask[NUM_BASIC_TRIGGER_STAGES];
+	uint32_t trigger_value[NUM_BASIC_TRIGGER_STAGES];
+	int num_stages;
+};
+
 SR_PRIV int send_shortcommand(struct sr_serial_dev_inst *serial,
 		uint8_t command)
 {
@@ -70,46 +77,39 @@ SR_PRIV int ols_send_reset(struct sr_serial_dev_inst *serial)
 }
 
 /* Configures the channel mask based on which channels are enabled. */
-SR_PRIV void ols_channel_mask(const struct sr_dev_inst *sdi)
+SR_PRIV uint32_t ols_channel_mask(const struct sr_dev_inst *sdi)
 {
-	struct dev_context *devc;
-	struct sr_channel *channel;
-	const GSList *l;
-
-	devc = sdi->priv;
-
-	devc->channel_mask = 0;
-	for (l = sdi->channels; l; l = l->next) {
-		channel = l->data;
+	uint32_t channel_mask = 0;
+	for (const GSList *l = sdi->channels; l; l = l->next) {
+		struct sr_channel *channel = l->data;
 		if (channel->enabled)
-			devc->channel_mask |= 1 << channel->index;
+			channel_mask |= 1 << channel->index;
 	}
+
+	return channel_mask;
 }
 
-SR_PRIV int ols_convert_trigger(const struct sr_dev_inst *sdi)
+static int convert_trigger(const struct sr_dev_inst *sdi, struct ols_basic_trigger_desc *ols_trigger)
 {
-	struct dev_context *devc;
 	struct sr_trigger *trigger;
 	struct sr_trigger_stage *stage;
 	struct sr_trigger_match *match;
 	const GSList *l, *m;
 	int i;
 
-	devc = sdi->priv;
-
-	devc->num_stages = 0;
-	for (i = 0; i < NUM_TRIGGER_STAGES; i++) {
-		devc->trigger_mask[i] = 0;
-		devc->trigger_value[i] = 0;
+	ols_trigger->num_stages = 0;
+	for (i = 0; i < NUM_BASIC_TRIGGER_STAGES; i++) {
+		ols_trigger->trigger_mask[i] = 0;
+		ols_trigger->trigger_value[i] = 0;
 	}
 
 	if (!(trigger = sr_session_trigger_get(sdi->session)))
 		return SR_OK;
 
-	devc->num_stages = g_slist_length(trigger->stages);
-	if (devc->num_stages > NUM_TRIGGER_STAGES) {
+	ols_trigger->num_stages = g_slist_length(trigger->stages);
+	if (ols_trigger->num_stages > NUM_BASIC_TRIGGER_STAGES) {
 		sr_err("This device only supports %d trigger stages.",
-				NUM_TRIGGER_STAGES);
+				NUM_BASIC_TRIGGER_STAGES);
 		return SR_ERR;
 	}
 
@@ -120,9 +120,9 @@ SR_PRIV int ols_convert_trigger(const struct sr_dev_inst *sdi)
 			if (!match->channel->enabled)
 				/* Ignore disabled channels with a trigger. */
 				continue;
-			devc->trigger_mask[stage->stage] |= 1 << match->channel->index;
+			ols_trigger->trigger_mask[stage->stage] |= 1 << match->channel->index;
 			if (match->match == SR_TRIGGER_ONE)
-				devc->trigger_value[stage->stage] |= 1 << match->channel->index;
+				ols_trigger->trigger_value[stage->stage] |= 1 << match->channel->index;
 		}
 	}
 
@@ -361,7 +361,7 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 	struct sr_datafeed_packet packet;
 	struct sr_datafeed_logic logic;
 	uint32_t sample;
-	int num_ols_changrp, offset, j;
+	int num_changroups, offset, j;
 	unsigned int i;
 	unsigned char byte;
 
@@ -386,10 +386,10 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 		memset(devc->raw_sample_buf, 0x82, devc->limit_samples * 4);
 	}
 
-	num_ols_changrp = 0;
+	num_changroups = 0;
 	for (i = 0x20; i > 0x02; i >>= 1) {
 		if ((devc->capture_flags & i) == 0) {
-			num_ols_changrp++;
+			num_changroups++;
 		}
 	}
 
@@ -404,7 +404,7 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 
 		devc->sample[devc->num_bytes++] = byte;
 		sr_spew("Received byte 0x%.2x.", byte);
-		if (devc->num_bytes == num_ols_changrp) {
+		if (devc->num_bytes == num_changroups) {
 			devc->cnt_samples++;
 			devc->cnt_samples_rle++;
 			/*
@@ -437,7 +437,7 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 				devc->num_samples = devc->limit_samples;
 			}
 
-			if (num_ols_changrp < 4) {
+			if (num_changroups < 4) {
 				/*
 				 * Some channel groups may have been turned
 				 * off, to speed up transfer between the
@@ -528,4 +528,156 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 	}
 
 	return TRUE;
+}
+
+static int ols_set_basic_trigger_stage(const struct ols_basic_trigger_desc *trigger_desc, struct sr_serial_dev_inst *serial, int stage)
+{
+	uint8_t cmd, arg[4];
+
+	cmd = CMD_SET_BASIC_TRIGGER_MASK0 + stage * 4;
+	arg[0] = trigger_desc->trigger_mask[stage] & 0xff;
+	arg[1] = (trigger_desc->trigger_mask[stage] >> 8) & 0xff;
+	arg[2] = (trigger_desc->trigger_mask[stage] >> 16) & 0xff;
+	arg[3] = (trigger_desc->trigger_mask[stage] >> 24) & 0xff;
+	if (send_longcommand(serial, cmd, arg) != SR_OK)
+		return SR_ERR;
+
+	cmd = CMD_SET_BASIC_TRIGGER_VALUE0 + stage * 4;
+	arg[0] = trigger_desc->trigger_value[stage] & 0xff;
+	arg[1] = (trigger_desc->trigger_value[stage] >> 8) & 0xff;
+	arg[2] = (trigger_desc->trigger_value[stage] >> 16) & 0xff;
+	arg[3] = (trigger_desc->trigger_value[stage] >> 24) & 0xff;
+	if (send_longcommand(serial, cmd, arg) != SR_OK)
+		return SR_ERR;
+
+	cmd = CMD_SET_BASIC_TRIGGER_CONFIG0 + stage * 4;
+	arg[0] = arg[1] = arg[3] = 0x00;
+	arg[2] = stage;
+	if (stage == trigger_desc->num_stages)
+		/* Last stage, fire when this one matches. */
+		arg[3] |= TRIGGER_START;
+	if (send_longcommand(serial, cmd, arg) != SR_OK)
+		return SR_ERR;
+
+	return SR_OK;
+}
+
+SR_PRIV int ols_prepare_acquisition(const struct sr_dev_inst *sdi) {
+	int ret;
+	uint8_t arg[4];
+
+	struct dev_context *devc = sdi->priv;
+	struct sr_serial_dev_inst *serial = sdi->conn;
+
+	int num_changroups = 0;
+	uint8_t changroup_mask = 0;
+	uint32_t channel_mask = ols_channel_mask(sdi);
+	for (unsigned int i = 0; i < 4; i++) {
+		if (channel_mask & (0xff << (i * 8))) {
+			changroup_mask |= (1 << i);
+			num_changroups++;
+		}
+	}
+
+	/*
+	 * Limit readcount to prevent reading past the end of the hardware
+	 * buffer. Rather read too many samples than too few.
+	 */
+	uint32_t samplecount = MIN(devc->max_samples / num_changroups, devc->limit_samples);
+	uint32_t readcount = (samplecount + 3) / 4;
+	uint32_t delaycount;
+
+	/* Basic triggers. */
+	struct ols_basic_trigger_desc basic_trigger_desc;
+	if (convert_trigger(sdi, &basic_trigger_desc) != SR_OK) {
+		sr_err("Failed to configure channels.");
+		return SR_ERR;
+	}
+	if (basic_trigger_desc.num_stages > 0) {
+		/*
+		 * According to http://mygizmos.org/ols/Logic-Sniffer-FPGA-Spec.pdf
+		 * reset command must be send prior each arm command
+		 */
+		sr_dbg("Send reset command before trigger configure");
+		if (ols_send_reset(serial) != SR_OK)
+			return SR_ERR;
+
+		delaycount = readcount * (1 - devc->capture_ratio / 100.0);
+		devc->trigger_at_smpl = (readcount - delaycount) * 4 - basic_trigger_desc.num_stages;
+		for (int i = 0; i <= basic_trigger_desc.num_stages; i++) {
+			sr_dbg("Setting OLS stage %d trigger.", i);
+			if ((ret = ols_set_basic_trigger_stage(&basic_trigger_desc, serial, i)) != SR_OK)
+				return ret;
+		}
+	} else {
+		/* No triggers configured, force trigger on first stage. */
+		sr_dbg("Forcing trigger at stage 0.");
+		if ((ret = ols_set_basic_trigger_stage(&basic_trigger_desc, serial, 0)) != SR_OK)
+			return ret;
+		delaycount = readcount;
+	}
+
+	/* Samplerate. */
+	sr_dbg("Setting samplerate to %" PRIu64 "Hz (divider %u)",
+			devc->cur_samplerate, devc->cur_samplerate_divider);
+	arg[0] = devc->cur_samplerate_divider & 0xff;
+	arg[1] = (devc->cur_samplerate_divider & 0xff00) >> 8;
+	arg[2] = (devc->cur_samplerate_divider & 0xff0000) >> 16;
+	arg[3] = 0x00;
+	if (send_longcommand(serial, CMD_SET_DIVIDER, arg) != SR_OK)
+		return SR_ERR;
+
+	/* Send sample limit and pre/post-trigger capture ratio. */
+	sr_dbg("Setting sample limit %d, trigger point at %d",
+			(readcount - 1) * 4, (delaycount - 1) * 4);
+
+	if (devc->max_samples > 256 * 1024) {
+		arg[0] = ((readcount - 1) & 0xff);
+		arg[1] = ((readcount - 1) & 0xff00) >> 8;
+		arg[2] = ((readcount - 1) & 0xff0000) >> 16;
+		arg[3] = ((readcount - 1) & 0xff000000) >> 24;
+		if (send_longcommand(serial, CMD_CAPTURE_READCOUNT, arg) != SR_OK)
+			return SR_ERR;
+		arg[0] = ((delaycount - 1) & 0xff);
+		arg[1] = ((delaycount - 1) & 0xff00) >> 8;
+		arg[2] = ((delaycount - 1) & 0xff0000) >> 16;
+		arg[3] = ((delaycount - 1) & 0xff000000) >> 24;
+		if (send_longcommand(serial, CMD_CAPTURE_DELAYCOUNT, arg) != SR_OK)
+			return SR_ERR;
+	} else {
+		arg[0] = ((readcount - 1) & 0xff);
+		arg[1] = ((readcount - 1) & 0xff00) >> 8;
+		arg[2] = ((delaycount - 1) & 0xff);
+		arg[3] = ((delaycount - 1) & 0xff00) >> 8;
+		if (send_longcommand(serial, CMD_CAPTURE_SIZE, arg) != SR_OK)
+			return SR_ERR;
+	}
+
+	/* Flag register. */
+	sr_dbg("Setting intpat %s, extpat %s, RLE %s, noise_filter %s, demux %s, %s clock%s",
+			devc->capture_flags & CAPTURE_FLAG_INTERNAL_TEST_MODE ? "on": "off",
+			devc->capture_flags & CAPTURE_FLAG_EXTERNAL_TEST_MODE ? "on": "off",
+			devc->capture_flags & CAPTURE_FLAG_RLE ? "on" : "off",
+			devc->capture_flags & CAPTURE_FLAG_NOISE_FILTER ? "on": "off",
+			devc->capture_flags & CAPTURE_FLAG_DEMUX ? "on" : "off",
+			devc->capture_flags & CAPTURE_FLAG_CLOCK_EXTERNAL ? "external" : "internal",
+			devc->capture_flags & CAPTURE_FLAG_CLOCK_EXTERNAL ? (devc->capture_flags & CAPTURE_FLAG_INVERT_EXT_CLOCK
+				? " on falling edge" : "on rising edge") : "");
+
+	/*
+	 * Enable/disable OLS channel groups in the flag register according
+	 * to the channel mask. 1 means "disable channel".
+	 */
+	devc->capture_flags &= ~0x3c;
+	devc->capture_flags |= ~(changroup_mask << 2) & 0x3c;
+
+	/* RLE mode is always zero, for now. */
+
+	arg[0] = devc->capture_flags & 0xff;
+	arg[1] = devc->capture_flags >> 8;
+	arg[2] = arg[3] = 0x00;
+	if (send_longcommand(serial, CMD_SET_FLAGS, arg) != SR_OK)
+		return SR_ERR;
+
+	return SR_OK;
 }

--- a/src/hardware/openbench-logic-sniffer/protocol.c
+++ b/src/hardware/openbench-logic-sniffer/protocol.c
@@ -151,7 +151,7 @@ static void ols_channel_new(struct sr_dev_inst *sdi, int num_chan)
 	devc->max_channels = num_chan;
 }
 
-static void metadata_quirks(struct sr_dev_inst *sdi)
+static void ols_metadata_quirks(struct sr_dev_inst *sdi)
 {
 	struct dev_context *devc;
 	gboolean is_shrimp;
@@ -302,7 +302,7 @@ SR_PRIV struct sr_dev_inst *get_metadata(struct sr_serial_dev_inst *serial)
 	g_string_free(version, FALSE);
 
 	/* Optionally amend received metadata, model specific quirks. */
-	metadata_quirks(sdi);
+	ols_metadata_quirks(sdi);
 
 	return sdi;
 }

--- a/src/hardware/openbench-logic-sniffer/protocol.h
+++ b/src/hardware/openbench-logic-sniffer/protocol.h
@@ -28,7 +28,7 @@
 
 #define LOG_PREFIX "openbench-logic-sniffer"
 
-#define NUM_TRIGGER_STAGES         4
+#define NUM_BASIC_TRIGGER_STAGES   4
 #define CLOCK_RATE                 SR_MHZ(100)
 #define MIN_NUM_SAMPLES            4
 #define DEFAULT_SAMPLERATE         SR_KHZ(200)
@@ -112,10 +112,6 @@ struct dev_context {
 	uint64_t limit_samples;
 	uint64_t capture_ratio;
 	int trigger_at_smpl;
-	uint32_t channel_mask;
-	uint32_t trigger_mask[NUM_TRIGGER_STAGES];
-	uint32_t trigger_value[NUM_TRIGGER_STAGES];
-	int num_stages;
 	uint16_t capture_flags;
 
 	unsigned int num_transfers;
@@ -138,8 +134,8 @@ SR_PRIV int send_shortcommand(struct sr_serial_dev_inst *serial,
 SR_PRIV int send_longcommand(struct sr_serial_dev_inst *serial,
 		uint8_t command, uint8_t *data);
 SR_PRIV int ols_send_reset(struct sr_serial_dev_inst *serial);
-SR_PRIV void ols_channel_mask(const struct sr_dev_inst *sdi);
-SR_PRIV int ols_convert_trigger(const struct sr_dev_inst *sdi);
+SR_PRIV int ols_prepare_acquisition(const struct sr_dev_inst *sdi);
+SR_PRIV uint32_t ols_channel_mask(const struct sr_dev_inst *sdi);
 SR_PRIV struct dev_context *ols_dev_new(void);
 SR_PRIV struct sr_dev_inst *get_metadata(struct sr_serial_dev_inst *serial);
 SR_PRIV int ols_set_samplerate(const struct sr_dev_inst *sdi,


### PR DESCRIPTION
This is the next chunk of #51, which fixes a bug, extends the support for external clocks and shuffles code around to aid introducing advanced triggers.