### PR TITLE
dslogic: Optimize deinterleave_buffer

### DIFF
--- a/src/hardware/dreamsourcelab-dslogic/protocol.c
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.c
@@ -731,6 +731,10 @@ static void deinterleave_buffer(const uint8_t *src, size_t length,
 	uint64_t last_data[NUM_CHANNELS];
 	bool first_loop = TRUE;
 	unsigned int idx;
+
+	/* initially memset first samples of destination buffer to avoid
+	recording uninitialized garbage for channels which are not enabled */
+	memset(dst_ptr, 0, DSLOGIC_ATOMIC_SAMPLES * sizeof(uint16_t));
 	/* for first iteration, force last_data to be different */
 	for (unsigned int i = 0; i < channel_count; i++)
 		last_data[i] = ~src_ptr[i];

--- a/src/hardware/dreamsourcelab-dslogic/protocol.c
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.c
@@ -753,7 +753,7 @@ static void deinterleave_buffer(const uint8_t *src, size_t length,
 			if (channel_mask & (1 << channel)) {
 				if (last_data[idx] != src_ptr[idx]) {
 					for (unsigned int bit = 0; bit != DSLOGIC_ATOMIC_SAMPLES; bit++) {
-						if (src_ptr[channel] & (UINT64_C(1) << bit))
+						if (src_ptr[idx] & (UINT64_C(1) << bit))
 							dst_ptr[bit] |= (1 << channel);
 						else
 							dst_ptr[bit] &= ~(uint16_t)(1 << channel);


### PR DESCRIPTION
deinterleave_buffer is used to convert the received samples from DSLogic device (which is a sequence of 64-bit words in round-robin for each channel, to the format sigrok is expecting (sequence of words containing the value for given channel as bitmask).

The existing implementation looped over every single bit, making it inefficient assuming that a typical trace contains little signal changes compared to the sample rate.

This change improves the deainterleave function by forward copying 64 words assuming there is no change. Only if there is a change, it searches the individual channels for bit-wise changes.