### PR TITLE
fx2lafw: Make SR_CONF_LIMIT_SAMPLES above 2^32 working

### DIFF
--- a/src/hardware/fx2lafw/protocol.h
+++ b/src/hardware/fx2lafw/protocol.h
@@ -112,7 +112,7 @@ struct dev_context {
 	struct soft_trigger_logic *stl;
 
 	uint64_t num_frames;
-	unsigned int sent_samples;
+	uint64_t sent_samples;
 	int submitted_transfers;
 	int empty_transfer_count;
 


### PR DESCRIPTION
Sampling with "sigrok-cli -d fx2lafw -o capture.sr --config samplerate=8M --time 600000" does not stop after 10 minutes
8M*600s is 4,800,000,000 samples, which needs more than 32-bit in devc->sent_samples for counting

