### PR TITLE
fix memory-leak in scpi_vxi_read_data()

### DIFF
--- a/src/scpi/scpi_vxi.c
+++ b/src/scpi/scpi_vxi.c
@@ -190,6 +190,7 @@ static int scpi_vxi_read_data(void *priv, char *buf, int maxlen)
 	}
 
 	memcpy(buf, read_resp->data.data_val, read_resp->data.data_len);
+	free(read_resp->data.data_val);
 	vxi->read_complete = read_resp->reason & (RRR_TERM | RRR_END);
 	return read_resp->data.data_len;  /* actual number of bytes received */
 }


### PR DESCRIPTION
Allocated memory was not free'd.

here is the relevant part of valgrind report:
==836576== 385,578 bytes in 124 blocks are definitely lost in loss record 309 of 309
==836576==    at 0x483BAE9: calloc (vg_replace_malloc.c:760)
==836576==    by 0x4D4028C: xdr_bytes (in /usr/lib64/libtirpc.so.3.0.0)
==836576==    by 0x48F8DA4: xdr_Device_ReadResp (vxi_xdr.c:216)
==836576==    by 0x4D3BC45: ??? (in /usr/lib64/libtirpc.so.3.0.0)
==836576==    by 0x48F84A7: device_read_1 (vxi_clnt.c:66)
==836576==    by 0x48F8079: scpi_vxi_read_data (scpi_vxi.c:185)
==836576==    by 0x48F60BF: scpi_read_response.isra.0 (scpi.c:239)
==836576==    by 0x48F6195: scpi_get_data (scpi.c:302)
==836576==    by 0x48F69B0: sr_scpi_get_data (scpi.c:675)
==836576==    by 0x48F69B0: sr_scpi_get_string (scpi.c:625)