### PR TITLE
dslogic: Optimize deinterleave_buffer

### DIFF
--- a/src/hardware/dreamsourcelab-dslogic/api.c
+++ b/src/hardware/dreamsourcelab-dslogic/api.c
@@ -26,23 +26,34 @@ static const struct dslogic_profile supported_device[] = {
 	/* DreamSourceLab DSLogic */
 	{ 0x2a0e, 0x0001, "DreamSourceLab", "DSLogic", NULL,
 		"dreamsourcelab-dslogic-fx2.fw",
-		0, "DreamSourceLab", "DSLogic", 256 * 1024 * 1024},
+		0, "DreamSourceLab", "DSLogic", 256 * 1024 * 1024, 100,
+		512, DS_API_V1, SR_MHZ(100), SR_MHZ(200), SR_MHZ(400), 1},
 	/* DreamSourceLab DSCope */
 	{ 0x2a0e, 0x0002, "DreamSourceLab", "DSCope", NULL,
 		"dreamsourcelab-dscope-fx2.fw",
-		0, "DreamSourceLab", "DSCope", 256 * 1024 * 1024},
+		0, "DreamSourceLab", "DSCope", 256 * 1024 * 1024, 100,
+		512, DS_API_V1, SR_MHZ(100), SR_MHZ(200), SR_MHZ(400), 1},
 	/* DreamSourceLab DSLogic Pro */
 	{ 0x2a0e, 0x0003, "DreamSourceLab", "DSLogic Pro", NULL,
 		"dreamsourcelab-dslogic-pro-fx2.fw",
-		0, "DreamSourceLab", "DSLogic", 256 * 1024 * 1024},
+		0, "DreamSourceLab", "DSLogic", 256 * 1024 * 1024, 100,
+		512, DS_API_V1, SR_MHZ(100), SR_MHZ(200), SR_MHZ(400), 1},
 	/* DreamSourceLab DSLogic Plus */
 	{ 0x2a0e, 0x0020, "DreamSourceLab", "DSLogic Plus", NULL,
 		"dreamsourcelab-dslogic-plus-fx2.fw",
-		0, "DreamSourceLab", "DSLogic", 256 * 1024 * 1024},
+		0, "DreamSourceLab", "DSLogic", 256 * 1024 * 1024, 100,
+		512, DS_API_V1, SR_MHZ(100), SR_MHZ(200), SR_MHZ(400), 1},
 	/* DreamSourceLab DSLogic Basic */
 	{ 0x2a0e, 0x0021, "DreamSourceLab", "DSLogic Basic", NULL,
 		"dreamsourcelab-dslogic-basic-fx2.fw",
-		0, "DreamSourceLab", "DSLogic", 256 * 1024},
+		0, "DreamSourceLab", "DSLogic", 256 * 1024, 100,
+		512, DS_API_V1, SR_MHZ(100), SR_MHZ(200), SR_MHZ(400), 1},
+	/* DreamSourceLab DSLogic U3Pro16 */
+	{ 0x2a0e, 0x002a, "DreamSourceLab", "DSLogic U3Pro16", NULL,
+		"dreamsourcelab-dslogic-basic-fx2.fw",
+		DSLOGIC_CAPS_ADF4360, "DreamSourceLab", "DSLogic", 
+		2ULL * 1024ULL * 1024ULL * 1024ULL, 40,
+		1024, DS_API_V2, SR_MHZ(500), SR_MHZ(500), SR_GHZ(1), 5},
 
 	ALL_ZERO
 };
@@ -102,6 +113,27 @@ static const uint64_t samplerates[] = {
 	SR_MHZ(100),
 	SR_MHZ(200),
 	SR_MHZ(400),
+};
+
+static const uint64_t samplerates_U3Pro16[] = {
+	SR_KHZ(10),
+	SR_KHZ(20),
+	SR_KHZ(50),
+	SR_KHZ(100),
+	SR_KHZ(200),
+	SR_KHZ(500),
+	SR_MHZ(1),
+	SR_MHZ(2),
+	SR_MHZ(5),
+	SR_MHZ(10),
+	SR_MHZ(20),
+	SR_MHZ(25),
+	SR_MHZ(50),
+	SR_MHZ(100),
+	SR_MHZ(125),
+	SR_MHZ(250),
+	SR_MHZ(500),
+	SR_MHZ(1000),
 };
 
 static gboolean is_plausible(const struct libusb_device_descriptor *des)
@@ -255,9 +287,18 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 		sdi->priv = devc;
 		devices = g_slist_append(devices, sdi);
 
-		devc->samplerates = samplerates;
-		devc->num_samplerates = ARRAY_SIZE(samplerates);
-		has_firmware = usb_match_manuf_prod(devlist[i], "DreamSourceLab", "USB-based Instrument");
+		if (strcmp("DSLogic U3Pro16", devc->profile->model) == 0) {
+			devc->samplerates = samplerates_U3Pro16;
+			devc->num_samplerates = ARRAY_SIZE(samplerates_U3Pro16);
+		} else {
+			devc->samplerates = samplerates;
+			devc->num_samplerates = ARRAY_SIZE(samplerates);
+
+		}
+		if (devc->profile->api_version == DS_API_V1)
+			has_firmware = usb_match_manuf_prod(devlist[i], "DreamSourceLab", "USB-based Instrument");
+		else
+			has_firmware = usb_match_manuf_prod(devlist[i], "DreamSourceLab", "USB-based DSL Instrument v2");
 
 		if (has_firmware) {
 			/* Already has the firmware, so fix the new address. */

--- a/src/hardware/dreamsourcelab-dslogic/api.c
+++ b/src/hardware/dreamsourcelab-dslogic/api.c
@@ -477,9 +477,6 @@ static int config_get(uint32_t key, GVariant **data,
 	case SR_CONF_EXTERNAL_CLOCK:
 		*data = g_variant_new_boolean(devc->external_clock);
 		break;
-	case SR_CONF_CONTINUOUS:
-		*data = g_variant_new_boolean(devc->continuous_mode);
-		break;
 	case SR_CONF_CLOCK_EDGE:
 		idx = devc->clock_edge;
 		if (idx >= (int)ARRAY_SIZE(signal_edges))
@@ -532,9 +529,6 @@ static int config_set(uint32_t key, GVariant *data,
 		break;
 	case SR_CONF_EXTERNAL_CLOCK:
 		devc->external_clock = g_variant_get_boolean(data);
-		break;
-	case SR_CONF_CONTINUOUS:
-		devc->continuous_mode = g_variant_get_boolean(data);
 		break;
 	case SR_CONF_CLOCK_EDGE:
 		if ((idx = std_str_idx(data, ARRAY_AND_SIZE(signal_edges))) < 0)

--- a/src/hardware/dreamsourcelab-dslogic/protocol.c
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.c
@@ -25,6 +25,11 @@
 #include <glib/gstdio.h>
 #include "protocol.h"
 
+/* Protocol commands */
+#define DS_CMD_CTL_WR			0xb0
+#define DS_CMD_CTL_RD_PRE		0xb1
+#define DS_CMD_CTL_RD			0xb2
+
 #define DS_CMD_GET_FW_VERSION		0xb0
 #define DS_CMD_GET_REVID_VERSION	0xb1
 #define DS_CMD_START			0xb2
@@ -39,6 +44,14 @@
 #define DS_CMD_RD_NVM_PRE		0xbb
 #define DS_CMD_GET_HW_INFO		0xbc
 
+#define DS_I2C_REG_VTH_ADDR		0x78
+#define DS_I2C_REG_CTR1_ADDR	0x71
+#define DS_I2C_REG_CTR0_ADDR	0x70
+#define DS_I2C_REG_COMB_ADDR	0x68
+#define DS_I2C_REG_EI2C_ADDR	0x60
+#define DS_I2C_REG_VCO_ADDR		0x48
+#define DS_I2C_REG_HDL_VERSION_ADDR	0x04
+
 #define DS_START_FLAGS_STOP		(1 << 7)
 #define DS_START_FLAGS_CLK_48MHZ	(1 << 6)
 #define DS_START_FLAGS_SAMPLE_WIDE	(1 << 5)
@@ -49,7 +62,6 @@
 #define DS_ADDR_VTH			0x78
 
 #define DS_MAX_LOGIC_DEPTH		SR_MHZ(16)
-#define DS_MAX_LOGIC_SAMPLERATE		SR_MHZ(100)
 #define DS_MAX_TRIG_PERCENT		90
 
 #define DS_MODE_TRIG_EN			(1 << 0)
@@ -68,6 +80,25 @@
 #define DS_MODE_EXT_TEST		(1 << 14)
 #define DS_MODE_INT_TEST		(1 << 15)
 
+// read only
+#define DS_GPIF_DONE     (1 << 7)
+#define DS_FPGA_DONE     (1 << 6)
+#define DS_FPGA_INIT_B   (1 << 5)
+// write only
+#define DS_CH_CH0        (1 << 7)
+#define DS_CH_COM        (1 << 6)
+#define DS_CH_CH1        (1 << 5)
+// read/write
+#define DS_SYS_OVERFLOW  (1 << 4)
+#define DS_SYS_CLR       (1 << 3)
+#define DS_SYS_EN        (1 << 2)
+#define DS_LED_RED       (1 << 1)
+#define DS_LED_GREEN     (1 << 0)
+
+#define DS_WR_PROG_B        (1 << 2)
+#define DS_WR_INTRDY        (1 << 7)
+#define DS_WR_WORDWIDE      (1 << 0)
+
 #define DSLOGIC_ATOMIC_SAMPLES		(sizeof(uint64_t) * 8)
 #define DSLOGIC_ATOMIC_BYTES		sizeof(uint64_t)
 
@@ -83,10 +114,49 @@
 #define DS_CFG_TRIG_POS			_DS_CFG(5, 2)
 #define DS_CFG_TRIG_GLB			_DS_CFG(7, 1)
 #define DS_CFG_CH_EN			_DS_CFG(8, 1)
+#define DS_CFG_CH_EN_V2			_DS_CFG(10, 2)
 #define DS_CFG_TRIG			_DS_CFG(64, 160)
 #define DS_CFG_END			0xfa5afa5a
 
 #pragma pack(push, 1)
+
+enum {
+    DSL_CTL_FW_VERSION		= 0,
+    DSL_CTL_REVID_VERSION	= 1,
+    DSL_CTL_HW_STATUS		= 2,
+    DSL_CTL_PROG_B			= 3,
+    DSL_CTL_SYS				= 4,
+    DSL_CTL_LED				= 5,
+    DSL_CTL_INTRDY			= 6,
+    DSL_CTL_WORDWIDE		= 7,
+
+    DSL_CTL_START			= 8,
+    DSL_CTL_STOP			= 9,
+    DSL_CTL_BULK_WR			= 10,
+    DSL_CTL_REG				= 11,
+    DSL_CTL_NVM				= 12,
+
+    DSL_CTL_I2C_DSO			= 13,
+    DSL_CTL_I2C_REG			= 14,
+    DSL_CTL_I2C_STATUS		= 15,
+
+    DSL_CTL_DSO_EN0			= 16,
+    DSL_CTL_DSO_DC0			= 17,
+    DSL_CTL_DSO_ATT0		= 18,
+    DSL_CTL_DSO_EN1			= 19,
+    DSL_CTL_DSO_DC1			= 20,
+    DSL_CTL_DSO_ATT1		= 21,
+
+    DSL_CTL_AWG_WR			= 22,
+    DSL_CTL_I2C_PROBE		= 23,
+    DSL_CTL_I2C_EXT         = 24,
+};
+
+struct ctl_header {
+    uint8_t dest;
+    uint16_t offset;
+    uint8_t size;
+};
 
 struct version_info {
 	uint8_t major;
@@ -99,7 +169,7 @@ struct cmd_start_acquisition {
 	uint8_t sample_delay_l;
 };
 
-struct fpga_config {
+struct fpga_config_common {
 	uint32_t sync;
 
 	uint16_t mode_header;
@@ -112,8 +182,6 @@ struct fpga_config {
 	uint32_t trig_pos;
 	uint16_t trig_glb_header;
 	uint16_t trig_glb;
-	uint16_t ch_en_header;
-	uint16_t ch_en;
 
 	uint16_t trig_header;
 	uint16_t trig_mask0[NUM_TRIGGER_STAGES];
@@ -126,7 +194,38 @@ struct fpga_config {
 	uint16_t trig_logic1[NUM_TRIGGER_STAGES];
 	uint32_t trig_count[NUM_TRIGGER_STAGES];
 
+};
+
+struct fpga_config_v1 {
+	struct fpga_config_common common;
+	uint16_t ch_en_header;
+	uint16_t ch_en;
+
 	uint32_t end_sync;
+};
+
+struct fpga_config_v2 {
+	struct fpga_config_common common;
+
+	uint16_t ch_en_header;
+	uint32_t ch_en;
+
+	uint32_t end_sync;
+};
+
+struct vco_config {
+	uint8_t dest;
+	uint8_t cnt;
+	uint8_t delay;
+	uint8_t byte[4];
+};
+
+static const struct vco_config vco_init_config[] = {
+	{DS_I2C_REG_VCO_ADDR+2, 1, 0, {0x01, 0x00, 0x00, 0x00}},
+	{DS_I2C_REG_VCO_ADDR, 4, 0, {0x01, 0x61, 0x00, 0x30}},
+	{DS_I2C_REG_VCO_ADDR, 4, 0, {0x01, 0x40, 0xF1, 0x46}},
+	{DS_I2C_REG_VCO_ADDR, 4, 10, {0x01, 0x62, 0x3D, 0x40}},
+	{0, 0, 0, {0, 0, 0, 0}}
 };
 
 #pragma pack(pop)
@@ -142,10 +241,97 @@ struct fpga_config {
 
 #define USB_TIMEOUT (3 * 1000)
 
-static int command_get_fw_version(libusb_device_handle *devhdl,
-				  struct version_info *vi)
+static int command_read_ext(libusb_device_handle *devhdl, uint8_t control_code,
+					uint8_t offset, uint8_t read_len, uint8_t *read_buffer)
 {
 	int ret;
+
+	struct ctl_header cmd;
+	cmd.dest = control_code;
+	cmd.size = read_len;
+	cmd.offset = offset;
+
+	/* Send the control message. */
+	ret = libusb_control_transfer(devhdl, LIBUSB_REQUEST_TYPE_VENDOR |
+			LIBUSB_ENDPOINT_OUT, DS_CMD_CTL_RD_PRE, 0x0000, 0x0000,
+			(unsigned char *)&cmd, sizeof(struct ctl_header), USB_TIMEOUT);
+	if (ret < 0) {
+		sr_err("Unable to send CMD_CTL_RD_PRE command(dest:%d/offset:%d/size:%d): %s.",
+				cmd.dest, cmd.offset, cmd.size,
+				libusb_error_name(ret));
+		return SR_ERR;
+	}
+
+	g_usleep(10*1000);
+
+	ret = libusb_control_transfer(devhdl, LIBUSB_REQUEST_TYPE_VENDOR |
+		LIBUSB_ENDPOINT_IN, DS_CMD_CTL_RD, 0x0000, 0x0000,
+		(unsigned char *)read_buffer, read_len, USB_TIMEOUT);
+
+	if (ret < 0) {
+		sr_err("Unable to send DS_CMD_CTL_RD for command %d: %s.",
+				control_code,
+				libusb_error_name(ret));
+		return SR_ERR;
+	}
+
+	return SR_OK;
+
+}
+
+static int command_read(libusb_device_handle *devhdl, uint8_t control_code,
+					uint8_t read_len, uint8_t *read_buffer)
+{
+	return command_read_ext(devhdl, control_code, 0, read_len,
+						read_buffer);
+}
+
+static int command_write_ext(libusb_device_handle *devhdl, uint8_t control_code,
+					uint8_t offset, uint8_t write_len, uint8_t *write_buffer)
+{
+	int ret;
+	struct ctl_header cmd;
+	cmd.dest = control_code;
+	cmd.size = write_len;
+	cmd.offset = offset;
+	unsigned char *buf;
+	buf = g_malloc(sizeof(cmd) + write_len);
+	memcpy(buf, &cmd, sizeof(cmd));
+	memcpy(&buf[sizeof(cmd)], write_buffer, write_len);
+
+	/* Send the control message. */
+	ret = libusb_control_transfer(devhdl, LIBUSB_REQUEST_TYPE_VENDOR |
+			LIBUSB_ENDPOINT_OUT, DS_CMD_CTL_WR, 0x0000, 0x0000,
+			buf, write_len+sizeof(cmd), USB_TIMEOUT);
+	g_free(buf);
+	if (ret < 0) {
+		sr_err("Unable to send DS_CMD_CTL_WR command(dest:%d/offset:%d/size:%d): %s.",
+				cmd.dest, cmd.offset, cmd.size,
+				libusb_error_name(ret));
+		return SR_ERR;
+	}
+	return SR_OK;
+
+}
+
+static int command_write(libusb_device_handle *devhdl, uint8_t control_code,
+					uint8_t write_len, uint8_t *write_buffer)
+{
+	return command_write_ext(devhdl, control_code, 0, write_len,
+						write_buffer);
+}
+
+static int command_get_fw_version(struct sr_dev_inst *sdi,
+				  struct version_info *vi)
+{
+	struct sr_usb_dev_inst *usb = sdi->conn;
+	struct dev_context *devc = sdi->priv;
+	libusb_device_handle *devhdl = usb->devhdl;
+	int ret;
+
+	if (devc->profile->api_version == DS_API_V2)
+		return command_read(devhdl,	DSL_CTL_FW_VERSION,
+				sizeof(struct version_info), (uint8_t *)vi);
 
 	ret = libusb_control_transfer(devhdl, LIBUSB_REQUEST_TYPE_VENDOR |
 		LIBUSB_ENDPOINT_IN, DS_CMD_GET_FW_VERSION, 0x0000, 0x0000,
@@ -163,7 +349,12 @@ static int command_get_fw_version(libusb_device_handle *devhdl,
 static int command_get_revid_version(struct sr_dev_inst *sdi, uint8_t *revid)
 {
 	struct sr_usb_dev_inst *usb = sdi->conn;
+	struct dev_context *devc = sdi->priv;
 	libusb_device_handle *devhdl = usb->devhdl;
+
+	if (devc->profile->api_version == DS_API_V2)
+		return command_read(devhdl,	DSL_CTL_REVID_VERSION,
+				sizeof(uint8_t), revid);
 	int ret;
 
 	ret = libusb_control_transfer(devhdl, LIBUSB_REQUEST_TYPE_VENDOR |
@@ -178,22 +369,60 @@ static int command_get_revid_version(struct sr_dev_inst *sdi, uint8_t *revid)
 	return SR_OK;
 }
 
+
+static int write_register(libusb_device_handle *devhdl, uint8_t addr,
+							uint8_t value)
+{
+    if (command_write_ext(devhdl, DSL_CTL_I2C_REG, addr, sizeof(value), &value)
+			!= SR_OK) {
+        sr_err("Sent DSL_CTL_I2C_REG command failed.");
+        return SR_ERR;
+    }
+
+    return SR_OK;
+}
+
+
+static int configure_vco(libusb_device_handle *devhdl,
+						const struct vco_config *config)
+{
+	while(config->dest) {
+		if (config->delay > 0)
+			g_usleep(config->delay*1000);
+		for (int i = 0; i < config->cnt; i++) {
+			write_register(devhdl, config->dest, config->byte[i]);
+		}
+		config++;
+	}
+	return SR_OK;
+}
+
 static int command_start_acquisition(const struct sr_dev_inst *sdi)
 {
 	struct sr_usb_dev_inst *usb;
 	struct dslogic_mode mode;
+	struct dev_context *devc;
 	int ret;
 
-	mode.flags = DS_START_FLAGS_MODE_LA | DS_START_FLAGS_SAMPLE_WIDE;
-	mode.sample_delay_h = mode.sample_delay_l = 0;
-
+	devc = sdi->priv;
 	usb = sdi->conn;
-	ret = libusb_control_transfer(usb->devhdl, LIBUSB_REQUEST_TYPE_VENDOR |
-			LIBUSB_ENDPOINT_OUT, DS_CMD_START, 0x0000, 0x0000,
-			(unsigned char *)&mode, sizeof(mode), USB_TIMEOUT);
-	if (ret < 0) {
-		sr_err("Failed to send start command: %s.", libusb_error_name(ret));
-		return SR_ERR;
+
+	if (devc->profile->api_version == DS_API_V1) {
+		mode.flags = DS_START_FLAGS_MODE_LA | DS_START_FLAGS_SAMPLE_WIDE;
+		mode.sample_delay_h = mode.sample_delay_l = 0;
+
+		ret = libusb_control_transfer(usb->devhdl, LIBUSB_REQUEST_TYPE_VENDOR |
+				LIBUSB_ENDPOINT_OUT, DS_CMD_START, 0x0000, 0x0000,
+				(unsigned char *)&mode, sizeof(mode), USB_TIMEOUT);
+		if (ret < 0) {
+			sr_err("Failed to send start command: %s.", libusb_error_name(ret));
+			return SR_ERR;
+		}
+	} else {
+		if (command_write(usb->devhdl, DSL_CTL_START, 0, NULL) != SR_OK) {
+			sr_err("Failed to send start command.");
+			return SR_ERR;
+		}
 	}
 
 	return SR_OK;
@@ -203,18 +432,152 @@ static int command_stop_acquisition(const struct sr_dev_inst *sdi)
 {
 	struct sr_usb_dev_inst *usb;
 	struct dslogic_mode mode;
+	struct dev_context *devc;
 	int ret;
 
+	devc = sdi->priv;
 	mode.flags = DS_START_FLAGS_STOP;
 	mode.sample_delay_h = mode.sample_delay_l = 0;
 
 	usb = sdi->conn;
-	ret = libusb_control_transfer(usb->devhdl, LIBUSB_REQUEST_TYPE_VENDOR |
-			LIBUSB_ENDPOINT_OUT, DS_CMD_START, 0x0000, 0x0000,
-			(unsigned char *)&mode, sizeof(struct dslogic_mode), USB_TIMEOUT);
+	if (devc->profile->api_version == DS_API_V1) {
+		ret = libusb_control_transfer(usb->devhdl, LIBUSB_REQUEST_TYPE_VENDOR |
+				LIBUSB_ENDPOINT_OUT, DS_CMD_START, 0x0000, 0x0000,
+				(unsigned char *)&mode, sizeof(struct dslogic_mode), USB_TIMEOUT);
+	}
+	else {
+		ret = command_write(usb->devhdl, DSL_CTL_STOP, 0, NULL);
+	}
 	if (ret < 0) {
 		sr_err("Failed to send stop command: %s.", libusb_error_name(ret));
 		return SR_ERR;
+	}
+
+	return SR_OK;
+}
+
+static int fpga_firmware_upload_v2(struct libusb_device_handle *devhdl,
+						struct sr_context *ctx,
+						struct sr_resource *bitstream)
+{
+	uint8_t cmd[3];
+	int result;
+	unsigned char *buf;
+	uint64_t sum;
+	ssize_t chunksize;
+	int transferred;
+	bool fpga_done;
+
+	result = command_read(devhdl, DSL_CTL_HW_STATUS, sizeof(uint8_t), cmd);
+	if (result != SR_OK)
+		return result;
+	fpga_done = (cmd[0] & DS_FPGA_DONE) == DS_FPGA_DONE;
+
+	if (!fpga_done) {
+
+		cmd[0] = ~DS_WR_PROG_B;
+		result = command_write(devhdl, DSL_CTL_PROG_B, sizeof(uint8_t), cmd);
+		if (result != SR_OK)
+			return result;
+
+		cmd[0] = DS_WR_PROG_B;
+		result = command_write(devhdl, DSL_CTL_PROG_B, sizeof(uint8_t), cmd);
+		if (result != SR_OK)
+			return result;
+
+		while(1) {
+			result = command_read(devhdl, DSL_CTL_HW_STATUS, sizeof(uint8_t), cmd);
+			if (result != SR_OK)
+				return result;
+			if (cmd[0] & DS_FPGA_INIT_B)
+				break;
+		}
+
+		cmd[0] = (uint8_t)~DS_WR_INTRDY;
+		result = command_write(devhdl, DSL_CTL_INTRDY, sizeof(uint8_t), cmd);
+		if (result != SR_OK)
+			return result;
+
+		cmd[0] = (uint8_t)bitstream->size;
+		cmd[1] = (uint8_t)(bitstream->size >> 8);
+		cmd[2] = (uint8_t)(bitstream->size >> 16);
+		result = command_write(devhdl, DSL_CTL_BULK_WR, 3*sizeof(uint8_t), cmd);
+		if (result != SR_OK)
+			return result;
+
+		buf = g_malloc(FW_BUFSIZE);
+		sum = 0;
+		while (1) {
+			chunksize = sr_resource_read(ctx, bitstream,
+					buf, FW_BUFSIZE);
+			if (chunksize < 0) {
+				g_free(buf);
+				return SR_ERR;
+			}
+			if (chunksize == 0)
+				break;
+
+			result = libusb_bulk_transfer(devhdl, 2 | LIBUSB_ENDPOINT_OUT,
+					buf, chunksize, &transferred, USB_TIMEOUT);
+			if (result != SR_OK) {
+				g_free(buf);
+				return result;
+			}
+			sum += transferred;
+			sr_spew("Uploaded %" PRIu64 "/%" PRIu64 " bytes.",
+				sum, bitstream->size);
+
+			if (transferred != chunksize) {
+				sr_err("Short transfer while uploading FPGA firmware.");
+				g_free(buf);
+				return SR_ERR;
+			}
+		}
+		g_free(buf);
+
+
+		cmd[0] = DS_WR_INTRDY;
+		result = command_write(devhdl, DSL_CTL_INTRDY, sizeof(uint8_t), cmd);
+		if (result != SR_OK)
+			return result;
+
+		while(1) {
+			result = command_read(devhdl, DSL_CTL_HW_STATUS, sizeof(uint8_t), cmd);
+			if (result != SR_OK)
+				return result;
+			if (cmd[0] & DS_GPIF_DONE)
+				break;
+		}
+
+		cmd[0] = (uint8_t)~DS_WR_INTRDY;
+		result = command_write(devhdl, DSL_CTL_INTRDY, sizeof(uint8_t), cmd);
+		if (result != SR_OK)
+			return result;
+
+		while(1) {
+			result = command_read(devhdl, DSL_CTL_HW_STATUS, sizeof(uint8_t), cmd);
+			if (result != SR_OK)
+				return result;
+			if (cmd[0] & DS_FPGA_DONE)
+				break;
+		}
+
+		cmd[0] = DS_LED_GREEN;
+		result = command_write(devhdl, DSL_CTL_LED, sizeof(uint8_t), cmd);
+		if (result != SR_OK)
+			return result;
+
+
+		cmd[0] = DS_WR_WORDWIDE;
+		result = command_write(devhdl, DSL_CTL_WORDWIDE, sizeof(uint8_t), cmd);
+		if (result != SR_OK)
+			return result;
+
+	} else {
+		/* fpga bitstream downloaded before */
+		result = write_register(devhdl, DS_I2C_REG_CTR0_ADDR, 0);
+		if (result != SR_OK)
+			return result;
 	}
 
 	return SR_OK;
@@ -251,6 +614,8 @@ SR_PRIV int dslogic_fpga_firmware_upload(const struct sr_dev_inst *sdi)
 		name = DSLOGIC_BASIC_FPGA_FIRMWARE;
 	} else if (!strcmp(devc->profile->model, "DSCope")) {
 		name = DSCOPE_FPGA_FIRMWARE;
+	} else if (!strcmp(devc->profile->model, "DSLogic U3Pro16")) {
+		name = DSLOGIC_U3PRO16_FPGA_FIRMWARE;
 	} else {
 		sr_err("Failed to select FPGA firmware.");
 		return SR_ERR;
@@ -263,47 +628,65 @@ SR_PRIV int dslogic_fpga_firmware_upload(const struct sr_dev_inst *sdi)
 	if (result != SR_OK)
 		return result;
 
-	/* Tell the device firmware is coming. */
-	if ((ret = libusb_control_transfer(usb->devhdl, LIBUSB_REQUEST_TYPE_VENDOR |
-			LIBUSB_ENDPOINT_OUT, DS_CMD_CONFIG, 0x0000, 0x0000,
-			(unsigned char *)&cmd, sizeof(cmd), USB_TIMEOUT)) < 0) {
-		sr_err("Failed to upload FPGA firmware: %s.", libusb_error_name(ret));
-		sr_resource_close(drvc->sr_ctx, &bitstream);
-		return SR_ERR;
-	}
-
-	/* Give the FX2 time to get ready for FPGA firmware upload. */
-	g_usleep(FPGA_UPLOAD_DELAY);
-
-	buf = g_malloc(FW_BUFSIZE);
-	sum = 0;
-	result = SR_OK;
-	while (1) {
-		chunksize = sr_resource_read(drvc->sr_ctx, &bitstream,
-				buf, FW_BUFSIZE);
-		if (chunksize < 0)
-			result = SR_ERR;
-		if (chunksize <= 0)
-			break;
-
-		if ((ret = libusb_bulk_transfer(usb->devhdl, 2 | LIBUSB_ENDPOINT_OUT,
-				buf, chunksize, &transferred, USB_TIMEOUT)) < 0) {
-			sr_err("Unable to configure FPGA firmware: %s.",
-					libusb_error_name(ret));
-			result = SR_ERR;
-			break;
+	if (devc->profile->api_version == DS_API_V2) {
+		result = fpga_firmware_upload_v2(usb->devhdl, drvc->sr_ctx,
+									&bitstream);
+		if (result != SR_OK) {
+			sr_err("Failed to upload FPGA firmware.");
+			sr_resource_close(drvc->sr_ctx, &bitstream);
+			return SR_ERR;
 		}
-		sum += transferred;
-		sr_spew("Uploaded %" PRIu64 "/%" PRIu64 " bytes.",
-			sum, bitstream.size);
-
-		if (transferred != chunksize) {
-			sr_err("Short transfer while uploading FPGA firmware.");
-			result = SR_ERR;
-			break;
+		if (devc->profile->dev_caps & DSLOGIC_CAPS_ADF4360) {
+			/* configure frequency synthesizer/VCO if present */
+			result = configure_vco(usb->devhdl, vco_init_config);
+			if (result != SR_OK) {
+				sr_err("Failed to configure the VCO.");
+				
+			}
 		}
+	} else {
+		/* Tell the device firmware is coming. */
+		if ((ret = libusb_control_transfer(usb->devhdl, LIBUSB_REQUEST_TYPE_VENDOR |
+				LIBUSB_ENDPOINT_OUT, DS_CMD_CONFIG, 0x0000, 0x0000,
+				(unsigned char *)&cmd, sizeof(cmd), USB_TIMEOUT)) < 0) {
+			sr_err("Failed to upload FPGA firmware: %s.", libusb_error_name(ret));
+			sr_resource_close(drvc->sr_ctx, &bitstream);
+			return SR_ERR;
+		}
+
+		/* Give the FX2 time to get ready for FPGA firmware upload. */
+		g_usleep(FPGA_UPLOAD_DELAY);
+
+		buf = g_malloc(FW_BUFSIZE);
+		sum = 0;
+		result = SR_OK;
+		while (1) {
+			chunksize = sr_resource_read(drvc->sr_ctx, &bitstream,
+					buf, FW_BUFSIZE);
+			if (chunksize < 0)
+				result = SR_ERR;
+			if (chunksize <= 0)
+				break;
+
+			if ((ret = libusb_bulk_transfer(usb->devhdl, 2 | LIBUSB_ENDPOINT_OUT,
+					buf, chunksize, &transferred, USB_TIMEOUT)) < 0) {
+				sr_err("Unable to configure FPGA firmware: %s.",
+						libusb_error_name(ret));
+				result = SR_ERR;
+				break;
+			}
+			sum += transferred;
+			sr_spew("Uploaded %" PRIu64 "/%" PRIu64 " bytes.",
+				sum, bitstream.size);
+
+			if (transferred != chunksize) {
+				sr_err("Short transfer while uploading FPGA firmware.");
+				result = SR_ERR;
+				break;
+			}
+		}
+		g_free(buf);
 	}
-	g_free(buf);
 	sr_resource_close(drvc->sr_ctx, &bitstream);
 
 	if (result == SR_OK)
@@ -339,7 +722,7 @@ static uint16_t enabled_channel_mask(const struct sr_dev_inst *sdi)
  * accordingly.
  * @return @c true if any triggers are enabled, @c false otherwise.
  */
-static bool set_trigger(const struct sr_dev_inst *sdi, struct fpga_config *cfg)
+static bool set_trigger(const struct sr_dev_inst *sdi, struct fpga_config_common *cfg)
 {
 	struct sr_trigger *trigger;
 	struct sr_trigger_stage *stage;
@@ -353,8 +736,6 @@ static bool set_trigger(const struct sr_dev_inst *sdi, struct fpga_config *cfg)
 	uint32_t trigger_point;
 
 	devc = sdi->priv;
-
-	cfg->ch_en = enabled_channel_mask(sdi);
 
 	for (i = 0; i < NUM_TRIGGER_STAGES; i++) {
 		cfg->trig_mask0[i] = 0xffff;
@@ -425,44 +806,90 @@ static bool set_trigger(const struct sr_dev_inst *sdi, struct fpga_config *cfg)
 	return num_trigger_stages != 0;
 }
 
+static int fpga_config_size(const struct sr_dev_inst *sdi)
+{
+	const struct dev_context *const devc = sdi->priv;
+	if (devc->profile->api_version == DS_API_V1) {
+		return sizeof(struct fpga_config_v1);
+	} else {
+		return sizeof(struct fpga_config_v2);
+	}
+}
+
 static int fpga_configure(const struct sr_dev_inst *sdi)
 {
 	const struct dev_context *const devc = sdi->priv;
 	const struct sr_usb_dev_inst *const usb = sdi->conn;
 	uint8_t c[3];
-	struct fpga_config cfg;
+	struct fpga_config_common *cfg;
+	uint8_t *cfg_buffer;
 	uint16_t mode = 0;
-	uint32_t divider;
+	uint32_t divider, tmp;
 	int transferred, len, ret;
 
 	sr_dbg("Configuring FPGA.");
 
-	WL32(&cfg.sync, DS_CFG_START);
-	WL16(&cfg.mode_header, DS_CFG_MODE);
-	WL16(&cfg.divider_header, DS_CFG_DIVIDER);
-	WL16(&cfg.count_header, DS_CFG_COUNT);
-	WL16(&cfg.trig_pos_header, DS_CFG_TRIG_POS);
-	WL16(&cfg.trig_glb_header, DS_CFG_TRIG_GLB);
-	WL16(&cfg.ch_en_header, DS_CFG_CH_EN);
-	WL16(&cfg.trig_header, DS_CFG_TRIG);
-	WL32(&cfg.end_sync, DS_CFG_END);
+	if (devc->profile->api_version == DS_API_V1) {
+		struct fpga_config_v1 * v1_cfg;
+		cfg_buffer = g_malloc0(sizeof(struct fpga_config_v1));
+		v1_cfg = (struct fpga_config_v1 *)cfg_buffer;
+		cfg = &v1_cfg->common;
+		WL16(&v1_cfg->ch_en_header, DS_CFG_CH_EN);
+		v1_cfg->ch_en = enabled_channel_mask(sdi);
+		WL32(&v1_cfg->end_sync, DS_CFG_END);
+	} else {
+		struct fpga_config_v2 * v2_cfg;
+		cfg_buffer = g_malloc0(sizeof(struct fpga_config_v2));
+		v2_cfg = (struct fpga_config_v2 *)cfg_buffer;
+		cfg = &v2_cfg->common;
+		WL16(&v2_cfg->ch_en_header, DS_CFG_CH_EN_V2);
+		v2_cfg->ch_en = enabled_channel_mask(sdi);
+		WL32(&v2_cfg->end_sync, DS_CFG_END);
+	}
+
+	WL32(&cfg->sync, DS_CFG_START);
+	WL16(&cfg->mode_header, DS_CFG_MODE);
+	WL16(&cfg->divider_header, DS_CFG_DIVIDER);
+	WL16(&cfg->count_header, DS_CFG_COUNT);
+	WL16(&cfg->trig_pos_header, DS_CFG_TRIG_POS);
+	WL16(&cfg->trig_glb_header, DS_CFG_TRIG_GLB);
+	WL16(&cfg->trig_header, DS_CFG_TRIG);
 
 	/* Pass in the length of a fixed-size struct. Really. */
-	len = sizeof(struct fpga_config) / 2;
+	len = fpga_config_size(sdi) / 2;
 	c[0] = len & 0xff;
 	c[1] = (len >> 8) & 0xff;
 	c[2] = (len >> 16) & 0xff;
 
-	ret = libusb_control_transfer(usb->devhdl, LIBUSB_REQUEST_TYPE_VENDOR |
-			LIBUSB_ENDPOINT_OUT, DS_CMD_SETTING, 0x0000, 0x0000,
-			c, sizeof(c), USB_TIMEOUT);
-	if (ret < 0) {
-		sr_err("Failed to send FPGA configure command: %s.",
-			libusb_error_name(ret));
-		return SR_ERR;
+	if (devc->profile->api_version == DS_API_V1) {
+		ret = libusb_control_transfer(usb->devhdl, LIBUSB_REQUEST_TYPE_VENDOR |
+				LIBUSB_ENDPOINT_OUT, DS_CMD_SETTING, 0x0000, 0x0000,
+				c, sizeof(c), USB_TIMEOUT);
+		if (ret < 0) {
+			sr_err("Failed to send FPGA configure command: %s.",
+				libusb_error_name(ret));
+			g_free(cfg_buffer);
+			return SR_ERR;
+		}
+	} else {
+		ret = command_write(usb->devhdl, DSL_CTL_BULK_WR, sizeof(c), c);
+		if (ret == SR_OK) {
+			while(1) {
+				ret = command_read(usb->devhdl, DSL_CTL_HW_STATUS, 1, c);
+				if (ret != SR_OK)
+					break;
+				if (c[0] & DS_SYS_CLR)
+					break;
+			}
+		}
+		if (ret != SR_OK) {
+			sr_err("Failed to send FPGA configure command");
+			g_free(cfg_buffer);
+			return ret;
+		}
 	}
 
-	if (set_trigger(sdi, &cfg))
+	if (set_trigger(sdi, cfg))
 		mode |= DS_MODE_TRIG_EN;
 
 	if (devc->mode == DS_OP_INTERNAL_TEST)
@@ -472,9 +899,9 @@ static int fpga_configure(const struct sr_dev_inst *sdi)
 	else if (devc->mode == DS_OP_LOOPBACK_TEST)
 		mode |= DS_MODE_LPB_TEST;
 
-	if (devc->cur_samplerate == DS_MAX_LOGIC_SAMPLERATE * 2)
+	if (devc->cur_samplerate == devc->profile->half_samplerate)
 		mode |= DS_MODE_HALF_MODE;
-	else if (devc->cur_samplerate == DS_MAX_LOGIC_SAMPLERATE * 4)
+	else if (devc->cur_samplerate == devc->profile->quarter_samplerate)
 		mode |= DS_MODE_QUAR_MODE;
 
 	if (devc->continuous_mode)
@@ -485,7 +912,7 @@ static int fpga_configure(const struct sr_dev_inst *sdi)
 			mode |= DS_MODE_CLK_EDGE;
 	}
 	if (devc->limit_samples > DS_MAX_LOGIC_DEPTH *
-		ceil(devc->cur_samplerate * 1.0 / DS_MAX_LOGIC_SAMPLERATE)
+		ceil(devc->cur_samplerate * 1.0 / devc->profile->max_samplerate)
 		&& !devc->continuous_mode) {
 		/* Enable RLE for long captures.
 		 * Without this, captured data present errors.
@@ -493,19 +920,43 @@ static int fpga_configure(const struct sr_dev_inst *sdi)
 		mode |= DS_MODE_RLE_MODE;
 	}
 
-	WL16(&cfg.mode, mode);
-	divider = ceil(DS_MAX_LOGIC_SAMPLERATE * 1.0 / devc->cur_samplerate);
-	WL32(&cfg.divider, divider);
+	WL16(&cfg->mode, mode);
+	tmp = ceil(devc->profile->max_samplerate * 1.0 / devc->cur_samplerate);
+	divider  = ((tmp >= devc->profile->max_predivider) ?
+			devc->profile->max_predivider - 1U : tmp - 1U) << 24;
+	divider |= (uint32_t)ceil(tmp * 1.0 / devc->profile->max_predivider);
+	WL32(&cfg->divider, divider);
 
 	/* Number of 16-sample units. */
-	WL32(&cfg.count, devc->limit_samples / 16);
+	WL32(&cfg->count, devc->limit_samples / 16);
 
-	len = sizeof(struct fpga_config);
+	len = fpga_config_size(sdi);
 	ret = libusb_bulk_transfer(usb->devhdl, 2 | LIBUSB_ENDPOINT_OUT,
-			(unsigned char *)&cfg, len, &transferred, USB_TIMEOUT);
+			(unsigned char *)cfg_buffer, len, &transferred, USB_TIMEOUT);
+	g_free(cfg_buffer);
 	if (ret < 0 || transferred != len) {
 		sr_err("Failed to send FPGA configuration: %s.", libusb_error_name(ret));
 		return SR_ERR;
+	}
+
+	if (devc->profile->api_version == DS_API_V2) {
+		/* assert INTRDY high to indicate data end) */
+		c[0] = DS_WR_INTRDY;
+		if (command_write(usb->devhdl, DSL_CTL_INTRDY, 1, c) != SR_OK) {
+			sr_err("Failed to assert INTRDY high.");
+			return SR_ERR;
+		}
+
+		/* check for FPGA done bit */
+		if (command_read(usb->devhdl, DSL_CTL_HW_STATUS, 1, c) != SR_OK) {
+			sr_err("Failed to read FPGA status.");
+			return SR_ERR;
+		}
+		if (!(c[0] & DS_GPIF_DONE)) {
+			sr_err("FPGA config failed.");
+			return SR_ERR;
+		}
+
 	}
 
 	return SR_OK;
@@ -520,10 +971,15 @@ SR_PRIV int dslogic_set_voltage_threshold(const struct sr_dev_inst *sdi, double 
 	const uint16_t cmd = value | (DS_ADDR_VTH << 8);
 
 	/* Send the control command. */
-	ret = libusb_control_transfer(usb->devhdl,
-			LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_ENDPOINT_OUT,
-			DS_CMD_WR_REG, 0x0000, 0x0000,
-			(unsigned char *)&cmd, sizeof(cmd), 3000);
+	if (devc->profile->api_version == DS_API_V1) {
+		ret = libusb_control_transfer(usb->devhdl,
+				LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_ENDPOINT_OUT,
+				DS_CMD_WR_REG, 0x0000, 0x0000,
+				(unsigned char *)&cmd, sizeof(cmd), 3000);
+	} else {
+		ret = write_register(usb->devhdl, DS_I2C_REG_VTH_ADDR,
+				value);
+	}
 	if (ret < 0) {
 		sr_err("Unable to set voltage-threshold register: %s.",
 		libusb_error_name(ret));
@@ -545,6 +1001,7 @@ SR_PRIV int dslogic_dev_open(struct sr_dev_inst *sdi, struct sr_dev_driver *di)
 	struct version_info vi;
 	int ret = SR_ERR, i, device_count;
 	uint8_t revid;
+	uint8_t req_major_version;
 	char connection_id[64];
 
 	drvc = di->context;
@@ -601,7 +1058,7 @@ SR_PRIV int dslogic_dev_open(struct sr_dev_inst *sdi, struct sr_dev_driver *di)
 			}
 		}
 
-		ret = command_get_fw_version(usb->devhdl, &vi);
+		ret = command_get_fw_version(sdi, &vi);
 		if (ret != SR_OK) {
 			sr_err("Failed to get firmware version.");
 			break;
@@ -618,9 +1075,12 @@ SR_PRIV int dslogic_dev_open(struct sr_dev_inst *sdi, struct sr_dev_driver *di)
 		 * bail out if we encounter an incompatible version.
 		 * Different minor versions are OK, they should be compatible.
 		 */
-		if (vi.major != DSLOGIC_REQUIRED_VERSION_MAJOR) {
+		req_major_version = (devc->profile->api_version == DS_API_V1) ?
+									DSLOGIC_REQUIRED_VERSION_MAJOR_V1 : 
+									DSLOGIC_REQUIRED_VERSION_MAJOR_V2;
+		if (vi.major != req_major_version) {
 			sr_err("Expected firmware version %d.x, "
-			       "got %d.%d.", DSLOGIC_REQUIRED_VERSION_MAJOR,
+			       "got %d.%d.", req_major_version,
 			       vi.major, vi.minor);
 			ret = SR_ERR;
 			break;
@@ -934,7 +1394,7 @@ static void LIBUSB_CALL receive_transfer(struct libusb_transfer *transfer)
 	 * time-consuming data processing to a dedicated worker thread
 	 * and continue here to process the next transfer which may have finished
 	 * already.
-		 */
+	 */
 	g_mutex_lock(&devc->data_proc_mutex);
 	while ((devc->data_proc_state == DS_DATA_PROC_RUNNING) ||
 		(devc->data_proc_state == DS_DATA_PROC_START_REQ))
@@ -988,11 +1448,12 @@ static size_t to_bytes_per_ms(const struct sr_dev_inst *sdi)
 
 static size_t get_buffer_size(const struct sr_dev_inst *sdi)
 {
+	struct dev_context *devc = sdi->priv;
 	/*
 	 * The buffer should be large enough to hold 10ms of data and
 	 * a multiple of the size of a data atom.
 	 */
-	const size_t block_size = enabled_channel_count(sdi) * 512;
+	const size_t block_size = enabled_channel_count(sdi) * devc->profile->block_size;
 	const size_t s = 10 * to_bytes_per_ms(sdi);
 	if (!block_size)
 		return s;
@@ -1001,9 +1462,11 @@ static size_t get_buffer_size(const struct sr_dev_inst *sdi)
 
 static unsigned int get_number_of_transfers(const struct sr_dev_inst *sdi)
 {
+	struct dev_context *devc = sdi->priv;
 	/* Total buffer size should be able to hold about 100ms of data. */
 	const unsigned int s = get_buffer_size(sdi);
-	const unsigned int n = (100 * to_bytes_per_ms(sdi) + s - 1) / s;
+	const unsigned int n = (devc->profile->usb_buffer_duration_ms *
+					to_bytes_per_ms(sdi) + s - 1) / s;
 	return (n > NUM_SIMUL_TRANSFERS) ? NUM_SIMUL_TRANSFERS : n;
 }
 
@@ -1096,7 +1559,7 @@ static void LIBUSB_CALL trigger_receive(struct libusb_transfer *transfer)
 		devc->num_transfers = 0;
 		g_free(devc->transfers);
 	} else if (transfer->status == LIBUSB_TRANSFER_COMPLETED
-			&& transfer->actual_length == sizeof(struct dslogic_trigger_pos)) {
+			&& transfer->actual_length == (int)devc->profile->block_size) {
 		tpos = (struct dslogic_trigger_pos *)transfer->buffer;
 		sr_info("tpos real_pos %d ram_saddr %d cnt_h %d cnt_l %d", tpos->real_pos,
 			tpos->ram_saddr, tpos->remain_cnt_h, tpos->remain_cnt_l);
@@ -1147,10 +1610,10 @@ SR_PRIV int dslogic_acquisition_start(const struct sr_dev_inst *sdi)
 		return ret;
 
 	sr_dbg("Getting trigger.");
-	tpos = g_malloc(sizeof(struct dslogic_trigger_pos));
+	tpos = g_malloc(devc->profile->block_size);
 	transfer = libusb_alloc_transfer(0);
 	libusb_fill_bulk_transfer(transfer, usb->devhdl, 6 | LIBUSB_ENDPOINT_IN,
-			(unsigned char *)tpos, sizeof(struct dslogic_trigger_pos),
+			(unsigned char *)tpos, devc->profile->block_size,
 			trigger_receive, (void *)sdi, 0);
 	if ((ret = libusb_submit_transfer(transfer)) < 0) {
 		sr_err("Failed to request trigger: %s.", libusb_error_name(ret));

--- a/src/hardware/dreamsourcelab-dslogic/protocol.c
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.c
@@ -753,8 +753,7 @@ static bool set_trigger(const struct sr_dev_inst *sdi, struct fpga_config_common
 	if (trigger_point < DSLOGIC_ATOMIC_SAMPLES)
 		trigger_point = DSLOGIC_ATOMIC_SAMPLES;
 	const uint32_t mem_depth = devc->profile->mem_depth;
-	const uint32_t max_trigger_point = devc->continuous_mode ? ((mem_depth * 10) / 100) :
-		((mem_depth * DS_MAX_TRIG_PERCENT) / 100);
+	const uint32_t max_trigger_point = (mem_depth * 10) / 100;
 	if (trigger_point > max_trigger_point)
 		trigger_point = max_trigger_point;
 	cfg->trig_pos = trigger_point & ~(DSLOGIC_ATOMIC_SAMPLES - 1);
@@ -904,20 +903,11 @@ static int fpga_configure(const struct sr_dev_inst *sdi)
 	else if (devc->cur_samplerate == devc->profile->quarter_samplerate)
 		mode |= DS_MODE_QUAR_MODE;
 
-	if (devc->continuous_mode)
-		mode |= DS_MODE_STREAM_MODE;
+	mode |= DS_MODE_STREAM_MODE;
 	if (devc->external_clock) {
 		mode |= DS_MODE_CLK_TYPE;
 		if (devc->clock_edge == DS_EDGE_FALLING)
 			mode |= DS_MODE_CLK_EDGE;
-	}
-	if (devc->limit_samples > DS_MAX_LOGIC_DEPTH *
-		ceil(devc->cur_samplerate * 1.0 / devc->profile->max_samplerate)
-		&& !devc->continuous_mode) {
-		/* Enable RLE for long captures.
-		 * Without this, captured data present errors.
-		 */
-		mode |= DS_MODE_RLE_MODE;
 	}
 
 	WL16(&cfg->mode, mode);
@@ -1114,7 +1104,6 @@ SR_PRIV struct dev_context *dslogic_dev_new(void)
 	devc->cur_samplerate = 0;
 	devc->limit_samples = 0;
 	devc->capture_ratio = 0;
-	devc->continuous_mode = FALSE;
 	devc->clock_edge = DS_EDGE_RISING;
 
 	return devc;
@@ -1436,14 +1425,7 @@ static size_t to_bytes_per_ms(const struct sr_dev_inst *sdi)
 	const struct dev_context *const devc = sdi->priv;
 	const size_t ch_count = enabled_channel_count(sdi);
 
-	if (devc->continuous_mode)
 		return (devc->cur_samplerate * ch_count) / (1000 * 8);
-
-
-	/* If we're in buffered mode, the transfer rate is not so important,
-	 * but we expect to get at least 10% of the high-speed USB bandwidth.
-	 */
-	return 35000000 / (1000 * 10);
 }
 
 static size_t get_buffer_size(const struct sr_dev_inst *sdi)

--- a/src/hardware/dreamsourcelab-dslogic/protocol.h
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.h
@@ -41,7 +41,8 @@
 #define NUM_CHANNELS		16
 #define NUM_TRIGGER_STAGES	16
 
-#define DSLOGIC_REQUIRED_VERSION_MAJOR	1
+#define DSLOGIC_REQUIRED_VERSION_MAJOR_V1	1
+#define DSLOGIC_REQUIRED_VERSION_MAJOR_V2	2
 
 /* 6 delay states of up to 256 clock ticks */
 #define MAX_SAMPLE_DELAY	(6 * 256)
@@ -52,6 +53,9 @@
 #define DSLOGIC_PRO_FPGA_FIRMWARE "dreamsourcelab-dslogic-pro-fpga.fw"
 #define DSLOGIC_PLUS_FPGA_FIRMWARE "dreamsourcelab-dslogic-plus-fpga.fw"
 #define DSLOGIC_BASIC_FPGA_FIRMWARE "dreamsourcelab-dslogic-basic-fpga.fw"
+#define DSLOGIC_U3PRO16_FPGA_FIRMWARE "dreamsourcelab-dslogic-u3pro16-fpga.fw"
+
+#define DSLOGIC_CAPS_ADF4360 (1 << 8)
 
 enum dslogic_operation_modes {
 	DS_OP_NORMAL,
@@ -73,6 +77,11 @@ enum dslogic_edge_modes {
 	DS_EDGE_FALLING,
 };
 
+enum dslogic_api_version {
+	DS_API_V1,
+	DS_API_V2
+};
+
 struct dslogic_version {
 	uint8_t major;
 	uint8_t minor;
@@ -91,7 +100,6 @@ struct dslogic_trigger_pos {
 	uint32_t remain_cnt_l;
 	uint32_t remain_cnt_h;
 	uint32_t status;
-	uint8_t first_block[488];
 };
 
 struct dslogic_profile {
@@ -111,6 +119,13 @@ struct dslogic_profile {
 
 	/* Memory depth in bits. */
 	uint64_t mem_depth;
+	uint32_t usb_buffer_duration_ms;
+	uint32_t block_size;
+	enum dslogic_api_version api_version;
+	uint64_t max_samplerate;
+	uint64_t half_samplerate;
+    uint64_t quarter_samplerate;
+	uint8_t max_predivider;
 };
 
 struct dev_context {

--- a/src/hardware/dreamsourcelab-dslogic/protocol.h
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.h
@@ -160,7 +160,6 @@ struct dev_context {
 	uint16_t mode;
 	uint32_t trigger_pos;
 	gboolean external_clock;
-	gboolean continuous_mode;
 	int clock_edge;
 	double cur_threshold;
 	GThread *thread_handle;

--- a/src/hardware/dreamsourcelab-dslogic/protocol.h
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.h
@@ -60,6 +60,14 @@ enum dslogic_operation_modes {
 	DS_OP_LOOPBACK_TEST,
 };
 
+enum dslogic_data_processing_states {
+	DS_DATA_PROC_IDLE,
+	DS_DATA_PROC_START_REQ,
+	DS_DATA_PROC_RUNNING,
+	DS_DATA_PROC_ABORT_REQ,
+	DS_DATA_PROC_MAX_SAMPLES_REACHED,
+};
+
 enum dslogic_edge_modes {
 	DS_EDGE_RISING,
 	DS_EDGE_FALLING,
@@ -140,6 +148,11 @@ struct dev_context {
 	gboolean continuous_mode;
 	int clock_edge;
 	double cur_threshold;
+	GThread *thread_handle;
+	struct libusb_transfer *completed_transfer;
+	GMutex data_proc_mutex;
+	GCond data_proc_state_cond;
+	enum dslogic_data_processing_states data_proc_state;
 };
 
 SR_PRIV int dslogic_fpga_firmware_upload(const struct sr_dev_inst *sdi);


### PR DESCRIPTION
deinterleave_buffer is used to convert the received samples from DSLogic device (which is a sequence of 64-bit words in round-robin for each channel, to the format sigrok is expecting (sequence of words containing the value for given channel as bitmask).

The existing implementation looped over every single bit, making it inefficient assuming that a typical trace contains little signal changes compared to the sample rate.

This change improves the deainterleave function by forward copying 64 words assuming there is no change. Only if there is a change, it searches the individual channels for bit-wise changes.