### PR TITLE
serial-dmm: Add PeakTech 2025 meter support.

### DIFF
--- a/src/hardware/serial-dmm/api.c
+++ b/src/hardware/serial-dmm/api.c
@@ -569,6 +569,12 @@ SR_REGISTER_DEV_DRIVER_LIST(serial_dmm_drivers,
 		sr_fs9922_packet_valid, sr_fs9922_parse, NULL
 	),
 	DMM(
+		"peaktech-2025", fs9922,
+		"PeakTech", "2025", "2400/8n1/rts=0/dtr=1",
+		FS9922_PACKET_SIZE, 0, 0, NULL,
+		sr_fs9922_packet_valid, sr_fs9922_parse, NULL
+	),
+	DMM(
 		"sparkfun-70c", fs9922,
 		"SparkFun", "70C", "2400/8n1/rts=0/dtr=1",
 		FS9922_PACKET_SIZE, 0, 0, NULL,


### PR DESCRIPTION
This meter seems to be a rebranded Victor 86D. Vendor procotol documentation matches FS9922 RS232 protocol.