### PR TITLE
output/csv: fix dedup logic

### DIFF
--- a/src/output/csv.c
+++ b/src/output/csv.c
@@ -458,6 +458,8 @@ static void dump_saved_values(struct context *ctx, GString **out)
 			    &ctx->logic_samples[i * ctx->num_logic_channels];
 
 
+			ctx->out_sample_count++;
+
 			if (ctx->dedup) {
 				if (!memcmp(logic_sample, ctx->previous_sample,
 					    ctx->num_logic_channels) &&
@@ -476,7 +478,7 @@ static void dump_saved_values(struct context *ctx, GString **out)
 			if (ctx->time && !ctx->sample_rate) {
 				g_string_append_printf(*out, "0%s", ctx->value);
 			} else if (ctx->time) {
-				sample_time_dbl = ctx->out_sample_count++;
+				sample_time_dbl = ctx->out_sample_count - 1;
 				sample_time_dbl /= ctx->sample_rate;
 				sample_time_dbl *= ctx->sample_scale;
 				sample_time_u64 = sample_time_dbl;

--- a/src/output/csv.c
+++ b/src/output/csv.c
@@ -457,9 +457,9 @@ static void dump_saved_values(struct context *ctx, GString **out)
 			logic_sample =
 			    &ctx->logic_samples[i * ctx->num_logic_channels];
 
+
 			if (ctx->dedup) {
-				if (i > 0 && i < ctx->num_samples - 1 &&
-				    !memcmp(logic_sample, ctx->previous_sample,
+				if (!memcmp(logic_sample, ctx->previous_sample,
 					    ctx->num_logic_channels) &&
 				    !memcmp(analog_sample,
 					    ctx->previous_sample +
@@ -513,12 +513,10 @@ static void dump_saved_values(struct context *ctx, GString **out)
 	}
 
 	/* Discard all of the working space. */
-	g_free(ctx->previous_sample);
 	g_free(ctx->analog_samples);
 	g_free(ctx->logic_samples);
 	ctx->channels_seen = 0;
 	ctx->num_samples = 0;
-	ctx->previous_sample = NULL;
 	ctx->analog_samples = NULL;
 	ctx->logic_samples = NULL;
 }


### PR DESCRIPTION
This fixes the dedup logic in the csv output to:
- dedup across samples (much like the vcd output module)
- not print two values for every group of samples

`previous_sample` was being freed every receive, and so it was
impossible to dedup across multiple receives, which would cause many
rows even when the level hasn't changed when using high sample rates.

There was also a range check for `i` that makes it so that two values
will always skip the dedup check, again spamming rows even when the
level hasn't changed.