### PR TITLE
Python bindings: fix setting of rational values

### DIFF
--- a/bindings/python/sigrok/core/classes.i
+++ b/bindings/python/sigrok/core/classes.i
@@ -340,12 +340,11 @@ Glib::VariantBase python_to_variant_by_key(PyObject *input, const sigrok::Config
         return Glib::Variant<double>::create(PyFloat_AsDouble(input));
     else if (type == SR_T_INT32 && PyInt_Check(input))
         return Glib::Variant<gint32>::create(PyInt_AsLong(input));
-    else if ((type == SR_T_RATIONAL_VOLT) && PyTuple_Check(input) && (PyTuple_Size(input) == 2)) {
+    else if (((type == SR_T_RATIONAL_PERIOD) || (type == SR_T_RATIONAL_VOLT)) && PyTuple_Check(input) && (PyTuple_Size(input) == 2)) {
         PyObject *numObj = PyTuple_GetItem(input, 0);
         PyObject *denomObj = PyTuple_GetItem(input, 1);
         if ((PyInt_Check(numObj) || PyLong_Check(numObj)) && (PyInt_Check(denomObj) || PyLong_Check(denomObj))) {
-          const std::vector<guint64> v = {(guint64)PyInt_AsLong(numObj), (guint64)PyInt_AsLong(denomObj)};
-          return Glib::Variant< std::vector<guint64> >::create(v);
+          return Glib::VariantBase(g_variant_new("(tt)", (guint64)PyInt_AsLong(numObj), (guint64)PyInt_AsLong(denomObj)), false);
         }
     }
     throw sigrok::Error(SR_ERR_ARG);


### PR DESCRIPTION
Setting of rational voltage values like `vdiv` (Volts/division) is broken in the Python bindings because the GVariant type created by the Python bindings is rejected by libsigrok (tested with `rigol-ds`). This patch fixes the mismatch by using the same code as the C++ bindings.

In addition rational period values like `timebase` were not handled at all by the Python bindings. This is fixed by handling them the same way as rational voltage values.