### PR TITLE
siglent-sds: original driver fixes, USBTMC support

### DIFF
--- a/src/hardware/siglent-sds/api.c
+++ b/src/hardware/siglent-sds/api.c
@@ -294,6 +294,12 @@ static struct sr_dev_inst *probe_device(struct sr_scpi_dev_inst *scpi)
 	sdi->serial_num = g_strdup(hw_info->serial_number);
 	devc = g_malloc0(sizeof(struct dev_context));
 	devc->limit_frames = 1;
+
+	// Set some pointers to null so they can be safely g_free'd later
+	for (i = 0; i < MAX_ANALOG_CHANNELS; i++) {
+		devc->coupling[i] = NULL;
+	}
+	devc->trigger_slope = NULL;
 	devc->model = model;
 
 	sr_scpi_hw_info_free(hw_info);

--- a/src/hardware/siglent-sds/api.c
+++ b/src/hardware/siglent-sds/api.c
@@ -155,7 +155,7 @@ static const uint64_t averages[] = {
 
 /* Do not change the order of entries. */
 static const char *data_sources[] = {
-	"Display",
+	"Screen",
 	"History",
 };
 
@@ -677,7 +677,7 @@ static int config_set(uint32_t key, GVariant *data,
 		return ret;
 	case SR_CONF_DATA_SOURCE:
 		tmp_str = g_variant_get_string(data, NULL);
-		if (!strcmp(tmp_str, "Display"))
+		if (!strcmp(tmp_str, "Screen"))
 			devc->data_source = DATA_SOURCE_SCREEN;
 		else if (devc->model->series->protocol >= SPO_MODEL
 			&& !strcmp(tmp_str, "History"))


### PR DESCRIPTION
NOTE: Needs testing by someone who owns an older siglent scope.

Fixes a few memory leaks, one inconsistency with DATA_SOURCE and adds USBTMC support.

Addresses bugs

* https://sigrok.org/bugzilla/show_bug.cgi?id=1628 (usbtmc/eseries)
* https://sigrok.org/bugzilla/show_bug.cgi?id=1130 (usbtmc)


I've split off the eseries changes into a separate pull request #118  as that code should not require testing by someone with an older scope model. 