### PR TITLE
OLS improvements, chunk 3

### DIFF
--- a/src/hardware/openbench-logic-sniffer/api.c
+++ b/src/hardware/openbench-logic-sniffer/api.c
@@ -48,9 +48,9 @@ static const int32_t trigger_matches[] = {
 	SR_TRIGGER_ONE,
 };
 
-static const char* external_clock_edges[] = {
-	"rising", // positive edge
-	"falling" // negative edge
+static const char *external_clock_edges[] = {
+	"rising", /* positive edge */
+	"falling" /* negative edge */
 };
 
 #define STR_PATTERN_NONE     "None"
@@ -146,7 +146,8 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 		return NULL;
 	}
 
-	num_read = serial_read_blocking(serial, buf, 4, serial_timeout(serial, 4));
+	num_read =
+		serial_read_blocking(serial, buf, 4, serial_timeout(serial, 4));
 	if (num_read < 0) {
 		sr_err("Getting ID reply failed (%d).", num_read);
 		return NULL;
@@ -181,13 +182,13 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 		sdi->version = g_strdup("v1.0");
 		for (i = 0; i < ARRAY_SIZE(ols_channel_names); i++)
 			sr_channel_new(sdi, i, SR_CHANNEL_LOGIC, TRUE,
-					ols_channel_names[i]);
+				       ols_channel_names[i]);
 		sdi->priv = ols_dev_new();
 	}
 	/* Configure samplerate and divider. */
 	if (ols_set_samplerate(sdi, DEFAULT_SAMPLERATE) != SR_OK)
-		sr_dbg("Failed to set default samplerate (%"PRIu64").",
-				DEFAULT_SAMPLERATE);
+		sr_dbg("Failed to set default samplerate (%" PRIu64 ").",
+		       DEFAULT_SAMPLERATE);
 	sdi->inst_type = SR_INST_SERIAL;
 	sdi->conn = serial;
 
@@ -197,7 +198,8 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 }
 
 static int config_get(uint32_t key, GVariant **data,
-	const struct sr_dev_inst *sdi, const struct sr_channel_group *cg)
+		      const struct sr_dev_inst *sdi,
+		      const struct sr_channel_group *cg)
 {
 	struct dev_context *devc;
 
@@ -227,15 +229,18 @@ static int config_get(uint32_t key, GVariant **data,
 			*data = g_variant_new_string(STR_PATTERN_NONE);
 		break;
 	case SR_CONF_RLE:
-		*data = g_variant_new_boolean(devc->capture_flags & CAPTURE_FLAG_RLE ? TRUE : FALSE);
+		*data = g_variant_new_boolean(
+			devc->capture_flags & CAPTURE_FLAG_RLE ? TRUE : FALSE);
 		break;
 	case SR_CONF_EXTERNAL_CLOCK:
 		*data = g_variant_new_boolean(
-			devc->capture_flags & CAPTURE_FLAG_CLOCK_EXTERNAL ? TRUE : FALSE);
+			devc->capture_flags & CAPTURE_FLAG_CLOCK_EXTERNAL
+			? TRUE : FALSE);
 		break;
 	case SR_CONF_CLOCK_EDGE:
 		*data = g_variant_new_string(external_clock_edges[
-			devc->capture_flags & CAPTURE_FLAG_INVERT_EXT_CLOCK ? 1 : 0]);
+			devc->capture_flags & CAPTURE_FLAG_INVERT_EXT_CLOCK
+			? 1 : 0]);
 		break;
 	default:
 		return SR_ERR_NA;
@@ -245,7 +250,8 @@ static int config_get(uint32_t key, GVariant **data,
 }
 
 static int config_set(uint32_t key, GVariant *data,
-	const struct sr_dev_inst *sdi, const struct sr_channel_group *cg)
+		      const struct sr_dev_inst *sdi,
+		      const struct sr_channel_group *cg)
 {
 	struct dev_context *devc;
 	uint16_t flag;
@@ -334,7 +340,8 @@ static int config_set(uint32_t key, GVariant *data,
 }
 
 static int config_list(uint32_t key, GVariant **data,
-	const struct sr_dev_inst *sdi, const struct sr_channel_group *cg)
+		       const struct sr_dev_inst *sdi,
+		       const struct sr_channel_group *cg)
 {
 	struct dev_context *devc;
 	int num_ols_changrp, i;
@@ -342,7 +349,8 @@ static int config_list(uint32_t key, GVariant **data,
 	switch (key) {
 	case SR_CONF_SCAN_OPTIONS:
 	case SR_CONF_DEVICE_OPTIONS:
-		return STD_CONFIG_LIST(key, data, sdi, cg, scanopts, drvopts, devopts);
+		return STD_CONFIG_LIST(key, data, sdi, cg, scanopts, drvopts,
+				       devopts);
 	case SR_CONF_SAMPLERATE:
 		*data = std_gvar_samplerates_steps(ARRAY_AND_SIZE(samplerates));
 		break;
@@ -375,8 +383,8 @@ static int config_list(uint32_t key, GVariant **data,
 				num_ols_changrp++;
 		}
 
-		*data = std_gvar_tuple_u64(MIN_NUM_SAMPLES,
-			(num_ols_changrp) ? devc->max_samples / num_ols_changrp : MIN_NUM_SAMPLES);
+		*data = std_gvar_tuple_u64(MIN_NUM_SAMPLES, (num_ols_changrp)
+			? devc->max_samples / num_ols_changrp : MIN_NUM_SAMPLES);
 		break;
 	default:
 		return SR_ERR_NA;
@@ -413,8 +421,8 @@ static int dev_acquisition_start(const struct sr_dev_inst *sdi)
 	/* If the device stops sending for longer than it takes to send a byte,
 	 * that means it's finished. But wait at least 100 ms to be safe.
 	 */
-	serial_source_add(sdi->session, serial, G_IO_IN, 100,
-			ols_receive_data, (struct sr_dev_inst *)sdi);
+	serial_source_add(sdi->session, serial, G_IO_IN, 100, ols_receive_data,
+			  (struct sr_dev_inst *)sdi);
 
 	return SR_OK;
 }

--- a/src/hardware/openbench-logic-sniffer/api.c
+++ b/src/hardware/openbench-logic-sniffer/api.c
@@ -367,8 +367,6 @@ static int config_list(uint32_t key, GVariant **data,
 		if (!sdi)
 			return SR_ERR_ARG;
 		devc = sdi->priv;
-		if (devc->capture_flags & CAPTURE_FLAG_RLE)
-			return SR_ERR_NA;
 		if (devc->max_samples == 0)
 			/* Device didn't specify sample memory size in metadata. */
 			return SR_ERR_NA;

--- a/src/hardware/openbench-logic-sniffer/api.c
+++ b/src/hardware/openbench-logic-sniffer/api.c
@@ -419,10 +419,8 @@ static int dev_acquisition_start(const struct sr_dev_inst *sdi)
 	/* If the device stops sending for longer than it takes to send a byte,
 	 * that means it's finished. But wait at least 100 ms to be safe.
 	 */
-	serial_source_add(sdi->session, serial, G_IO_IN, 100, ols_receive_data,
-			  (struct sr_dev_inst *)sdi);
-
-	return SR_OK;
+	return serial_source_add(sdi->session, serial, G_IO_IN, 100,
+				 ols_receive_data, (struct sr_dev_inst *)sdi);
 }
 
 static int dev_acquisition_stop(struct sr_dev_inst *sdi)

--- a/src/hardware/openbench-logic-sniffer/protocol.c
+++ b/src/hardware/openbench-logic-sniffer/protocol.c
@@ -27,7 +27,7 @@ struct ols_basic_trigger_desc {
 };
 
 SR_PRIV int send_shortcommand(struct sr_serial_dev_inst *serial,
-		uint8_t command)
+			      uint8_t command)
 {
 	char buf[1];
 
@@ -42,13 +42,13 @@ SR_PRIV int send_shortcommand(struct sr_serial_dev_inst *serial,
 	return SR_OK;
 }
 
-SR_PRIV int send_longcommand(struct sr_serial_dev_inst *serial,
-		uint8_t command, uint8_t *data)
+SR_PRIV int send_longcommand(struct sr_serial_dev_inst *serial, uint8_t command,
+			     uint8_t *data)
 {
 	char buf[5];
 
-	sr_dbg("Sending cmd 0x%.2x data 0x%.2x%.2x%.2x%.2x.", command,
-			data[0], data[1], data[2], data[3]);
+	sr_dbg("Sending cmd 0x%.2x data 0x%.2x%.2x%.2x%.2x.", command, data[0],
+	       data[1], data[2], data[3]);
 	buf[0] = command;
 	buf[1] = data[0];
 	buf[2] = data[1];
@@ -63,8 +63,8 @@ SR_PRIV int send_longcommand(struct sr_serial_dev_inst *serial,
 	return SR_OK;
 }
 
-static int ols_send_longdata(struct sr_serial_dev_inst *serial,
-		uint8_t command, uint32_t value)
+static int ols_send_longdata(struct sr_serial_dev_inst *serial, uint8_t command,
+			     uint32_t value)
 {
 	uint8_t data[4];
 	WL32(data, value);
@@ -96,7 +96,8 @@ SR_PRIV uint32_t ols_channel_mask(const struct sr_dev_inst *sdi)
 	return channel_mask;
 }
 
-static int convert_trigger(const struct sr_dev_inst *sdi, struct ols_basic_trigger_desc *ols_trigger)
+static int convert_trigger(const struct sr_dev_inst *sdi,
+			   struct ols_basic_trigger_desc *ols_trigger)
 {
 	struct sr_trigger *trigger;
 	struct sr_trigger_stage *stage;
@@ -116,7 +117,7 @@ static int convert_trigger(const struct sr_dev_inst *sdi, struct ols_basic_trigg
 	ols_trigger->num_stages = g_slist_length(trigger->stages);
 	if (ols_trigger->num_stages > NUM_BASIC_TRIGGER_STAGES) {
 		sr_err("This device only supports %d trigger stages.",
-				NUM_BASIC_TRIGGER_STAGES);
+		       NUM_BASIC_TRIGGER_STAGES);
 		return SR_ERR;
 	}
 
@@ -127,9 +128,11 @@ static int convert_trigger(const struct sr_dev_inst *sdi, struct ols_basic_trigg
 			if (!match->channel->enabled)
 				/* Ignore disabled channels with a trigger. */
 				continue;
-			ols_trigger->trigger_mask[stage->stage] |= 1 << match->channel->index;
+			ols_trigger->trigger_mask[stage->stage] |=
+				1 << match->channel->index;
 			if (match->match == SR_TRIGGER_ONE)
-				ols_trigger->trigger_value[stage->stage] |= 1 << match->channel->index;
+				ols_trigger->trigger_value[stage->stage] |=
+					1 << match->channel->index;
 		}
 	}
 
@@ -153,7 +156,7 @@ static void ols_channel_new(struct sr_dev_inst *sdi, int num_chan)
 
 	for (i = 0; i < num_chan; i++)
 		sr_channel_new(sdi, i, SR_CHANNEL_LOGIC, TRUE,
-				ols_channel_names[i]);
+			       ols_channel_names[i]);
 
 	devc->max_channels = num_chan;
 }
@@ -216,13 +219,17 @@ SR_PRIV struct sr_dev_inst *get_metadata(struct sr_serial_dev_inst *serial)
 			/* NULL-terminated string */
 			tmp_str = g_string_new("");
 			delay_ms = serial_timeout(serial, 1);
-			while (serial_read_blocking(serial, &tmp_c, 1, delay_ms) == 1 && tmp_c != '\0')
+			while (serial_read_blocking(serial, &tmp_c, 1,
+						    delay_ms) == 1 &&
+			       tmp_c != '\0')
 				g_string_append_c(tmp_str, tmp_c);
-			sr_dbg("Got metadata token 0x%.2x value '%s'.", key, tmp_str->str);
+			sr_dbg("Got metadata token 0x%.2x value '%s'.", key,
+			       tmp_str->str);
 			switch (key) {
 			case METADATA_TOKEN_DEVICE_NAME:
 				/* Device name */
-				devname = g_string_append(devname, tmp_str->str);
+				devname =
+					g_string_append(devname, tmp_str->str);
 				break;
 			case METADATA_TOKEN_FPGA_VERSION:
 				/* FPGA firmware version */
@@ -239,7 +246,8 @@ SR_PRIV struct sr_dev_inst *get_metadata(struct sr_serial_dev_inst *serial)
 				g_string_append(version, tmp_str->str);
 				break;
 			default:
-				sr_info("ols: unknown token 0x%.2x: '%s'", key, tmp_str->str);
+				sr_info("ols: unknown token 0x%.2x: '%s'", key,
+					tmp_str->str);
 				break;
 			}
 			g_string_free(tmp_str, TRUE);
@@ -247,10 +255,12 @@ SR_PRIV struct sr_dev_inst *get_metadata(struct sr_serial_dev_inst *serial)
 		case 1:
 			/* 32-bit unsigned integer */
 			delay_ms = serial_timeout(serial, 4);
-			if (serial_read_blocking(serial, &tmp_int, 4, delay_ms) != 4)
+			if (serial_read_blocking(serial, &tmp_int, 4,
+						 delay_ms) != 4)
 				break;
 			tmp_int = RB32(&tmp_int);
-			sr_dbg("Got metadata token 0x%.2x value 0x%.8x.", key, tmp_int);
+			sr_dbg("Got metadata token 0x%.2x value 0x%.8x.", key,
+			       tmp_int);
 			switch (key) {
 			case METADATA_TOKEN_NUM_PROBES_LONG:
 				/* Number of usable channels */
@@ -273,7 +283,8 @@ SR_PRIV struct sr_dev_inst *get_metadata(struct sr_serial_dev_inst *serial)
 				devc->protocol_version = tmp_int;
 				break;
 			default:
-				sr_info("Unknown token 0x%.2x: 0x%.8x.", key, tmp_int);
+				sr_info("Unknown token 0x%.2x: 0x%.8x.", key,
+					tmp_int);
 				break;
 			}
 			break;
@@ -282,7 +293,8 @@ SR_PRIV struct sr_dev_inst *get_metadata(struct sr_serial_dev_inst *serial)
 			delay_ms = serial_timeout(serial, 1);
 			if (serial_read_blocking(serial, &tmp_c, 1, delay_ms) != 1)
 				break;
-			sr_dbg("Got metadata token 0x%.2x value 0x%.2x.", key, tmp_c);
+			sr_dbg("Got metadata token 0x%.2x value 0x%.2x.", key,
+			       tmp_c);
 			switch (key) {
 			case METADATA_TOKEN_NUM_PROBES_SHORT:
 				/* Number of usable channels */
@@ -293,7 +305,8 @@ SR_PRIV struct sr_dev_inst *get_metadata(struct sr_serial_dev_inst *serial)
 				devc->protocol_version = tmp_c;
 				break;
 			default:
-				sr_info("Unknown token 0x%.2x: 0x%.2x.", key, tmp_c);
+				sr_info("Unknown token 0x%.2x: 0x%.2x.", key,
+					tmp_c);
 				break;
 			}
 			break;
@@ -315,7 +328,7 @@ SR_PRIV struct sr_dev_inst *get_metadata(struct sr_serial_dev_inst *serial)
 }
 
 SR_PRIV int ols_set_samplerate(const struct sr_dev_inst *sdi,
-		const uint64_t samplerate)
+			       const uint64_t samplerate)
 {
 	struct dev_context *devc;
 
@@ -327,7 +340,8 @@ SR_PRIV int ols_set_samplerate(const struct sr_dev_inst *sdi,
 		sr_info("Enabling demux mode.");
 		devc->capture_flags |= CAPTURE_FLAG_DEMUX;
 		devc->capture_flags &= ~CAPTURE_FLAG_NOISE_FILTER;
-		devc->cur_samplerate_divider = (CLOCK_RATE * 2 / samplerate) - 1;
+		devc->cur_samplerate_divider =
+			(CLOCK_RATE * 2 / samplerate) - 1;
 	} else {
 		sr_info("Disabling demux mode.");
 		devc->capture_flags &= ~CAPTURE_FLAG_DEMUX;
@@ -342,8 +356,9 @@ SR_PRIV int ols_set_samplerate(const struct sr_dev_inst *sdi,
 	if (devc->capture_flags & CAPTURE_FLAG_DEMUX)
 		devc->cur_samplerate *= 2;
 	if (devc->cur_samplerate != samplerate)
-		sr_info("Can't match samplerate %" PRIu64 ", using %"
-		       PRIu64 ".", samplerate, devc->cur_samplerate);
+		sr_info("Can't match samplerate %" PRIu64 ", using %" PRIu64
+			".",
+			samplerate, devc->cur_samplerate);
 
 	return SR_OK;
 }
@@ -418,9 +433,11 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 			 * Got a full sample. Convert from the OLS's little-endian
 			 * sample to the local format.
 			 */
-			sample = devc->sample[0] | (devc->sample[1] << 8) \
-					| (devc->sample[2] << 16) | (devc->sample[3] << 24);
-			sr_dbg("Received sample 0x%.*x.", devc->num_bytes * 2, sample);
+			sample = devc->sample[0] | (devc->sample[1] << 8) |
+				 (devc->sample[2] << 16) |
+				 (devc->sample[3] << 24);
+			sr_dbg("Received sample 0x%.*x.", devc->num_bytes * 2,
+			       sample);
 			if (devc->capture_flags & CAPTURE_FLAG_RLE) {
 				/*
 				 * In RLE mode the high bit of the sample is the
@@ -429,10 +446,13 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 				 */
 				if (devc->sample[devc->num_bytes - 1] & 0x80) {
 					/* Clear the high bit. */
-					sample &= ~(0x80 << (devc->num_bytes - 1) * 8);
+					sample &= ~(0x80 << (devc->num_bytes -
+							     1) * 8);
 					devc->rle_count = sample;
-					devc->cnt_samples_rle += devc->rle_count;
-					sr_dbg("RLE count: %u.", devc->rle_count);
+					devc->cnt_samples_rle +=
+						devc->rle_count;
+					sr_dbg("RLE count: %u.",
+					       devc->rle_count);
 					devc->num_bytes = 0;
 					return TRUE;
 				}
@@ -440,7 +460,8 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 			devc->num_samples += devc->rle_count + 1;
 			if (devc->num_samples > devc->limit_samples) {
 				/* Save us from overrunning the buffer. */
-				devc->rle_count -= devc->num_samples - devc->limit_samples;
+				devc->rle_count -=
+					devc->num_samples - devc->limit_samples;
 				devc->num_samples = devc->limit_samples;
 			}
 
@@ -457,21 +478,27 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 				j = 0;
 				memset(devc->tmp_sample, 0, 4);
 				for (i = 0; i < 4; i++) {
-					if (((devc->capture_flags >> 2) & (1 << i)) == 0) {
+					if (((devc->capture_flags >> 2) &
+					     (1 << i)) == 0) {
 						/*
 						 * This channel group was
 						 * enabled, copy from received
 						 * sample.
 						 */
-						devc->tmp_sample[i] = devc->sample[j++];
-					} else if (devc->capture_flags & CAPTURE_FLAG_DEMUX && (i > 2)) {
+						devc->tmp_sample[i] =
+							devc->sample[j++];
+					} else if (devc->capture_flags &
+							   CAPTURE_FLAG_DEMUX &&
+						   (i > 2)) {
 						/* group 2 & 3 get added to 0 & 1 */
-						devc->tmp_sample[i - 2] = devc->sample[j++];
+						devc->tmp_sample[i - 2] =
+							devc->sample[j++];
 					}
 				}
 				memcpy(devc->sample, devc->tmp_sample, 4);
 				sr_spew("Expanded sample: 0x%.2hhx%.2hhx%.2hhx%.2hhx ",
-					devc->sample[3], devc->sample[2], devc->sample[1], devc->sample[0]);
+					devc->sample[3], devc->sample[2],
+					devc->sample[1], devc->sample[0]);
 			}
 
 			/*
@@ -495,8 +522,8 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 		 * Send the (properly-ordered) buffer to the frontend.
 		 */
 		sr_dbg("Received %d bytes, %d samples, %d decompressed samples.",
-				devc->cnt_bytes, devc->cnt_samples,
-				devc->cnt_samples_rle);
+		       devc->cnt_bytes, devc->cnt_samples,
+		       devc->cnt_samples_rle);
 		if (devc->trigger_at_smpl != OLS_NO_TRIGGER) {
 			/*
 			 * A trigger was set up, so we need to tell the frontend
@@ -509,7 +536,9 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 				logic.length = devc->trigger_at_smpl * 4;
 				logic.unitsize = 4;
 				logic.data = devc->raw_sample_buf +
-					(devc->limit_samples - devc->num_samples) * 4;
+					     (devc->limit_samples -
+					      devc->num_samples) *
+						     4;
 				sr_session_send(sdi, &packet);
 			}
 
@@ -518,14 +547,19 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 		}
 
 		/* Send post-trigger / all captured samples. */
-		int num_pre_trigger_samples = devc->trigger_at_smpl == OLS_NO_TRIGGER
-			? 0 : devc->trigger_at_smpl;
+		int num_pre_trigger_samples = devc->trigger_at_smpl ==
+							      OLS_NO_TRIGGER ?
+							    0 :
+							    devc->trigger_at_smpl;
 		packet.type = SR_DF_LOGIC;
 		packet.payload = &logic;
-		logic.length = (devc->num_samples - num_pre_trigger_samples) * 4;
+		logic.length =
+			(devc->num_samples - num_pre_trigger_samples) * 4;
 		logic.unitsize = 4;
-		logic.data = devc->raw_sample_buf + (num_pre_trigger_samples +
-			devc->limit_samples - devc->num_samples) * 4;
+		logic.data = devc->raw_sample_buf +
+			     (num_pre_trigger_samples + devc->limit_samples -
+			      devc->num_samples) *
+				     4;
 		sr_session_send(sdi, &packet);
 
 		g_free(devc->raw_sample_buf);
@@ -537,7 +571,9 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 	return TRUE;
 }
 
-static int ols_set_basic_trigger_stage(const struct ols_basic_trigger_desc *trigger_desc, struct sr_serial_dev_inst *serial, int stage)
+static int
+ols_set_basic_trigger_stage(const struct ols_basic_trigger_desc *trigger_desc,
+			    struct sr_serial_dev_inst *serial, int stage)
 {
 	uint8_t cmd, arg[4];
 
@@ -561,7 +597,8 @@ static int ols_set_basic_trigger_stage(const struct ols_basic_trigger_desc *trig
 	return SR_OK;
 }
 
-SR_PRIV int ols_prepare_acquisition(const struct sr_dev_inst *sdi) {
+SR_PRIV int ols_prepare_acquisition(const struct sr_dev_inst *sdi)
+{
 	int ret;
 
 	struct dev_context *devc = sdi->priv;
@@ -581,7 +618,8 @@ SR_PRIV int ols_prepare_acquisition(const struct sr_dev_inst *sdi) {
 	 * Limit readcount to prevent reading past the end of the hardware
 	 * buffer. Rather read too many samples than too few.
 	 */
-	uint32_t samplecount = MIN(devc->max_samples / num_changroups, devc->limit_samples);
+	uint32_t samplecount =
+		MIN(devc->max_samples / num_changroups, devc->limit_samples);
 	uint32_t readcount = (samplecount + 3) / 4;
 	uint32_t delaycount;
 
@@ -601,53 +639,66 @@ SR_PRIV int ols_prepare_acquisition(const struct sr_dev_inst *sdi) {
 			return SR_ERR;
 
 		delaycount = readcount * (1 - devc->capture_ratio / 100.0);
-		devc->trigger_at_smpl = (readcount - delaycount) * 4 - basic_trigger_desc.num_stages;
+		devc->trigger_at_smpl = (readcount - delaycount) * 4 -
+					basic_trigger_desc.num_stages;
 		for (int i = 0; i <= basic_trigger_desc.num_stages; i++) {
 			sr_dbg("Setting OLS stage %d trigger.", i);
-			if ((ret = ols_set_basic_trigger_stage(&basic_trigger_desc, serial, i)) != SR_OK)
+			if ((ret = ols_set_basic_trigger_stage(
+				     &basic_trigger_desc, serial, i)) != SR_OK)
 				return ret;
 		}
 	} else {
 		/* No triggers configured, force trigger on first stage. */
 		sr_dbg("Forcing trigger at stage 0.");
-		if ((ret = ols_set_basic_trigger_stage(&basic_trigger_desc, serial, 0)) != SR_OK)
+		if ((ret = ols_set_basic_trigger_stage(&basic_trigger_desc,
+						       serial, 0)) != SR_OK)
 			return ret;
 		delaycount = readcount;
 	}
 
 	/* Samplerate. */
 	sr_dbg("Setting samplerate to %" PRIu64 "Hz (divider %u)",
-			devc->cur_samplerate, devc->cur_samplerate_divider);
-	if (ols_send_longdata(serial, CMD_SET_DIVIDER, devc->cur_samplerate_divider & 0x00FFFFFF) != SR_OK)
+	       devc->cur_samplerate, devc->cur_samplerate_divider);
+	if (ols_send_longdata(serial, CMD_SET_DIVIDER,
+			      devc->cur_samplerate_divider & 0x00FFFFFF) != SR_OK)
 		return SR_ERR;
 
 	/* Send sample limit and pre/post-trigger capture ratio. */
 	sr_dbg("Setting sample limit %d, trigger point at %d",
-			(readcount - 1) * 4, (delaycount - 1) * 4);
+	       (readcount - 1) * 4, (delaycount - 1) * 4);
 
 	if (devc->max_samples > 256 * 1024) {
-		if (ols_send_longdata(serial, CMD_CAPTURE_READCOUNT, readcount-1) != SR_OK)
+		if (ols_send_longdata(serial, CMD_CAPTURE_READCOUNT,
+				      readcount - 1) != SR_OK)
 			return SR_ERR;
-		if (ols_send_longdata(serial, CMD_CAPTURE_DELAYCOUNT, delaycount-1) != SR_OK)
+		if (ols_send_longdata(serial, CMD_CAPTURE_DELAYCOUNT,
+				      delaycount - 1) != SR_OK)
 			return SR_ERR;
 	} else {
 		uint8_t arg[4];
-		WL16(&arg[0], readcount-1);
-		WL16(&arg[2], delaycount-1);
+		WL16(&arg[0], readcount - 1);
+		WL16(&arg[2], delaycount - 1);
 		if (send_longcommand(serial, CMD_CAPTURE_SIZE, arg) != SR_OK)
 			return SR_ERR;
 	}
 
 	/* Flag register. */
-	sr_dbg("Setting intpat %s, extpat %s, RLE %s, noise_filter %s, demux %s, %s clock%s",
-			devc->capture_flags & CAPTURE_FLAG_INTERNAL_TEST_MODE ? "on": "off",
-			devc->capture_flags & CAPTURE_FLAG_EXTERNAL_TEST_MODE ? "on": "off",
-			devc->capture_flags & CAPTURE_FLAG_RLE ? "on" : "off",
-			devc->capture_flags & CAPTURE_FLAG_NOISE_FILTER ? "on": "off",
-			devc->capture_flags & CAPTURE_FLAG_DEMUX ? "on" : "off",
-			devc->capture_flags & CAPTURE_FLAG_CLOCK_EXTERNAL ? "external" : "internal",
-			devc->capture_flags & CAPTURE_FLAG_CLOCK_EXTERNAL ? (devc->capture_flags & CAPTURE_FLAG_INVERT_EXT_CLOCK
-				? " on falling edge" : "on rising edge") : "");
+	sr_dbg("Setting intpat %s, extpat %s, RLE %s, noise_filter %s, demux %s, "
+	       "%s clock%s",
+	       devc->capture_flags & CAPTURE_FLAG_INTERNAL_TEST_MODE ? "on" :
+									     "off",
+	       devc->capture_flags & CAPTURE_FLAG_EXTERNAL_TEST_MODE ? "on" :
+									     "off",
+	       devc->capture_flags & CAPTURE_FLAG_RLE ? "on" : "off",
+	       devc->capture_flags & CAPTURE_FLAG_NOISE_FILTER ? "on" : "off",
+	       devc->capture_flags & CAPTURE_FLAG_DEMUX ? "on" : "off",
+	       devc->capture_flags & CAPTURE_FLAG_CLOCK_EXTERNAL ? "external" :
+									 "internal",
+	       devc->capture_flags & CAPTURE_FLAG_CLOCK_EXTERNAL ?
+			     (devc->capture_flags & CAPTURE_FLAG_INVERT_EXT_CLOCK ?
+				      " on falling edge" :
+				      "on rising edge") :
+			     "");
 
 	/*
 	 * Enable/disable OLS channel groups in the flag register according

--- a/src/hardware/openbench-logic-sniffer/protocol.c
+++ b/src/hardware/openbench-logic-sniffer/protocol.c
@@ -487,12 +487,6 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 						 */
 						tmp_sample[i] =
 							devc->sample[j++];
-					} else if (devc->capture_flags &
-							   CAPTURE_FLAG_DEMUX &&
-						   (i > 2)) {
-						/* group 2 & 3 get added to 0 & 1 */
-						tmp_sample[i - 2] =
-							devc->sample[j++];
 					}
 				}
 				memcpy(devc->sample, tmp_sample, 4);

--- a/src/hardware/openbench-logic-sniffer/protocol.c
+++ b/src/hardware/openbench-logic-sniffer/protocol.c
@@ -582,7 +582,7 @@ ols_set_basic_trigger_stage(const struct ols_basic_trigger_desc *trigger_desc,
 	cmd = CMD_SET_BASIC_TRIGGER_CONFIG0 + stage * 4;
 	arg[0] = arg[1] = arg[3] = 0x00;
 	arg[2] = stage;
-	if (stage == trigger_desc->num_stages)
+	if (stage == trigger_desc->num_stages - 1)
 		/* Last stage, fire when this one matches. */
 		arg[3] |= TRIGGER_START;
 	if (send_longcommand(serial, cmd, arg) != SR_OK)
@@ -635,7 +635,7 @@ SR_PRIV int ols_prepare_acquisition(const struct sr_dev_inst *sdi)
 		delaycount = readcount * (1 - devc->capture_ratio / 100.0);
 		devc->trigger_at_smpl = (readcount - delaycount) * 4 -
 					basic_trigger_desc.num_stages;
-		for (int i = 0; i <= basic_trigger_desc.num_stages; i++) {
+		for (int i = 0; i < basic_trigger_desc.num_stages; i++) {
 			sr_dbg("Setting OLS stage %d trigger.", i);
 			if ((ret = ols_set_basic_trigger_stage(
 				     &basic_trigger_desc, serial, i)) != SR_OK)
@@ -644,6 +644,7 @@ SR_PRIV int ols_prepare_acquisition(const struct sr_dev_inst *sdi)
 	} else {
 		/* No triggers configured, force trigger on first stage. */
 		sr_dbg("Forcing trigger at stage 0.");
+		basic_trigger_desc.num_stages = 1;
 		if ((ret = ols_set_basic_trigger_stage(&basic_trigger_desc,
 						       serial, 0)) != SR_OK)
 			return ret;

--- a/src/hardware/openbench-logic-sniffer/protocol.c
+++ b/src/hardware/openbench-logic-sniffer/protocol.c
@@ -476,7 +476,7 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 				 * the number of channels.
 				 */
 				j = 0;
-				memset(devc->tmp_sample, 0, 4);
+				uint8_t tmp_sample[4] = { 0, 0, 0, 0 };
 				for (i = 0; i < 4; i++) {
 					if (((devc->capture_flags >> 2) &
 					     (1 << i)) == 0) {
@@ -485,17 +485,17 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 						 * enabled, copy from received
 						 * sample.
 						 */
-						devc->tmp_sample[i] =
+						tmp_sample[i] =
 							devc->sample[j++];
 					} else if (devc->capture_flags &
 							   CAPTURE_FLAG_DEMUX &&
 						   (i > 2)) {
 						/* group 2 & 3 get added to 0 & 1 */
-						devc->tmp_sample[i - 2] =
+						tmp_sample[i - 2] =
 							devc->sample[j++];
 					}
 				}
-				memcpy(devc->sample, devc->tmp_sample, 4);
+				memcpy(devc->sample, tmp_sample, 4);
 				sr_spew("Expanded sample: 0x%.2hhx%.2hhx%.2hhx%.2hhx ",
 					devc->sample[3], devc->sample[2],
 					devc->sample[1], devc->sample[0]);

--- a/src/hardware/openbench-logic-sniffer/protocol.h
+++ b/src/hardware/openbench-logic-sniffer/protocol.h
@@ -123,7 +123,6 @@ struct dev_context {
 
 	unsigned int rle_count;
 	unsigned char sample[4];
-	unsigned char tmp_sample[4];
 	unsigned char *raw_sample_buf;
 };
 

--- a/src/hardware/openbench-logic-sniffer/protocol.h
+++ b/src/hardware/openbench-logic-sniffer/protocol.h
@@ -28,10 +28,10 @@
 
 #define LOG_PREFIX "openbench-logic-sniffer"
 
-#define NUM_BASIC_TRIGGER_STAGES   4
-#define CLOCK_RATE                 SR_MHZ(100)
-#define MIN_NUM_SAMPLES            4
-#define DEFAULT_SAMPLERATE         SR_KHZ(200)
+#define NUM_BASIC_TRIGGER_STAGES     4
+#define CLOCK_RATE                   SR_MHZ(100)
+#define MIN_NUM_SAMPLES              4
+#define DEFAULT_SAMPLERATE           SR_KHZ(200)
 
 /* Command opcodes */
 #define CMD_RESET                     0x00
@@ -130,16 +130,16 @@ struct dev_context {
 SR_PRIV extern const char *ols_channel_names[];
 
 SR_PRIV int send_shortcommand(struct sr_serial_dev_inst *serial,
-		uint8_t command);
-SR_PRIV int send_longcommand(struct sr_serial_dev_inst *serial,
-		uint8_t command, uint8_t *data);
+			      uint8_t command);
+SR_PRIV int send_longcommand(struct sr_serial_dev_inst *serial, uint8_t command,
+			     uint8_t *data);
 SR_PRIV int ols_send_reset(struct sr_serial_dev_inst *serial);
 SR_PRIV int ols_prepare_acquisition(const struct sr_dev_inst *sdi);
 SR_PRIV uint32_t ols_channel_mask(const struct sr_dev_inst *sdi);
 SR_PRIV struct dev_context *ols_dev_new(void);
 SR_PRIV struct sr_dev_inst *get_metadata(struct sr_serial_dev_inst *serial);
 SR_PRIV int ols_set_samplerate(const struct sr_dev_inst *sdi,
-		uint64_t samplerate);
+			       uint64_t samplerate);
 SR_PRIV void abort_acquisition(const struct sr_dev_inst *sdi);
 SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data);
 


### PR DESCRIPTION
The next slice of #51 "OLS Improvements":
* Obey code style (new commit)
* Provide sample count in RLE mode to provide a more useful list of sample buffer lengths in PulseView
* Smaller clean-ups
* Fix operation of demuxer
* Fix off-by-one in logic that sets up trigger stages