### PR TITLE
Kingst la2016 driver fixup

### DIFF
--- a/src/hardware/kingst-la2016/api.c
+++ b/src/hardware/kingst-la2016/api.c
@@ -64,7 +64,7 @@ static const char *channel_names[] = {
 	"8", "9", "10", "11", "12", "13", "14", "15",
 };
 
-static const uint64_t samplerates[] = {
+static const uint64_t samplerates_la2016[] = {
 	SR_KHZ(20),
 	SR_KHZ(50),
 	SR_KHZ(100),
@@ -80,6 +80,23 @@ static const uint64_t samplerates[] = {
 	SR_MHZ(50),
 	SR_MHZ(100),
 	SR_MHZ(200),
+};
+
+static const uint64_t samplerates_la1016[] = {
+	SR_KHZ(20),
+	SR_KHZ(50),
+	SR_KHZ(100),
+	SR_KHZ(200),
+	SR_KHZ(500),
+	SR_MHZ(1),
+	SR_MHZ(2),
+	SR_MHZ(4),
+	SR_MHZ(5),
+	SR_MHZ(8),
+	SR_MHZ(10),
+	SR_MHZ(20),
+	SR_MHZ(50),
+	SR_MHZ(100),
 };
 
 static const float logic_threshold_value[] = {
@@ -485,12 +502,21 @@ static int config_set(uint32_t key, GVariant *data,
 static int config_list(uint32_t key, GVariant **data,
 	const struct sr_dev_inst *sdi, const struct sr_channel_group *cg)
 {
+	struct dev_context *devc;
+
+	devc = sdi->priv;
+
 	switch (key) {
 	case SR_CONF_SCAN_OPTIONS:
 	case SR_CONF_DEVICE_OPTIONS:
 		return STD_CONFIG_LIST(key, data, sdi, cg, scanopts, drvopts, devopts);
 	case SR_CONF_SAMPLERATE:
-		*data = std_gvar_samplerates(ARRAY_AND_SIZE(samplerates));
+		if (devc->max_samplerate == SR_MHZ(200)) {
+			*data = std_gvar_samplerates(ARRAY_AND_SIZE(samplerates_la2016));
+		}
+		else {
+			*data = std_gvar_samplerates(ARRAY_AND_SIZE(samplerates_la1016));
+		}
 		break;
 	case SR_CONF_LIMIT_SAMPLES:
 		*data = std_gvar_tuple_u64(LA2016_NUM_SAMPLES_MIN, LA2016_NUM_SAMPLES_MAX);

--- a/src/hardware/kingst-la2016/api.c
+++ b/src/hardware/kingst-la2016/api.c
@@ -681,6 +681,8 @@ static int handle_event(int fd, int revents, void *cb_data)
 		g_free(devc->convbuffer);
 		devc->convbuffer = NULL;
 
+		devc->transfer = NULL;
+
 		sr_dbg("transfer is now finished");
 	}
 

--- a/src/hardware/kingst-la2016/api.c
+++ b/src/hardware/kingst-la2016/api.c
@@ -648,7 +648,7 @@ static int handle_event(int fd, int revents, void *cb_data)
 
 	if (devc->have_trigger == 0) {
 		if (la2016_has_triggered(sdi) == 0) {
-			sr_dbg("not yet ready for download...");
+			/*sr_dbg("not yet ready for download...");*/
 			return TRUE;
 		}
 		devc->have_trigger = 1;

--- a/src/hardware/kingst-la2016/protocol.c
+++ b/src/hardware/kingst-la2016/protocol.c
@@ -472,7 +472,6 @@ static int set_sample_config(const struct sr_dev_inst *sdi)
 {
 	struct dev_context *devc;
 	double clock_divisor;
-	uint64_t psa;
 	uint64_t total;
 	int ret;
 	uint16_t divisor;
@@ -503,12 +502,13 @@ static int set_sample_config(const struct sr_dev_inst *sdi)
 	sr_dbg("set sampling configuration %.0fkHz, %d samples, trigger-pos %d%%",
 	       devc->cur_samplerate / 1e3, (unsigned int)devc->limit_samples, (unsigned int)devc->capture_ratio);
 
-	psa = devc->pre_trigger_size * 256;
 	wrptr = buf;
 	write_u32le_inc(&wrptr, devc->limit_samples);
-	write_u48le_inc(&wrptr, psa);
-	write_u32le_inc(&wrptr, (total * devc->capture_ratio) / 100);
-	write_u16le_inc(&wrptr, clock_divisor);
+	write_u8_inc(&wrptr, 0);
+	write_u32le_inc(&wrptr, devc->pre_trigger_size);
+	write_u32le_inc(&wrptr, ((total * devc->capture_ratio) / 100) & 0xFFFFFF00 );
+	write_u16le_inc(&wrptr, divisor);
+	write_u8_inc(&wrptr, 0);
 
 	ret = ctrl_out(sdi, CMD_FPGA_SPI, REG_SAMPLING, 0, buf, wrptr - buf);
 	if (ret != SR_OK) {

--- a/src/hardware/kingst-la2016/protocol.h
+++ b/src/hardware/kingst-la2016/protocol.h
@@ -80,6 +80,7 @@ struct dev_context {
 	pwm_setting_t pwm_setting[2];
 	unsigned int threshold_voltage_idx;
 	float threshold_voltage;
+	uint64_t max_samplerate;
 	uint64_t cur_samplerate;
 	uint64_t limit_samples;
 	uint64_t capture_ratio;


### PR DESCRIPTION
The sigrok driver for the Kingst LA2016 is currently broken for many use cases, it doesn't work at all for me in PulseView.
This pr fixes a number of driver issues, mainly the fpga spi register addressing, and also adds support for older LA2016 devices.
It also adds support for LA1016 devices (old and new revisions) which have the same hardware as LA2016 devices but use different fpga bitstreams and are limited to 100MHz sampling.
This has all been tested on LA2016 and LA1016 devices, on linux host but I don't envisage any portability issues.