### PR TITLE
hantek-dso: fix 100MS/s

### DIFF
--- a/src/hardware/hantek-dso/protocol.c
+++ b/src/hardware/hantek-dso/protocol.c
@@ -326,7 +326,8 @@ static int dso2250_set_trigger_samplerate(const struct sr_dev_inst *sdi)
 	}
 
 	tmp = base / devc->samplerate;
-	if (tmp) {
+	/* Downsample only if really necessary */
+	if (tmp > 1) {
 		/* Downsampling on */
 		cmdstring[2] |= 2;
 		/* Downsampler = 1comp((Base / Samplerate) - 2)


### PR DESCRIPTION
Do not downsample at 100MS/s, because this is the base frequency.
The device actually sampled at (100.0/0x1000)MS/s when 100MS/s was set.
Tested to be working on an Hantek DSO-2250 USB.