### PR TITLE
kingst-la2016: Fix USB issues on Win build

### DIFF
--- a/src/hardware/kingst-la2016/api.c
+++ b/src/hardware/kingst-la2016/api.c
@@ -641,8 +641,11 @@ static void LIBUSB_CALL receive_transfer(struct libusb_transfer *transfer)
 	devc->n_bytes_to_read -= transfer->actual_length;
 	if (devc->n_bytes_to_read) {
 		uint32_t to_read = devc->n_bytes_to_read;
-		if (to_read > LA2016_BULK_MAX)
-			to_read = LA2016_BULK_MAX;
+		/* determine read size for the next usb transfer */
+		if (to_read >= LA2016_USB_BUFSZ)
+			to_read = LA2016_USB_BUFSZ;
+		else /* last transfer, make read size some multiple of LA2016_EP6_PKTSZ */
+			to_read = (to_read + (LA2016_EP6_PKTSZ-1)) & ~(LA2016_EP6_PKTSZ-1);
 		libusb_fill_bulk_transfer(
 			transfer, usb->devhdl,
 			0x86, transfer->buffer, to_read,

--- a/src/hardware/kingst-la2016/protocol.c
+++ b/src/hardware/kingst-la2016/protocol.c
@@ -723,9 +723,11 @@ SR_PRIV int la2016_start_retrieval(const struct sr_dev_inst *sdi, libusb_transfe
 	}
 
 	to_read = devc->n_bytes_to_read;
-	if (to_read > LA2016_BULK_MAX)
-		to_read = LA2016_BULK_MAX;
-
+	/* choose a buffer size for all of the usb transfers */
+	if (to_read >= LA2016_USB_BUFSZ)
+		to_read = LA2016_USB_BUFSZ; /* multiple transfers */
+	else /* one transfer, make buffer size some multiple of LA2016_EP6_PKTSZ */
+		to_read = (to_read + (LA2016_EP6_PKTSZ-1)) & ~(LA2016_EP6_PKTSZ-1);
 	buffer = g_try_malloc(to_read);
 	if (!buffer) {
 		sr_err("Failed to allocate %d bytes for bulk transfer", to_read);

--- a/src/hardware/kingst-la2016/protocol.h
+++ b/src/hardware/kingst-la2016/protocol.h
@@ -37,6 +37,16 @@
 
 #define LA2016_BULK_MAX         8388608
 
+/*
+ * On Windows sigrok uses WinUSB RAW_IO policy which requires the
+ * USB transfer buffer size to be a multiple of the endpoint max packet
+ * size, which is 512 bytes in this case. Also, the maximum allowed size of
+ * the transfer buffer is normally read from WinUSB_GetPipePolicy API but
+ * libusb does not expose this function. Typically, max size is 2MB.
+ */
+#define LA2016_EP6_PKTSZ	512 /* endpoint 6 max packet size */
+#define LA2016_USB_BUFSZ	(256 * 2 * LA2016_EP6_PKTSZ) /* 256KB buffer */
+
 #define MAX_RENUM_DELAY_MS	3000
 #define DEFAULT_TIMEOUT_MS      200
 


### PR DESCRIPTION
My [previous pull request](https://github.com/sigrokproject/libsigrok/pull/131) for the Kingst LA2016 fixed some driver issues and got the device working in nightly builds for Linux. However, the driver did not work in Windows due to a USB transfer problem which this PR fixes.

The issue was related to the special build of libusb which sigrok uses on Windows, which enables WinUSB RAW_IO policy. This requires the USB transfer buffer size to be multiple of endpoint max packet size.

This PR is tiny and (trust me!) it will get the Windows nightly build working. Tested with LA2016 and LA1016 on Linux and Windows. I would appreciate it if this could be pulled relatively quickly.