### PR TITLE
python bindings: Support passing in rational voltages for config_set

### DIFF
--- a/bindings/python/sigrok/core/classes.i
+++ b/bindings/python/sigrok/core/classes.i
@@ -340,8 +340,15 @@ Glib::VariantBase python_to_variant_by_key(PyObject *input, const sigrok::Config
         return Glib::Variant<double>::create(PyFloat_AsDouble(input));
     else if (type == SR_T_INT32 && PyInt_Check(input))
         return Glib::Variant<gint32>::create(PyInt_AsLong(input));
-    else
-        throw sigrok::Error(SR_ERR_ARG);
+    else if (type == SR_T_RATIONAL_VOLT && PyTuple_Check(input) && PyTuple_Size(input) == 2) {
+        PyObject * numObj = PyTuple_GetItem(input,0);
+        PyObject * denomObj = PyTuple_GetItem(input,1);
+        if ((PyInt_Check(numObj) || PyLong_Check(numObj) ) && (PyInt_Check(denomObj) || PyLong_Check(denomObj)) ) {
+          std::tuple<guint64, guint64> tpl = {PyInt_AsLong(numObj), PyInt_AsLong(denomObj)};
+          return Glib::Variant< std::tuple<guint64,guint64> >::Variant::create( tpl );
+        }
+    }
+    throw sigrok::Error(SR_ERR_ARG);
 }
 
 /* Convert from a Python type to Glib::Variant, according to Option data type. */


### PR DESCRIPTION
This was needed to allow python to adjust SR_CONF_VDIV