### PR TITLE
Add compatibility for glib>=2.62 (replace GTimeVal by GDateTime)

### DIFF
--- a/bindings/cxx/classes.cpp
+++ b/bindings/cxx/classes.cpp
@@ -287,12 +287,12 @@ shared_ptr<UserDevice> Context::create_user_device(
 		default_delete<UserDevice>{}};
 }
 
-shared_ptr<Packet> Context::create_header_packet(Glib::TimeVal start_time)
+shared_ptr<Packet> Context::create_header_packet(Glib::DateTime start_time)
 {
 	auto header = g_new(struct sr_datafeed_header, 1);
 	header->feed_version = 1;
-	header->starttime.tv_sec = start_time.tv_sec;
-	header->starttime.tv_usec = start_time.tv_usec;
+	header->starttime.tv_sec = start_time.get_second();
+	header->starttime.tv_usec = start_time.get_microsecond();
 	auto packet = g_new(struct sr_datafeed_packet, 1);
 	packet->type = SR_DF_HEADER;
 	packet->payload = header;
@@ -1154,11 +1154,11 @@ int Header::feed_version() const
 	return _structure->feed_version;
 }
 
-Glib::TimeVal Header::start_time() const
+Glib::DateTime Header::start_time() const
 {
-	return Glib::TimeVal(
-		_structure->starttime.tv_sec,
-		_structure->starttime.tv_usec);
+	Glib::DateTime dt = Glib::DateTime();
+	dt.add_seconds(_structure->starttime.tv_sec + (_structure->starttime.tv_usec / 1000 / 1000));
+	return dt;
 }
 
 Meta::Meta(const struct sr_datafeed_meta *structure) :

--- a/bindings/cxx/include/libsigrokcxx/libsigrokcxx.hpp
+++ b/bindings/cxx/include/libsigrokcxx/libsigrokcxx.hpp
@@ -274,7 +274,7 @@ public:
 	std::shared_ptr<UserDevice> create_user_device(
 		std::string vendor, std::string model, std::string version);
 	/** Create a header packet. */
-	std::shared_ptr<Packet> create_header_packet(Glib::TimeVal start_time);
+	std::shared_ptr<Packet> create_header_packet(Glib::DateTime start_time);
 	/** Create a meta packet. */
 	std::shared_ptr<Packet> create_meta_packet(
 		std::map<const ConfigKey *, Glib::VariantBase> config);
@@ -711,7 +711,7 @@ public:
 	/* Feed version number. */
 	int feed_version() const;
 	/* Start time of this session. */
-	Glib::TimeVal start_time() const;
+	Glib::DateTime start_time() const;
 private:
 	explicit Header(const struct sr_datafeed_header *structure);
 	~Header();

--- a/configure.ac
+++ b/configure.ac
@@ -71,6 +71,7 @@ SR_PKG_VERSION_SET([SR_PACKAGE_VERSION], [AC_PACKAGE_VERSION])
 SR_LIB_VERSION_SET([SR_LIB_VERSION], [4:0:0])
 
 AM_CONDITIONAL([WIN32], [test -z "${host_os##mingw*}" || test -z "${host_os##cygwin*}"])
+AM_CONDITIONAL([MACOS], [test -z "${host_os##darwin*}"])
 
 #############################
 ##  Optional dependencies  ##
@@ -371,7 +372,9 @@ AS_IF([test "x$HAVE_CXX11" != x1],
 	[SR_APPEND([sr_cxx_missing], [', '], ['C++11'])])
 
 # The C++ bindings need glibmm.
-SR_PKG_CHECK([glibmm], [SR_PKGLIBS_CXX], [glibmm-2.4 >= 2.32.0])
+AM_COND_IF([MACOS],
+	[SR_PKG_CHECK([glibmm], [SR_PKGLIBS_CXX], [glibmm-2.68 >= 2.32.0])],
+	[SR_PKG_CHECK([glibmm], [SR_PKGLIBS_CXX], [glibmm-2.4 >= 2.32.0])])
 AS_IF([test "x$sr_have_glibmm" != xyes],
 	[SR_APPEND([sr_cxx_missing], [', '], [glibmm])])
 


### PR DESCRIPTION
Hi again,

while working on https://github.com/sigrokproject/sigrok-meter/pull/1, when building on macOS Catalina with glib installed through Homebrew, there is already glib 2.66.7.

However, `GTimeVal` has been deprecated since glib 2.62 and should be replaced by `GDateTime` [1], see also [2].

> `GTimeVal` has been deprecated since version 2.62 and should not be used in newly-written code. Use `GDateTime` or `guint64` instead.

So, this is just a humble attempt to make things work again on this end. As I told you in #122, I am not deeply involved into C/C++, but this update makes things work for us so you might want to build upon it in one of the future iterations.

With kind regards,
Andreas.

[1] https://developer.gnome.org/glib/stable/glib-Date-and-Time-Functions.html#GTimeVal
[2] https://tecnocode.co.uk/2019/08/24/gtimeval-deprecation-in-glib-2-61-2/