### PR TITLE
Add driver for TinyLogicFriend

### DIFF
--- a/src/hardware/tiny-logic-friend-la/api.c
+++ b/src/hardware/tiny-logic-friend-la/api.c
@@ -1,0 +1,469 @@
+/*
+ * This file is part of the libsigrok project.
+ *
+ * Copyright (C) 2021 Kevin Matocha <kmatocha@icloud.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+#include <scpi.h>
+#include <string.h>
+
+#include "protocol.h"
+
+static struct sr_dev_driver tiny_logic_friend_la_driver_info;
+
+static const uint32_t scanopts[] = { // setup the communication options, use USB TMC
+	// SR_CONF_CONN,
+	// SR_CONF_NUM_LOGIC_CHANNELS,
+};
+
+static const uint32_t drvopts[] = { // This driver is for a logic analyzer
+	SR_CONF_LOGIC_ANALYZER,
+};
+
+static const uint32_t devopts[] = {
+	// These are the options on the tinyLogicFriend that can be set
+//	SR_CONF_CONTINUOUS, // *todo* future expansion
+    SR_CONF_RLE | SR_CONF_GET, // get whether "RLE" or "CLOCK"
+    						  // RLE: Data provided in 16-bit timestamp, pin value
+    						  // CLOCK: Data provied in 16-bit pin value
+    						  //  - for example, see pipistrello-ols
+//  SR_CONF_FILTER | SR_CONF_GET | SR_CONF_SET, // *todo* future expansion
+//  SR_CONF_ENABLED | SR_CONF_SET,
+//  SR_CONF_NUM_LOGIC_CHANNELS | SR_CONF_GET,
+	SR_CONF_LIMIT_SAMPLES | SR_CONF_GET | SR_CONF_SET | SR_CONF_LIST,
+	SR_CONF_SAMPLERATE | SR_CONF_GET | SR_CONF_SET | SR_CONF_LIST,
+    SR_CONF_TRIGGER_MATCH | SR_CONF_LIST, // Need to update and verify this.
+};
+
+// Starting point is from rohde_schwarz_sme_0x driver, which uses
+// USB TMC (Test and Measurement Class) communication
+
+
+static int tlf_get_lists(struct sr_dev_inst *sdi)
+{
+	// This initializes all the device settings, collects all the key device
+	// parameters and current values and stores them into the appropriate variables
+	// in the private device context sdi->priv
+	//
+	// The private device context structure is defined in protocol.h:
+	// see ``struct dev_context``
+
+	uint8_t model_found;
+	//struct device_context *devc;
+
+	sr_spew("-> Enter tlf_init_device");
+
+	model_found = 0;
+
+	sr_spew("-> Enter tlf_init_device 1");
+	// check if the model is a tinyLogicFriend
+	if (g_ascii_strcasecmp(sdi->model, "tiny")  &&   // check that model includes
+		g_ascii_strcasecmp(sdi->model, "Logic") &&   // tiny, logic and friend, any order or case
+		g_ascii_strcasecmp(sdi->model, "Friend") ) {
+		model_found = 1;
+	}
+
+	sr_spew("-> Enter tlf_init_device 2");
+	if (!model_found) {
+		sr_dbg("Device %s is not supported by this driver.",
+			sdi->model);
+		return SR_ERR_NA;
+	}
+
+	sr_spew("-> Enter tlf_init_device 3");
+
+	// perform any other initialization here, get channel list, etc.
+	if (!(tlf_channels_list(sdi) == SR_OK)) {
+		return SR_ERR_NA;
+	}
+	sr_spew("-> Enter tlf_init_device 4");
+
+	if (!(tlf_samplerates_list(sdi) == SR_OK)) {
+		return SR_ERR_NA;
+	}
+	sr_spew("-> Enter tlf_init_device 5");
+	if (!(tlf_trigger_list(sdi) == SR_OK)) {
+		return SR_ERR_NA;
+	}
+
+	if (!(tlf_RLE_mode_get(sdi) == SR_OK)) {
+		return SR_ERR_NA;
+	}
+	sr_spew("-> Enter tlf_init_device 6");
+
+	return SR_OK;
+}
+
+static struct sr_dev_inst *probe_device(struct sr_scpi_dev_inst *scpi)
+{
+	struct sr_dev_inst *sdi;
+	struct dev_context *devc;
+	struct sr_scpi_hw_info *hw_info;
+
+	sr_spew("-> Enter probe_device");
+
+	sdi = NULL;
+	devc = NULL;
+	hw_info = NULL;
+
+	if (sr_scpi_get_hw_id(scpi, &hw_info) != SR_OK)
+		goto fail;
+
+	// store the information from the hardware ID (sr_scpi_get_hw_id)
+	sdi = g_malloc0(sizeof(struct sr_dev_inst));
+	sdi->vendor = g_strdup(hw_info->manufacturer);
+	sdi->model = g_strdup(hw_info->model);
+	sdi->version = g_strdup(hw_info->firmware_version);
+	sdi->serial_num = g_strdup(hw_info->serial_number);
+	sdi->driver = &tiny_logic_friend_la_driver_info;
+	sdi->inst_type = SR_INST_SCPI;
+	sdi->conn = scpi;
+
+	sr_spew("Vendor: %s\n", sdi->vendor);
+	sr_spew("Model: %s\n", sdi->model);
+	sr_spew("Version: %s\n", sdi->version);
+	sr_spew("Serial number: %s\n", sdi->serial_num);
+
+	sr_scpi_hw_info_free(hw_info);
+	hw_info = NULL;
+
+	// allocate the device context
+	devc = g_malloc0(sizeof(struct dev_context)); // header in protocol.h
+	sdi->priv = devc;
+	devc->trigger_matches_count = TRIGGER_MATCHES_COUNT;
+
+	if (tlf_get_lists(sdi) != SR_OK) // verify this device is a tinyLogicFriend
+									   // and initialize all device options and get current settings
+		goto fail;
+
+	GSList *l;
+	for (l = sdi->channels; l; l = l->next) {
+		sr_err("** probe_device channel found");
+	}
+
+	return sdi;
+
+fail:
+	sr_scpi_hw_info_free(hw_info);
+	sr_dev_inst_free(sdi);
+	g_free(devc);
+	return NULL;
+}
+
+static GSList *scan(struct sr_dev_driver *di, GSList *options)
+{
+	sr_spew("-> Enter scan");
+
+	// set all important setup parameters into the probe_device function
+	return sr_scpi_scan(di->context, options, probe_device);
+
+}
+
+static int dev_open(struct sr_dev_inst *sdi)
+{
+	int ret;
+
+	sr_spew("-> Enter dev_open");
+
+	if ((ret = sr_scpi_open(sdi->conn)) < 0) {
+		sr_err("Failed to open SCPI device: %s.", sr_strerror(ret));
+		return SR_ERR;
+	}
+
+	return SR_OK;
+}
+
+static int dev_close(struct sr_dev_inst *sdi)
+{
+	sr_spew("-> Enter dev_close");
+	return sr_scpi_close(sdi->conn);
+}
+
+static int config_get(uint32_t key, GVariant **data,
+	const struct sr_dev_inst *sdi, const struct sr_channel_group *cg)
+{
+	struct sr_channel *ch;
+	uint64_t buf_int;
+	int32_t buf_32;
+	gboolean enable_status;
+	enable_status = FALSE;
+
+	sr_spew("-> Enter config_get");
+
+	if (!sdi) {
+		sr_err("Must call `scan` prior to calling `config_get`.");
+		return SR_ERR_ARG;
+	}
+
+	if (!cg) {
+		switch (key) {
+		case SR_CONF_SAMPLERATE:
+			sr_spew("  -> SR_CONF_SAMPLERATE");
+			if (tlf_samplerate_get(sdi, &buf_int) != SR_OK) {
+				return SR_ERR;
+			}
+			*data = g_variant_new_uint64(buf_int);
+			sr_spew("config_get: returning samplerate");
+			break;
+		case SR_CONF_NUM_LOGIC_CHANNELS: // see Beaglelogic
+			sr_spew("  -> SR_CONF_NUM_LOGIC_CHANNELS");
+			*data = g_variant_new_uint32(g_slist_length(sdi->channels));
+			break;
+
+		case SR_CONF_LIMIT_SAMPLES:  // * todo cleanup switch statement
+			sr_spew("  -> SR_CONF_LIMIT_SAMPLES");
+			if (tlf_samples_get(sdi, &buf_32) != SR_OK) {
+				return SR_ERR;
+			}
+			*data = g_variant_new_uint64(buf_32);
+			break;
+		case SR_CONF_RLE:
+
+			// todo ADD code if you need to verify something for run-length-encoding RLE ********
+			// `RLE_mode` state variable should have been verified during `scan`
+
+		default:
+			sr_dbg("(1) Unsupported key: %d ", key);
+			return SR_ERR_NA;
+			break;
+		}
+	} else {
+		switch (key) {
+		case SR_CONF_ENABLED:
+			sr_spew("  -> SR_CONF_ENABLED");
+			ch = cg->channels->data;
+			if ( tlf_channel_state_get(sdi, ch->index, &enable_status) != SR_OK ) {
+				return SR_ERR;
+			}
+			*data = g_variant_new_boolean(enable_status);
+			break;
+		case SR_CONF_NUM_LOGIC_CHANNELS: // see Beaglelogic
+			sr_spew("  -> SR_CONF_NUM_LOGIC_CHANNELS");
+			*data = g_variant_new_uint32(g_slist_length(sdi->channels));
+			break;
+		case SR_CONF_LIMIT_SAMPLES: // * todo cleanup switch statement
+			sr_spew("  -> SR_CONF_LIMIT_SAMPLES");
+			if (tlf_samples_get(sdi, &buf_32) != SR_OK) {
+				return SR_ERR;
+			}
+			*data = g_variant_new_uint64(buf_32);
+			break;
+		default:
+			sr_dbg("(2) Unsupported key: %d ", key);
+			return SR_ERR_NA;
+			break;
+		}
+	}
+
+	return SR_OK;
+}
+
+static int config_channel_set(const struct sr_dev_inst *sdi,
+	struct sr_channel *ch, unsigned int changes)
+{
+	sr_spew("-> Enter config_channel_set");
+
+	/* Currently we only handle SR_CHANNEL_SET_ENABLED. */ // todo - update to trigger set
+	switch(changes) {
+		case SR_CHANNEL_SET_ENABLED:
+			sr_spew("  -> SR_CHANNEL_SET_ENABLED");
+			return tlf_channel_state_set(sdi, ch->index, ch->enabled);
+			break;
+		default:
+			return SR_ERR_NA;
+	}
+
+}
+
+static int config_set(uint32_t key, GVariant *data,
+	const struct sr_dev_inst *sdi, const struct sr_channel_group *cg)
+{
+	struct dev_context *devc;
+	struct sr_channel *ch;
+	uint64_t value;
+
+	sr_spew("-> Enter config_set");
+
+	if (!sdi) {
+		sr_err("Must call `scan` prior to calling `config_set`.");
+		return SR_ERR_NA;
+	}
+
+	devc = sdi->priv;
+
+	if (!sdi)
+		return SR_ERR_NA;
+
+	if (!cg) {
+		switch (key) {
+		case SR_CONF_SAMPLERATE:
+			sr_spew("  -> SR_CONF_SAMPLERATE");
+			value = g_variant_get_uint64(data);
+			if ( (value < devc->samplerate_range[0]) ||
+				 (value > devc->samplerate_range[1]) ) {
+				return SR_ERR_SAMPLERATE;
+			}
+			return tlf_samplerate_set(sdi, value);
+			break;
+		case SR_CONF_LIMIT_SAMPLES: // * todo cleanup switch statement
+			sr_spew("  -> SR_CONF_LIMIT_SAMPLES");
+			if (tlf_samples_set(sdi, g_variant_get_uint64(data)) != SR_OK) {
+				return SR_ERR;
+			}
+			break;
+		default:
+			sr_dbg("Unsupported key: %d ", key);
+			return SR_ERR_NA;
+		}
+	} else {
+		switch (key) {
+		case SR_CONF_ENABLED: // see `rigol-dg`
+			ch = cg->channels->data;
+			sr_spew("  -> SR_CONF_ENABLED");
+			if (tlf_channel_state_set(sdi, ch->index, g_variant_get_boolean(data)) != SR_OK) {
+				return SR_ERR;
+			}
+			break;
+		case SR_CONF_LIMIT_SAMPLES: // * todo cleanup switch statement
+			sr_spew("  -> SR_CONF_LIMIT_SAMPLES");
+			if (tlf_samples_set(sdi, g_variant_get_uint64(data)) != SR_OK) {
+				return SR_ERR;
+			}
+			break;
+		default:
+			sr_dbg("Unsupported key: %d ", key);
+			return SR_ERR_NA;
+		}
+	}
+
+	return SR_OK;
+}
+
+static int config_list(uint32_t key, GVariant **data,
+	const struct sr_dev_inst *sdi, const struct sr_channel_group *cg)
+{
+	sr_spew("-> config_list");
+	struct dev_context *devc;
+
+	sr_spew("-> Enter config_list");
+
+	switch(key) {
+	case SR_CONF_SCAN_OPTIONS:
+		sr_spew("  -> SR_CONF_SCAN_OPTIONS");
+	case SR_CONF_DEVICE_OPTIONS:
+		sr_spew("  -> SR_CONF_DEVICE_OPTIONS");
+		return STD_CONFIG_LIST(key, data, sdi, cg, scanopts, drvopts, devopts);
+	case SR_CONF_SAMPLERATE:
+		sr_spew("  -> SR_CONF_SAMPLERATE");
+		if (!sdi) {
+			sr_err("Must call `scan` prior to calling `config_list`.");
+		return SR_ERR_NA;
+		}
+		devc = sdi->priv;
+		*data = std_gvar_samplerates_steps(ARRAY_AND_SIZE(devc->samplerate_range));
+		break;
+	case SR_CONF_TRIGGER_MATCH:
+		sr_spew("  -> SR_CONF_TRIGGER_MATCH");
+		if (!sdi) {
+			sr_err("Must call `scan` prior to calling `config_list`.");
+		return SR_ERR_NA;
+		}
+		devc = sdi->priv;
+		tlf_trigger_list(sdi);
+		*data = std_gvar_array_i32(ARRAY_AND_SIZE(devc->trigger_matches));
+		break;
+	case SR_CONF_LIMIT_SAMPLES:
+		if (!sdi)
+			return SR_ERR_ARG;
+		else {
+			devc=sdi->priv;
+			if (tlf_maxsamples_get(sdi) != SR_OK) {
+				return SR_ERR;
+			}
+			*data = std_gvar_tuple_u64(100, devc->max_samples);
+			sr_dbg("max_samples: %u", devc->max_samples);
+			break;
+		}
+	default:
+		sr_dbg("Unsupported key: %d ", key);
+		return SR_ERR_NA;
+	}
+	sr_spew("<- Leaving config_list");
+
+	return SR_OK;
+}
+
+
+static int dev_acquisition_start(const struct sr_dev_inst *sdi)
+{
+	struct dev_context *devc;
+	struct sr_scpi_dev_inst *scpi;
+
+	sr_spew("->dev_acquisition_start");
+
+	scpi = sdi->conn;
+	devc = sdi->priv;
+	devc->data_pending = TRUE; // initialize all the variables before reading data.
+	devc->measured_samples = 0;
+	devc->last_sample = 0;
+	devc->last_timestamp = 0;
+
+
+	sr_scpi_source_add(sdi->session, scpi, G_IO_IN, 50, // timeout value (ms)
+			tlf_receive_data, (void *)sdi);
+
+	std_session_send_df_header(sdi); // sends the SR_DF_HEADER command to the session
+
+	sr_spew("Go RUN");
+	std_session_send_df_frame_begin(sdi);
+
+	return tlf_exec_run(sdi);
+}
+
+
+static int dev_acquisition_stop(const struct sr_dev_inst *sdi)
+{
+
+	sr_spew("-> Enter dev_acquisition_stop");
+	std_session_send_df_frame_end(sdi);
+	sr_scpi_source_remove(sdi->session, sdi->conn);
+	tlf_exec_stop(sdi);
+
+	return SR_OK;
+}
+
+
+static struct sr_dev_driver tiny_logic_friend_la_driver_info = {
+	.name = "tiny-logic-friend-la",
+	.longname = "Tiny Logic Friend-la",
+	.api_version = 1,
+	.init = std_init,
+	.cleanup = std_cleanup,
+	.scan = scan,
+	.dev_list = std_dev_list,
+	.dev_clear = std_dev_clear,
+	.config_channel_set = config_channel_set,
+	.config_get = config_get,
+	.config_set = config_set,
+	.config_list = config_list,
+	.dev_open = dev_open,
+	.dev_close = dev_close,
+	.dev_acquisition_start = dev_acquisition_start,
+	.dev_acquisition_stop = dev_acquisition_stop,
+	.context = NULL,
+};
+SR_REGISTER_DEV_DRIVER(tiny_logic_friend_la_driver_info);

--- a/src/hardware/tiny-logic-friend-la/protocol.c
+++ b/src/hardware/tiny-logic-friend-la/protocol.c
@@ -1,0 +1,611 @@
+/*
+ * This file is part of the libsigrok project.
+ *
+ * Copyright (C) 2021 Kevin Matocha <kmatocha@icloud.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <config.h>
+#include <scpi.h>
+
+#include "protocol.h"
+#include <libsigrok/libsigrok.h>
+#include "libsigrok-internal.h"
+
+
+size_t samples_sent = 0; // DEBUG
+
+SR_PRIV int tlf_samplerates_list(const struct sr_dev_inst *sdi) // gets sample rates from device
+{
+
+	struct dev_context *devc;
+	devc = sdi->priv;
+
+	int32_t sample_rate_min, sample_rate_max, sample_rate_step;
+
+	if (sr_scpi_get_int(sdi->conn, "RATE:MIN?", &sample_rate_min) != SR_OK) {
+		sr_spew("Sent \"RATE:MIN?\", ERROR on response\n");
+		return SR_ERR;
+	}
+
+	if (sr_scpi_get_int(sdi->conn, "RATE:MAX?", &sample_rate_max) != SR_OK) {
+		sr_spew("Sent \"RATE:MAX?\", ERROR on response\n");
+		return SR_ERR;
+	}
+
+	if (sr_scpi_get_int(sdi->conn, "RATE:STEP?", &sample_rate_step) != SR_OK) {
+		sr_spew("Sent \"RATE:STEP?\", ERROR on response\n");
+		return SR_ERR;
+	}
+
+	// store the sample rate range and step size
+	devc->samplerate_range[0] = (uint64_t) sample_rate_min;
+	devc->samplerate_range[1] = (uint64_t) sample_rate_max;
+	devc->samplerate_range[2] = (uint64_t) sample_rate_step;
+
+	sr_spew("Sample rate MIN: %d Hz, MAX: %d Hz, STEP: %d Hz\n",
+				sample_rate_min, sample_rate_max, sample_rate_step);
+
+	return SR_OK;
+}
+
+SR_PRIV int tlf_samplerate_set(const struct sr_dev_inst *sdi, uint64_t sample_rate)
+{
+	struct dev_context *devc;
+	devc = sdi->priv;
+
+	if (sr_scpi_send(sdi->conn, "RATE %ld", sample_rate) != SR_OK) {
+		sr_spew("Sent \"RATE %llu\", ERROR on response\n", sample_rate);
+		return SR_ERR;
+	}
+
+	devc->cur_samplerate = sample_rate;
+
+	return SR_OK;
+}
+
+SR_PRIV int tlf_samplerate_get(const struct sr_dev_inst *sdi, uint64_t *sample_rate)
+{
+	struct dev_context *devc;
+	int return_buf;
+
+	devc = sdi->priv;
+
+	if (sr_scpi_get_int(sdi->conn, "RATE?", &return_buf) != SR_OK) {
+		sr_spew("Sent \"RATE?\", ERROR on response\n");
+		return SR_ERR;
+	}
+	devc->cur_samplerate = (uint64_t) return_buf; // update private device context
+	*sample_rate = (uint64_t) return_buf;         // send back the sample_rate value
+
+	return SR_OK;
+}
+
+SR_PRIV int tlf_samples_set(const struct sr_dev_inst *sdi, int32_t samples) // set samples count
+{
+	struct dev_context *devc;
+	devc = sdi->priv;
+
+	if (sr_scpi_send(sdi->conn, "SAMPles %ld", samples) != SR_OK) {
+		sr_dbg("tlf_samples_set Sent \"SAMPLes %d\", ERROR on response\n", samples);
+		return SR_ERR;
+	}
+	sr_spew("tlf_samples_set sent \"SAMPLes %d\"", samples);
+
+	devc->cur_samples = samples;
+
+	return SR_OK;
+}
+
+SR_PRIV int tlf_maxsamples_get(const struct sr_dev_inst *sdi) // get samples count
+{
+	struct dev_context *devc;
+	uint32_t max_samples_buf;
+	devc = sdi->priv;
+
+	if (sr_scpi_get_int(sdi->conn, "SAMPles:MAX?", &max_samples_buf) != SR_OK) {
+		sr_dbg("tlf_samples_get Sent \"SAMPLes?\", ERROR on response\n");
+		return SR_ERR;
+	}
+	sr_spew("tlf_samples_get Samples = %d", &max_samples_buf);
+
+	devc->max_samples = max_samples_buf;
+
+	return SR_OK;
+}
+
+SR_PRIV int tlf_samples_get(const struct sr_dev_inst *sdi, int32_t *samples) // get samples count
+{
+	struct dev_context *devc;
+	devc = sdi->priv;
+
+	if (sr_scpi_get_int(sdi->conn, "SAMPles?", samples) != SR_OK) {
+		sr_dbg("tlf_samples_get Sent \"SAMPLes?\", ERROR on response\n");
+		return SR_ERR;
+	}
+	sr_spew("tlf_samples_get Samples = %d", *samples);
+
+	devc->cur_samples = *samples;
+
+	return SR_OK;
+}
+
+SR_PRIV int tlf_channel_state_set(const struct sr_dev_inst *sdi, int32_t channel_index, gboolean enabled) // gets channel status
+{
+	char command[64];
+	struct dev_context *devc;
+
+	devc = sdi->priv;
+
+	// channel count and names should be collected before setting any channels
+	if ( (channel_index < 0) ||
+		 (channel_index >= devc->channels) ) {
+		return SR_ERR;
+	}
+
+	if (enabled == TRUE) {
+		sprintf(command, "CHANnel%d:STATus %s", channel_index+1, "ON"); // define channel to get name
+	} else if (enabled == FALSE) {
+		sprintf(command, "CHANnel%d:STATus %s", channel_index+1, "OFF"); // define channel to get name
+	} else {
+		return SR_ERR;
+	}
+
+	if (sr_scpi_send(sdi->conn, command) != SR_OK) {
+		return SR_ERR;
+	}
+
+	devc->channel_state[channel_index] = enabled; // sets to gboolean value of enabled
+
+	sr_spew("tlf_channel_state_set Channel: %d set ON", channel_index+1);
+	return SR_OK;
+}
+
+SR_PRIV int tlf_channel_state_get(const struct sr_dev_inst *sdi, int32_t channel_index, gboolean *enabled) // sets channel status
+{
+	struct dev_context *devc;
+
+	devc = sdi->priv;
+
+	// channel count and names should be collected before setting any channels
+	if ( (channel_index < 0) ||
+		 (channel_index >= devc->channels) ) {
+		return SR_ERR;
+	}
+
+	*enabled = devc->channel_state[channel_index];
+
+	return SR_OK;
+}
+
+SR_PRIV int tlf_channels_list(struct sr_dev_inst *sdi) // gets channel names from device
+{
+	sr_spew("tlf_channels_list 0");
+
+	char *buf;
+	char command[25];
+	int32_t j;
+	int32_t channel_count;
+	struct dev_context *devc;
+	struct sr_channel_group *cg;
+	struct sr_channel *ch;
+
+	devc = sdi->priv;
+
+	sr_spew("tlf_channels_list 1");
+
+	// request the CHANnel count
+	if (sr_scpi_get_int(sdi->conn, "CHANnel:COUNT?", &channel_count) != SR_OK) {
+		sr_dbg("Sent \"CHANnel:COUNT?\", ERROR on response\n");
+		return SR_ERR;
+	}
+
+	sr_spew("tlf_channels_list 2");
+
+	if ( (channel_count < 0) ||
+		 (channel_count > TLF_CHANNEL_COUNT_MAX) ) {
+		sr_spew("Sent \"CHANnel:COUNT?\", received %d", channel_count);
+		sr_dbg("ERROR: Out of channel range \
+			   between 0 and %d (TLF_CHANNEL_COUNT_MAX)", TLF_CHANNEL_COUNT_MAX);
+		return SR_ERR;
+	}
+
+	sr_spew("channel_count = %d", channel_count);
+	devc->channels = channel_count; // update the device context channels value
+
+	sr_spew("tlf_channels_list 3");
+
+	for (int i=0; i < channel_count; i++) {
+		sprintf(command, "CHANnel%d:NAME?", i+1); // define channel to get name
+		if (sr_scpi_get_string(sdi->conn, command, &buf) != SR_OK) {
+			sr_dbg("Sent \"%s\", ERROR on response\n", command);
+			return SR_ERR;
+		}
+		sr_spew("send: %s, chan #: %d, channel name: %s", command, i+1, buf);
+		if ( strlen(buf) > TLF_CHANNEL_CHAR_MAX ) { // ensure string is shorter than max length
+			buf[TLF_CHANNEL_CHAR_MAX] = '\0'; // if so, put a null at max length
+		}
+		strcpy(devc->chan_names[i], buf); // copy into the device context's channel names
+	}
+
+	// set remaining channel names to NULL
+	if (channel_count < TLF_CHANNEL_COUNT_MAX) {
+		for (int i=channel_count; i < TLF_CHANNEL_COUNT_MAX; i++) {
+			strcpy(devc->chan_names[i], "");
+		}
+	}
+
+	for (int i=0; i < TLF_CHANNEL_COUNT_MAX; i++) {
+		sr_spew("Channel index: %d Channel name: %s", i, devc->chan_names[i]);
+	}
+
+	sr_dbg("Setting all channels on, configuring channels");
+
+	/* Logic channels, all in one channel group. */
+	cg = g_malloc0(sizeof(struct sr_channel_group));
+	cg->name = g_strdup("Logic");
+
+	for (j = 0; j < channel_count; j++) {
+		if ( tlf_channel_state_set(sdi, j, TRUE) != SR_OK ) {
+			return SR_ERR;
+		}
+		sr_spew("Adding channel %d: %s", j, devc->chan_names[j]);
+		ch = sr_channel_new(sdi, j, SR_CHANNEL_LOGIC, TRUE,
+			       devc->chan_names[j]);
+		cg->channels = g_slist_append(cg->channels, ch);
+	}
+
+	sdi->channel_groups = g_slist_append(NULL, cg);
+
+	return SR_OK;
+
+}
+
+SR_PRIV int tlf_trigger_list(const struct sr_dev_inst *sdi) // gets trigger options
+{
+	char *buf;
+	char command[25];
+	char *token;
+	int32_t trigger_option_count, array_count;
+	struct dev_context *devc;
+
+	devc = sdi->priv;
+
+	sprintf(command, "TRIGger:OPTions?"); // get trigger options
+	if (sr_scpi_get_string(sdi->conn, command, &buf) != SR_OK) {
+		return SR_ERR;
+	}
+	sr_spew("send: %s, TRIGGER options: %s", command, buf);
+
+	// parse the trigger options string (CSV format)
+	trigger_option_count = 0;
+	array_count = 0;
+	token = strtok(buf, ","); // initialize the pointer location to beginning of the buffer
+
+	for(size_t i=0;i < devc->trigger_matches_count; i++){
+		devc->trigger_matches[i] = NULL;
+	}
+
+
+	while (token!=NULL) {
+		// set the trigger_matches to the token's trigger type
+		if  ( !g_ascii_strcasecmp(token, "0") ) {
+			devc->trigger_matches[trigger_option_count]=SR_TRIGGER_ZERO;
+			trigger_option_count++;
+			sr_spew("Trigger token: %s, Accept ZERO trigger", token);
+		} else if ( !g_ascii_strcasecmp(token, "1") ) {
+			devc->trigger_matches[trigger_option_count]=SR_TRIGGER_ONE;
+			trigger_option_count++;
+			sr_spew("Trigger token: %s, Accept ONE trigger", token);
+		} else if ( !g_ascii_strcasecmp(token, "R") ) {
+			devc->trigger_matches[trigger_option_count]=SR_TRIGGER_RISING;
+			trigger_option_count++;
+			sr_spew("Trigger token: %s, Accept RISING trigger", token);
+		} else if ( !g_ascii_strcasecmp(token, "F") ) {
+			devc->trigger_matches[trigger_option_count]=SR_TRIGGER_FALLING;
+			trigger_option_count++;
+			sr_spew("Trigger token: %s, Accept FALLING trigger", token);
+		} else if ( !g_ascii_strcasecmp(token, "E") ) {
+			devc->trigger_matches[trigger_option_count]=SR_TRIGGER_EDGE;
+			trigger_option_count++;
+			sr_spew("Trigger token: %s, Accept EDGE trigger", token);
+		} else if ( !g_ascii_strcasecmp(token, "X") ) {
+			// ignore 'X' that means OFF
+		} else {
+			sr_spew("Error on token: %s", token);
+			return SR_ERR;
+		}
+
+		token = strtok(NULL, ","); // set to the next token
+	}
+
+	return SR_OK;
+}
+
+
+SR_PRIV int tlf_RLE_mode_get(const struct sr_dev_inst *sdi)
+{
+	char *buf;
+	char command[25];
+	struct dev_context *devc;
+	devc = sdi->priv;
+
+	sprintf(command, "MODE?"); // get trigger options
+	if (sr_scpi_get_string(sdi->conn, command, &buf) != SR_OK) {
+		return SR_ERR;
+	}
+	sr_spew("send: %s, Response: %s", command, buf);
+
+	if ( !g_ascii_strcasecmp(buf, "RLE") ) {
+			devc->RLE_mode = TRUE;
+			sr_spew("Mode is Run Length Encoded (RLE)");
+			return SR_OK;
+		}
+
+	if ( !g_ascii_strcasecmp(buf, "CLOCK") ) {
+			devc->RLE_mode = FALSE;
+			sr_spew("Mode is Clock sampling (CLOCK)");
+			return SR_OK;
+		}
+
+	// no match to availble modes
+	return SR_ERR;
+
+}
+
+SR_PRIV int tlf_exec_run(const struct sr_dev_inst *sdi) // start measurement
+{
+	struct dev_context *devc;
+
+	if (!(devc = sdi->priv)) {
+		return SR_ERR;
+	}
+
+	devc->measured_samples = 0; // reset measurement counter
+	samples_sent=0;
+	sr_spew("reset devc->measured_samples, samples_sent");
+
+	return sr_scpi_send(sdi->conn, "RUN");
+
+}
+
+SR_PRIV int tlf_exec_stop(const struct sr_dev_inst *sdi) // stop measurement
+{
+	return sr_scpi_send(sdi->conn, "STOP");
+
+}
+
+SR_PRIV int tlf_receive_data(int fd, int revents, void *cb_data)
+// tlf_receive_data is currently configured to receive Run-Length-Encoded tuples (16-bit timestamp, value)
+//
+// * todo *
+// This function should be updated to re-configure based on devc->RLE_mode value, whether it is
+// Run Length Encoded data or pure clock sampling data
+{
+	const struct sr_dev_inst *sdi;
+	struct dev_context *devc;
+	int chunk_len;
+	static GArray *data = NULL;
+
+	struct sr_datafeed_packet packet;
+	struct sr_datafeed_logic logic;
+
+	// if run length encoded
+	unsigned int rle_buffer_size = 12;
+	uint32_t timestamp;
+	uint16_t value;
+
+	// char print_buffer[6000]; // for debugging data values
+	// char tmp_buffer[6000];
+
+	// int ret;
+
+	(void) revents;
+
+	(void) fd;
+
+
+	sr_spew("---> Entering tlf_receive_data");
+
+	if (!(sdi = cb_data))
+		return TRUE;
+	sr_spew("---> tlf_receive_data - A");
+
+	if (!(devc = sdi->priv))
+		return TRUE;
+
+	sr_spew("---> tlf_receive_data - B");
+	 //Are we waiting for a response from the device?
+	if (!devc->data_pending)
+		return TRUE;
+
+	sr_spew("---> tlf_receive_data - ask for DATA?");
+	if ( sr_scpi_send(sdi->conn, "DATA?") != SR_OK ) {
+			sr_spew("---> tlf_receive_data - going to close");
+			goto close;
+		}
+
+
+	if (!data) {
+		sr_spew("---> tlf_receive_data -> read_begin A");
+
+		if (sr_scpi_read_begin(sdi->conn) == SR_OK) {
+			// /* The 16 here accounts for the header and EOL. */
+			data = g_array_sized_new(FALSE, FALSE, sizeof(uint8_t),
+					32);
+					//16 + model_state->samples_per_frame);
+			sr_spew("read_begin");
+		}
+		else
+			return TRUE;
+	} else {
+		sr_spew("---> tlf_receive_data -> read_begin 2");
+		sr_scpi_read_begin(sdi->conn);
+	}
+
+	sr_spew("get a chunk");
+
+	// read data
+
+	chunk_len = sr_scpi_read_data(sdi->conn, devc->receive_buffer,
+			RECEIVE_BUFFER_SIZE);
+	if (chunk_len < 0) {
+		sr_dbg("Finished reading data, chunk_len: %d", chunk_len);
+		goto close;
+	}
+
+	sr_spew("Received data, chunk_len: %d", chunk_len);
+
+	packet.type = SR_DF_LOGIC; // setup packet for sr_session_send
+	packet.payload = &logic;
+	logic.unitsize = 2; // 16 bits
+
+	if (devc->RLE_mode) {
+	// Perform Run-Length Encoded extraction into samples at each tick
+	//
+
+		// print_buffer[0] = '\0'; // for debugging data values
+		for (int i=0; i < chunk_len; i=i+4) { // for 32 bit uint timestamp
+			timestamp = (((uint8_t) devc->receive_buffer[i+1]) << 8) | ((uint8_t) devc->receive_buffer[i]);
+			value = (((uint8_t) devc->receive_buffer[i+3]) << 8) | ((uint8_t) devc->receive_buffer[i+2]);
+
+			// sprintf(tmp_buffer, "[%u %u]", timestamp, value); // for debugging data values
+			// strcat(print_buffer, tmp_buffer); // for debugging data values
+		}
+		// sr_warn("Data: %s", print_buffer); // for debugging data values
+
+
+		// should initialize prior to starting first read
+		//		- devc->last_sample
+		//		- devc->last_timestamp
+		//		- devc->num_samples
+
+		if (devc->measured_samples == 0) { // this is the first time reading, so allocate the buffer
+								  // todo *** after the last read, free the malloc'ed buffer.
+			devc->raw_sample_buf = g_try_malloc(rle_buffer_size * 2);
+			if (!devc->raw_sample_buf) {
+				sr_err("Sample buffer malloc failed.");
+				return FALSE;
+			}
+		}
+
+		// packet.type = SR_DF_LOGIC;
+		// packet.payload = &logic;
+		// logic.unitsize = 2;
+		logic.data = devc->raw_sample_buf;
+
+
+		for (int i=0; i < chunk_len; i=i+4) {
+			timestamp = (((uint8_t) devc->receive_buffer[i+1]) << 8) | ((uint8_t) devc->receive_buffer[i]);
+			value = (((uint8_t) devc->receive_buffer[i+3]) << 8) | ((uint8_t) devc->receive_buffer[i+2]);
+			samples_sent++;
+
+			sr_spew("devc->measured_samples: %zu", devc->measured_samples);
+
+			// todo * can we do math with int32_t and uint16_t unsigned??  WARNING
+			for (int32_t tick=devc->last_timestamp; tick < (int32_t) timestamp; tick++) {
+				// run from the previous time_stamp to the current one, fill with last_sample data
+				((uint16_t*) devc->raw_sample_buf)[devc->pending_samples] = devc->last_sample;
+				devc->measured_samples++;
+				devc->pending_samples++; // number of samples currently stored in the buffer
+
+				if (devc->pending_samples == rle_buffer_size) { //run length encoded buffer_size) {
+					logic.length = devc->pending_samples * 2;
+					if (logic.data == NULL) {
+						sr_spew("tlf_receive_data: payload is NULL");
+					}
+					sr_session_send(sdi, &packet);
+
+					devc->pending_samples = 0;
+				}
+			}
+
+			// finished processing the previous sample and timestamp, save next sample
+			devc->last_sample = value;
+			if (timestamp == 65535) {
+				devc->last_timestamp = -1; // wrapped around the 16 bit counter,
+										   // so reset to -1 for next sample
+			} else {
+				devc->last_timestamp = timestamp;
+			}
+		}
+
+		sr_spew("About to flush...");
+		// flush any remaining data in the buffer wit sr_session_send
+		if (devc->pending_samples > 0) {
+			logic.length = devc->pending_samples * 2;
+			sr_session_send(sdi, &packet);
+		}
+
+		// sr_warn("Data: %s", print_buffer); // for debugging data values
+		sr_spew("Finished flush.");
+	} else {  // data is provided in pure sampling mode
+
+		for (int i=0; i < chunk_len*2; i=i+2) { // break chunk_len (32 bit pieces) into 16-bit pieces
+
+			devc->raw_sample_buf = g_try_malloc(chunk_len * 4);
+			if (!devc->raw_sample_buf) {
+				sr_err("Sample buffer malloc failed.");
+				return FALSE;
+			}
+			devc->raw_sample_buf[i] = (uint16_t) (((uint8_t) devc->receive_buffer[i+1]) << 8) | ((uint8_t) devc->receive_buffer[i]);
+
+		}
+		logic.data = devc->raw_sample_buf;
+		logic.length = chunk_len * 2;
+
+		sr_session_send(sdi, &packet);
+
+	}
+
+
+
+	sr_warn("Sent samples %zu", samples_sent);
+
+	if (samples_sent >= devc->cur_samples) {
+		goto close;
+	}
+
+	sr_spew("<- returning from tlf_receive_data");
+
+	return TRUE;
+
+	/* We finished reading and are no longer waiting for data. */
+
+	sr_spew("freeing data");
+	g_array_free(data, TRUE);
+	data = NULL;
+	return TRUE;
+
+	close:
+	if (data) {
+		std_session_send_df_frame_end(sdi);
+		std_session_send_df_end(sdi);
+		sr_dbg("read is complete");
+		devc->data_pending = FALSE;
+
+		g_array_free(data, TRUE);
+		data = NULL;
+		sr_dev_acquisition_stop(sdi);
+
+	}
+
+	return FALSE;
+
+}
+
+

--- a/src/hardware/tiny-logic-friend-la/protocol.h
+++ b/src/hardware/tiny-logic-friend-la/protocol.h
@@ -1,0 +1,103 @@
+/*
+ * This file is part of the libsigrok project.
+ *
+ * Copyright (C) 2021 Kevin Matocha <kmatocha@icloud.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBSIGROK_HARDWARE_TINY_LOGIC_FRIEND_LA_PROTOCOL_H
+#define LIBSIGROK_HARDWARE_TINY_LOGIC_FRIEND_LA_PROTOCOL_H
+
+#include <stdint.h>
+#include <glib.h>
+#include <libsigrok/libsigrok.h>
+#include "libsigrok-internal.h"
+
+#define LOG_PREFIX "tiny-logic-friend-la"
+
+#define TLF_CHANNEL_COUNT_MAX 16 // maximum number of channels allowed
+#define TLF_CHANNEL_CHAR_MAX 6   // maximum number of characters for the channel names
+
+#define TRIGGER_MATCHES_COUNT 5 // maximum number of trigger matches
+
+#define RECEIVE_BUFFER_SIZE 4096
+
+/** Private, per-device-instance driver context. */
+
+// dev_context is where all the device specific variables should go that are private
+// should hold state variables for the device
+//
+struct dev_context {
+	//const struct tlf_device_model *model_config; // what is this? *** todo
+
+	int channels; // actual number of channels
+	char chan_names[TLF_CHANNEL_COUNT_MAX][TLF_CHANNEL_COUNT_MAX + 1];// = { // channel names, initialize with default value
+
+	uint64_t samplerate_range[3]; // sample rate storage: min, max, step size (all in Hz)
+	uint64_t cur_samplerate; // currently set sample rate
+
+	uint32_t max_samples; // maximum number of samples the device will measure
+	uint32_t cur_samples; // currently set samples to measure
+
+	int32_t trigger_matches[TRIGGER_MATCHES_COUNT];
+									// See the list of trigger option constants, used in tlf_trigger_list
+									// SR_TRIGGER_ZERO,      "0"
+									// SR_TRIGGER_ONE,       "1"
+									// SR_TRIGGER_RISING,    "R"
+									// SR_TRIGGER_FALLING,   "F"
+									// SR_TRIGGER_EDGE,      "E"
+	size_t trigger_matches_count;
+	gboolean channel_state[TLF_CHANNEL_COUNT_MAX]; // set TRUE for enable, FALSE for disable
+
+	char receive_buffer[RECEIVE_BUFFER_SIZE];
+	gboolean data_pending; // state variable if data is pending to be measured
+
+	size_t measured_samples;
+	size_t pending_samples;
+	size_t num_samples;
+
+	uint16_t last_sample;
+	int32_t last_timestamp; // must store -1 for handling the 16-bit timer
+
+	uint16_t * raw_sample_buf;
+
+	int RLE_mode; // set TRUE if uses Run Length Encoding
+
+};
+
+
+SR_PRIV int tlf_samplerates_list(const struct sr_dev_inst *sdi); // gets sample rates
+SR_PRIV int tlf_samplerate_set(const struct sr_dev_inst *sdi, uint64_t sample_rate); // set sample rate
+SR_PRIV int tlf_samplerate_get(const struct sr_dev_inst *sdi, uint64_t *sample_rate); // get sample rate
+
+SR_PRIV int tlf_samples_set(const struct sr_dev_inst *sdi, int32_t samples); // set samples count
+SR_PRIV int tlf_samples_get(const struct sr_dev_inst *sdi, int32_t *samples); // get samples count
+SR_PRIV int tlf_maxsamples_get(const struct sr_dev_inst *sdi); // get max samples, store in device context
+
+SR_PRIV int tlf_channel_state_set(const struct sr_dev_inst *sdi, int32_t channel_index, gboolean enabled); // set channel status
+SR_PRIV int tlf_channel_state_get(const struct sr_dev_inst *sdi, int32_t channel_index, gboolean *enabled); // get channel status
+SR_PRIV int tlf_channels_list(struct sr_dev_inst *sdi); // gets channel names from device
+
+SR_PRIV int tlf_trigger_list(const struct sr_dev_inst *sdi); // get list of trigger options
+SR_PRIV int tlf_trigger_set(const struct sr_dev_inst *sdi, int32_t channel_index, char * trigger); // set trigger
+
+SR_PRIV int tlf_RLE_mode_get(const struct sr_dev_inst *sdi); // get data mode, Run Length Encoded or Clock
+
+SR_PRIV int tlf_exec_run(const struct sr_dev_inst *sdi); // start measurement
+SR_PRIV int tlf_exec_stop(const struct sr_dev_inst *sdi); // stop measurement
+
+SR_PRIV int tlf_receive_data(int fd, int revents, void *cb_data);
+
+#endif


### PR DESCRIPTION
Implements a `libsigrok` device driver for the [TinyLogicFriend](https://github.com/kmatch98/tinylogicfriend?organization=kmatch98&organization=kmatch98).  

## Objective:
Affordable, high-quality development boards are now available to many users.  Many of these boards have adequate capabilities for use as a logic analyzer.  But the need to be able to interface with available, high-quality software that can decode and visualize the signals.

This TinyLogicFriend driver is designed to interface **sigrok** and **PulseView** with a wide array of affordable development boards as a logic analyzer.  In contrast to most `sigrok` drivers where all of device's capabilities are predefined in the driver, this TinyLogicFriend driver strives to rely on the board to inform the driver about its specifical capabilities (pin names, sample rates, triggers, etc).

While the initial demonstrations have been performed using Cortex M4 boards from Adafruit, the [TinyLogicFriend firmware code](https://github.com/kmatch98/tinylogicfriend) is organized to be adaptable to other boards and other chip families.  This driver is designed to support TinyLogicFriend logic analyzers with either Run-Length-Encoding or pure sampling.  See the "SCPI command set" for insights into the various device options (sample rates, trigger options, etc.) that are currently supported and tested by this driver. 

**Main, main, main Objective**: A driver that will allow a wide array of development boards to be used as a logic analyzer with `sigrok` and `PulseView`.

## Current status: 
Has been demonstrated with the [TinyLogicFriend firmware](https://github.com/kmatch98/tinylogicfriend?organization=kmatch98&organization=kmatch98) on three ARM Cortex M4-based development boards:
- Adafruit Metro M4 Express
- Adafruit Feather M4 Express
- Adafruit ItsyBitsy M4 Express

These boards have successfully demonstrated decoding of I2C signals operating at 100kHz.  

With the current firmware, these boards use Run-Length-Encoding to sample and store the measurements, and then this driver transfers the RLE-encoded signals into `sigrok` and `PulseView`. 

These demo boards can measure up to 11 simultaneous channels. The current ARM Cortex M4 firmware supports a maximum of 16 channels if the appropriate pins are broken out. The board's firmware can be loaded by copying a `.UF2` onto the board.  Boards with an attached Neopixel provide a status indicator light.  The channel names are collected from the board during the `scan` operation, and pin names correspond to the silkscreen markings on the board.  

See below the sample image taken from decoding an I2C-connected, SSD1305 OLED display measured using an Adafruit ItsyBitsy M4 Express TinyLogicFriend.  On this ItsyBitsy M4 Express TinyLogicFriend, 11 channels are available.  Please note that the channel pin names match the silkscreen on this board.

<img width="1172" alt="image" src="https://user-images.githubusercontent.com/33587466/117486847-cf3ae800-af2f-11eb-95fa-f1c225c70145.png">




## Communication with the device: 
This `libsigrok` driver communicates with the TinyLogicFriend analyzer using USB Test and Measurement Class (USBTMC).  The following list shows the SCPI commands that are [currently implemented in the TinyLogicFriend firmware](https://github.com/kmatch98/tinylogicfriend?organization=kmatch98&organization=kmatch98):

------

#### Communication protocol: SCPI command set

This is the set of commands currently supported by this `libsigrok` driver and the TinyLogicFriend firmware.  The following commands that are [x] _checked_ have been implemented in the TinyLogicFriend firmware SCPI parser.  Note: Some commands have not been "hooked-up" or verified in the initial firmware demonstrations, with the status as noted in the parenthetical comments below.

- [x] `IDN?` Get identification details of the board

- [x] `CHANnel:COUNT?` Get number of channels

- [x] `CHANnel<n>:NAME?` Get channel number \<n\> name

- [x] `CHANnel<n>:STATus` either  `OFF` or `ON` Set channel reading status (Implemented in parser, but not hooked up to chip controls.)

- [x] `CHANnel<n>:STATus?` Get channel read status (Implemented in parser, but not hooked up to chip controls.)

- [ ] `CHANnel<n>:FILTer` either `OFF` or `ON` For Run-length encoding mode, whether filtering is placed on the interrupt pin. (Is interrupt filtering applied for all pins or each individually?)

- [ ] `CHANnel<n>:FILTer?` Get filter status, only relevant when `MODE RLE`

- [x] `TRIGger:OPTions?` (Implemented in parser, but not hooked up to chip controls.)

    Get trigger options `<v>`
    * X=trigger off
    * 0=on zero
    * 1=on one
    * R=rising
    * F=falling
    * E=any edge

- [x] `CHANnel<n>:TRIGger <v>` Set trigger type (Implemented in parser, but not hooked up to chip controls.)

- [x] `CHANnel<n>:TRIGger?` Get trigger type for channel `<n>` (Implemented in parser, but not hooked up to chip controls.)

- [x] `RATE:MIN?` Get *minimum* sampling rate (in Hz)

- [x] `RATE:MAX?` Get *maximum* sampling rate (in Hz)

- [x] `RATE:STEP?` Get sampling rate step size (in Hz)

- [x] `RATE <xxxx>` Set sampling rate

- [x] `RATE?` Get sampling rate

- [x] `SAMPles <xxx>` Set number of samples to be captured. Set to 0 for continuous sampling. Sample count is relative to the sampling rate clock, even when run-length encoding is used

- [x] `SAMPles?` Get number of samples

- [x] `SAMPles:MAX?` Get maximum number of samples

- [ ] `MODE <Y>` Either `RLE` or `CLOCK`.  Run-length encoded or sample at configured sampling rate.

- [x] `MODE?` Either `RLE` or `CLOCK` (Note: RLE has been verified, CLOCK has not been tested.)

- [x] `Run` Start measurement

- [x] `STOP` Stop measurement

- [x] `DATA?` Request a data packet



