### PR TITLE
chronovu-la: Add checking of VendorId

### DIFF
--- a/src/hardware/chronovu-la/api.c
+++ b/src/hardware/chronovu-la/api.c
@@ -20,6 +20,8 @@
 #include <config.h>
 #include "protocol.h"
 
+#define CHRONOVU_VENDOR (0x0403)
+
 static const uint32_t scanopts[] = {
 	SR_CONF_CONN,
 };
@@ -168,6 +170,9 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 		}
 
 		libusb_get_device_descriptor(devlist[i], &des);
+
+		if (des.idVendor != CHRONOVU_VENDOR)
+			continue;
 
 		if ((ret = libusb_open(devlist[i], &hdl)) < 0)
 			continue;


### PR DESCRIPTION
On my machine, I have an AURA LED Controller.
It causes SEGV in libusb when reading its string descriptors.

Checking the VID during the scan filters out this controller and workarounds the problem. I chose to filter only VID as I don't own any device of this type and I couldn't find if there are multiple PIDs for these devices.
The VID is taken from https://sigrok.org/wiki/ChronoVu_LA8/Info and https://sigrok.org/wiki/ChronoVu_LA16/Info.

As a side-effect, device scanning should speed up a bit.

This together with https://github.com/sigrokproject/libsigrok/pull/165 should fix https://sigrok.org/bugzilla/show_bug.cgi?id=1115
