### PR TITLE
SR_CONF_xxx: Clarify rationale behind unusual key

### DIFF
--- a/include/libsigrok/libsigrok.h
+++ b/include/libsigrok/libsigrok.h
@@ -836,7 +836,11 @@ enum sr_configkey {
 	/** Trigger matches. */
 	SR_CONF_TRIGGER_MATCH,
 
-	/** The device supports setting its sample interval, in ms. */
+	/**
+	 * The device supports setting its sample interval, in ms.
+	 * This is only used for devices that only support <1Hz sample rates.
+	 * @sa SR_CONF_SAMPLERATE
+	 */
 	SR_CONF_SAMPLE_INTERVAL,
 
 	/** Number of horizontal divisions, as related to SR_CONF_TIMEBASE. */


### PR DESCRIPTION
As reported on IRC, meaning of SR_CONF_SAMPLE_INTERVAL is unclear.  We already have doxygen comments, we can use them, and rather than simply repeating the field name, provide some context.