### PR TITLE
Support for dreamsourcelab DSLogic U3Pro16

### DIFF
--- a/contrib/60-libsigrok.rules
+++ b/contrib/60-libsigrok.rules
@@ -110,6 +110,8 @@ ATTRS{idVendor}=="2a0e", ATTRS{idProduct}=="0002", ENV{ID_SIGROK}="1"
 ATTRS{idVendor}=="2a0e", ATTRS{idProduct}=="0020", ENV{ID_SIGROK}="1"
 # DreamSourceLab DSLogic Basic
 ATTRS{idVendor}=="2a0e", ATTRS{idProduct}=="0021", ENV{ID_SIGROK}="1"
+# DreamSourceLab DSLogic U3Pro16
+ATTRS{idVendor}=="2a0e", ATTRS{idProduct}=="002a", ENV{ID_SIGROK}="1"
 
 # GW-Instek GDM-9061 (USBTMC mode)
 ATTRS{idVendor}=="2184", ATTRS{idProduct}=="0059", ENV{ID_SIGROK}="1"

--- a/src/hardware/dreamsourcelab-dslogic/api.c
+++ b/src/hardware/dreamsourcelab-dslogic/api.c
@@ -51,7 +51,7 @@ static const struct dslogic_profile supported_device[] = {
 	/* DreamSourceLab DSLogic U3Pro16 */
 	{ 0x2a0e, 0x002a, "DreamSourceLab", "DSLogic U3Pro16", NULL,
 		"dreamsourcelab-dslogic-basic-fx2.fw",
-		DSLOGIC_CAPS_ADF4360, "DreamSourceLab", "DSLogic", 
+		DSLOGIC_CAPS_ADF4360 | DSLOGIC_CAPS_USB30, "DreamSourceLab", "DSLogic", 
 		2ULL * 1024ULL * 1024ULL * 1024ULL, 40,
 		1024, SR_MHZ(500), SR_MHZ(500), SR_GHZ(1), 5},
 

--- a/src/hardware/dreamsourcelab-dslogic/api.c
+++ b/src/hardware/dreamsourcelab-dslogic/api.c
@@ -26,23 +26,34 @@ static const struct dslogic_profile supported_device[] = {
 	/* DreamSourceLab DSLogic */
 	{ 0x2a0e, 0x0001, "DreamSourceLab", "DSLogic", NULL,
 		"dreamsourcelab-dslogic-fx2.fw",
-		0, "DreamSourceLab", "DSLogic", 256 * 1024 * 1024},
+		0, "DreamSourceLab", "DSLogic", 256 * 1024 * 1024, 100,
+		512, DS_API_V1, SR_MHZ(100), SR_MHZ(200), SR_MHZ(400), 1},
 	/* DreamSourceLab DSCope */
 	{ 0x2a0e, 0x0002, "DreamSourceLab", "DSCope", NULL,
 		"dreamsourcelab-dscope-fx2.fw",
-		0, "DreamSourceLab", "DSCope", 256 * 1024 * 1024},
+		0, "DreamSourceLab", "DSCope", 256 * 1024 * 1024, 100,
+		512, DS_API_V1, SR_MHZ(100), SR_MHZ(200), SR_MHZ(400), 1},
 	/* DreamSourceLab DSLogic Pro */
 	{ 0x2a0e, 0x0003, "DreamSourceLab", "DSLogic Pro", NULL,
 		"dreamsourcelab-dslogic-pro-fx2.fw",
-		0, "DreamSourceLab", "DSLogic", 256 * 1024 * 1024},
+		0, "DreamSourceLab", "DSLogic", 256 * 1024 * 1024, 100,
+		512, DS_API_V1, SR_MHZ(100), SR_MHZ(200), SR_MHZ(400), 1},
 	/* DreamSourceLab DSLogic Plus */
 	{ 0x2a0e, 0x0020, "DreamSourceLab", "DSLogic Plus", NULL,
 		"dreamsourcelab-dslogic-plus-fx2.fw",
-		0, "DreamSourceLab", "DSLogic", 256 * 1024 * 1024},
+		0, "DreamSourceLab", "DSLogic", 256 * 1024 * 1024, 100,
+		512, DS_API_V1, SR_MHZ(100), SR_MHZ(200), SR_MHZ(400), 1},
 	/* DreamSourceLab DSLogic Basic */
 	{ 0x2a0e, 0x0021, "DreamSourceLab", "DSLogic Basic", NULL,
 		"dreamsourcelab-dslogic-basic-fx2.fw",
-		0, "DreamSourceLab", "DSLogic", 256 * 1024},
+		0, "DreamSourceLab", "DSLogic", 256 * 1024, 100,
+		512, DS_API_V1, SR_MHZ(100), SR_MHZ(200), SR_MHZ(400), 1},
+	/* DreamSourceLab DSLogic U3Pro16 */
+	{ 0x2a0e, 0x002a, "DreamSourceLab", "DSLogic U3Pro16", NULL,
+		"dreamsourcelab-dslogic-basic-fx2.fw",
+		DSLOGIC_CAPS_ADF4360, "DreamSourceLab", "DSLogic", 
+		2ULL * 1024ULL * 1024ULL * 1024ULL, 40,
+		1024, DS_API_V2, SR_MHZ(500), SR_MHZ(500), SR_GHZ(1), 5},
 
 	ALL_ZERO
 };
@@ -102,6 +113,27 @@ static const uint64_t samplerates[] = {
 	SR_MHZ(100),
 	SR_MHZ(200),
 	SR_MHZ(400),
+};
+
+static const uint64_t samplerates_U3Pro16[] = {
+	SR_KHZ(10),
+	SR_KHZ(20),
+	SR_KHZ(50),
+	SR_KHZ(100),
+	SR_KHZ(200),
+	SR_KHZ(500),
+	SR_MHZ(1),
+	SR_MHZ(2),
+	SR_MHZ(5),
+	SR_MHZ(10),
+	SR_MHZ(20),
+	SR_MHZ(25),
+	SR_MHZ(50),
+	SR_MHZ(100),
+	SR_MHZ(125),
+	SR_MHZ(250),
+	SR_MHZ(500),
+	SR_MHZ(1000),
 };
 
 static gboolean is_plausible(const struct libusb_device_descriptor *des)
@@ -255,9 +287,18 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 		sdi->priv = devc;
 		devices = g_slist_append(devices, sdi);
 
-		devc->samplerates = samplerates;
-		devc->num_samplerates = ARRAY_SIZE(samplerates);
-		has_firmware = usb_match_manuf_prod(devlist[i], "DreamSourceLab", "USB-based Instrument");
+		if (strcmp("DSLogic U3Pro16", devc->profile->model) == 0) {
+			devc->samplerates = samplerates_U3Pro16;
+			devc->num_samplerates = ARRAY_SIZE(samplerates_U3Pro16);
+		} else {
+			devc->samplerates = samplerates;
+			devc->num_samplerates = ARRAY_SIZE(samplerates);
+
+		}
+		if (devc->profile->api_version == DS_API_V1)
+			has_firmware = usb_match_manuf_prod(devlist[i], "DreamSourceLab", "USB-based Instrument");
+		else
+			has_firmware = usb_match_manuf_prod(devlist[i], "DreamSourceLab", "USB-based DSL Instrument v2");
 
 		if (has_firmware) {
 			/* Already has the firmware, so fix the new address. */

--- a/src/hardware/dreamsourcelab-dslogic/api.c
+++ b/src/hardware/dreamsourcelab-dslogic/api.c
@@ -477,6 +477,9 @@ static int config_get(uint32_t key, GVariant **data,
 	case SR_CONF_EXTERNAL_CLOCK:
 		*data = g_variant_new_boolean(devc->external_clock);
 		break;
+	case SR_CONF_CONTINUOUS:
+		*data = g_variant_new_boolean(devc->continuous_mode);
+		break;
 	case SR_CONF_CLOCK_EDGE:
 		idx = devc->clock_edge;
 		if (idx >= (int)ARRAY_SIZE(signal_edges))
@@ -529,6 +532,9 @@ static int config_set(uint32_t key, GVariant *data,
 		break;
 	case SR_CONF_EXTERNAL_CLOCK:
 		devc->external_clock = g_variant_get_boolean(data);
+		break;
+	case SR_CONF_CONTINUOUS:
+		devc->continuous_mode = g_variant_get_boolean(data);
 		break;
 	case SR_CONF_CLOCK_EDGE:
 		if ((idx = std_str_idx(data, ARRAY_AND_SIZE(signal_edges))) < 0)

--- a/src/hardware/dreamsourcelab-dslogic/api.c
+++ b/src/hardware/dreamsourcelab-dslogic/api.c
@@ -27,33 +27,33 @@ static const struct dslogic_profile supported_device[] = {
 	{ 0x2a0e, 0x0001, "DreamSourceLab", "DSLogic", NULL,
 		"dreamsourcelab-dslogic-fx2.fw",
 		0, "DreamSourceLab", "DSLogic", 256 * 1024 * 1024, 100,
-		512, DS_API_V1, SR_MHZ(100), SR_MHZ(200), SR_MHZ(400), 1},
+		512, SR_MHZ(100), SR_MHZ(200), SR_MHZ(400), 1},
 	/* DreamSourceLab DSCope */
 	{ 0x2a0e, 0x0002, "DreamSourceLab", "DSCope", NULL,
 		"dreamsourcelab-dscope-fx2.fw",
 		0, "DreamSourceLab", "DSCope", 256 * 1024 * 1024, 100,
-		512, DS_API_V1, SR_MHZ(100), SR_MHZ(200), SR_MHZ(400), 1},
+		512, SR_MHZ(100), SR_MHZ(200), SR_MHZ(400), 1},
 	/* DreamSourceLab DSLogic Pro */
 	{ 0x2a0e, 0x0003, "DreamSourceLab", "DSLogic Pro", NULL,
 		"dreamsourcelab-dslogic-pro-fx2.fw",
 		0, "DreamSourceLab", "DSLogic", 256 * 1024 * 1024, 100,
-		512, DS_API_V1, SR_MHZ(100), SR_MHZ(200), SR_MHZ(400), 1},
+		512, SR_MHZ(100), SR_MHZ(200), SR_MHZ(400), 1},
 	/* DreamSourceLab DSLogic Plus */
 	{ 0x2a0e, 0x0020, "DreamSourceLab", "DSLogic Plus", NULL,
 		"dreamsourcelab-dslogic-plus-fx2.fw",
 		0, "DreamSourceLab", "DSLogic", 256 * 1024 * 1024, 100,
-		512, DS_API_V1, SR_MHZ(100), SR_MHZ(200), SR_MHZ(400), 1},
+		512, SR_MHZ(100), SR_MHZ(200), SR_MHZ(400), 1},
 	/* DreamSourceLab DSLogic Basic */
 	{ 0x2a0e, 0x0021, "DreamSourceLab", "DSLogic Basic", NULL,
 		"dreamsourcelab-dslogic-basic-fx2.fw",
 		0, "DreamSourceLab", "DSLogic", 256 * 1024, 100,
-		512, DS_API_V1, SR_MHZ(100), SR_MHZ(200), SR_MHZ(400), 1},
+		512, SR_MHZ(100), SR_MHZ(200), SR_MHZ(400), 1},
 	/* DreamSourceLab DSLogic U3Pro16 */
 	{ 0x2a0e, 0x002a, "DreamSourceLab", "DSLogic U3Pro16", NULL,
 		"dreamsourcelab-dslogic-basic-fx2.fw",
 		DSLOGIC_CAPS_ADF4360, "DreamSourceLab", "DSLogic", 
 		2ULL * 1024ULL * 1024ULL * 1024ULL, 40,
-		1024, DS_API_V2, SR_MHZ(500), SR_MHZ(500), SR_GHZ(1), 5},
+		1024, SR_MHZ(500), SR_MHZ(500), SR_GHZ(1), 5},
 
 	ALL_ZERO
 };
@@ -160,8 +160,8 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 	struct sr_channel_group *cg;
 	struct sr_config *src;
 	const struct dslogic_profile *prof;
+	enum dslogic_api_version api_version;
 	GSList *l, *devices, *conn_devices;
-	gboolean has_firmware;
 	struct libusb_device_descriptor des;
 	libusb_device **devlist;
 	struct libusb_device_handle *hdl;
@@ -295,14 +295,11 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 			devc->num_samplerates = ARRAY_SIZE(samplerates);
 
 		}
-		if (devc->profile->api_version == DS_API_V1)
-			has_firmware = usb_match_manuf_prod(devlist[i], "DreamSourceLab", "USB-based Instrument");
-		else
-			has_firmware = usb_match_manuf_prod(devlist[i], "DreamSourceLab", "USB-based DSL Instrument v2");
+		api_version = dslogic_detect_api_version(devlist[i]);
 
-		if (has_firmware) {
+		if (api_version != DS_API_V_UNKNOWN) {
 			/* Already has the firmware, so fix the new address. */
-			sr_dbg("Found a DSLogic device.");
+			sr_dbg("Found a DSLogic device with API version %d", api_version);
 			sdi->status = SR_ST_INACTIVE;
 			sdi->inst_type = SR_INST_USB;
 			sdi->conn = sr_usb_dev_inst_new(libusb_get_bus_number(devlist[i]),

--- a/src/hardware/dreamsourcelab-dslogic/api.c
+++ b/src/hardware/dreamsourcelab-dslogic/api.c
@@ -477,9 +477,6 @@ static int config_get(uint32_t key, GVariant **data,
 	case SR_CONF_EXTERNAL_CLOCK:
 		*data = g_variant_new_boolean(devc->external_clock);
 		break;
-	case SR_CONF_CONTINUOUS:
-		*data = g_variant_new_boolean(devc->continuous_mode);
-		break;
 	case SR_CONF_CLOCK_EDGE:
 		idx = devc->clock_edge;
 		if (idx >= (int)ARRAY_SIZE(signal_edges))
@@ -532,9 +529,6 @@ static int config_set(uint32_t key, GVariant *data,
 		break;
 	case SR_CONF_EXTERNAL_CLOCK:
 		devc->external_clock = g_variant_get_boolean(data);
-		break;
-	case SR_CONF_CONTINUOUS:
-		devc->continuous_mode = g_variant_get_boolean(data);
 		break;
 	case SR_CONF_CLOCK_EDGE:
 		if ((idx = std_str_idx(data, ARRAY_AND_SIZE(signal_edges))) < 0)

--- a/src/hardware/dreamsourcelab-dslogic/api.c
+++ b/src/hardware/dreamsourcelab-dslogic/api.c
@@ -405,10 +405,11 @@ static int dev_open(struct sr_dev_inst *sdi)
 
 	if (devc->cur_threshold == 0.0) {
 		devc->cur_threshold = thresholds[1][0];
-		return dslogic_set_voltage_threshold(sdi, devc->cur_threshold);
+		ret = dslogic_set_voltage_threshold(sdi, devc->cur_threshold);
 	}
+	devc->continuous_mode = TRUE;
 
-	return SR_OK;
+	return ret;
 }
 
 static int dev_close(struct sr_dev_inst *sdi)

--- a/src/hardware/dreamsourcelab-dslogic/protocol.c
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.c
@@ -866,6 +866,17 @@ static int fpga_configure(const struct sr_dev_inst *sdi)
 	WL16(&cfg->trig_glb_header, DS_CFG_TRIG_GLB);
 	WL16(&cfg->trig_header, DS_CFG_TRIG);
 
+	if ((devc->profile->dev_caps & DSLOGIC_CAPS_USB30) == 0) {
+		uint8_t cmd;
+		cmd = DS_WR_WORDWIDE;
+		ret = command_write(usb->devhdl, DSL_CTL_WORDWIDE, sizeof(uint8_t), &cmd);
+		if (ret != SR_OK) {
+			sr_err("Failed to set GPIF to be wordwide.");
+			g_free(cfg_buffer);
+			return ret;
+		}
+	}
+
 	/* Pass in the length of a fixed-size struct. Really. */
 	len = fpga_config_size(sdi) / 2;
 	c[0] = len & 0xff;

--- a/src/hardware/dreamsourcelab-dslogic/protocol.c
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.c
@@ -752,11 +752,9 @@ static bool set_trigger(const struct sr_dev_inst *sdi, struct fpga_config_common
 	trigger_point = (devc->capture_ratio * devc->limit_samples) / 100;
 	if (trigger_point < DSLOGIC_ATOMIC_SAMPLES)
 		trigger_point = DSLOGIC_ATOMIC_SAMPLES;
-	const uint64_t mem_depth_per_channel = devc->profile->mem_depth /
+	const uint64_t mem_depth = devc->profile->mem_depth /
 		num_enabled_channels;
-	const uint64_t max_trigger_point = devc->continuous_mode ?
-		((mem_depth_per_channel * 10) / 100) :
-		((mem_depth_per_channel * DS_MAX_TRIG_PERCENT) / 100);
+	const uint64_t max_trigger_point = (mem_depth * 10) / 100;
 	if (trigger_point > max_trigger_point)
 		trigger_point = max_trigger_point;
 	cfg->trig_pos = trigger_point & ~(DSLOGIC_ATOMIC_SAMPLES - 1);
@@ -910,20 +908,11 @@ static int fpga_configure(const struct sr_dev_inst *sdi)
 	else if (devc->cur_samplerate == devc->profile->quarter_samplerate)
 		mode |= DS_MODE_QUAR_MODE;
 
-	if (devc->continuous_mode)
-		mode |= DS_MODE_STREAM_MODE;
+	mode |= DS_MODE_STREAM_MODE;
 	if (devc->external_clock) {
 		mode |= DS_MODE_CLK_TYPE;
 		if (devc->clock_edge == DS_EDGE_FALLING)
 			mode |= DS_MODE_CLK_EDGE;
-	}
-	if (devc->limit_samples > DS_MAX_LOGIC_DEPTH *
-		ceil(devc->cur_samplerate * 1.0 / devc->profile->max_samplerate)
-		&& !devc->continuous_mode) {
-		/* Enable RLE for long captures.
-		 * Without this, captured data present errors.
-		 */
-		mode |= DS_MODE_RLE_MODE;
 	}
 
 	WL16(&cfg->mode, mode);
@@ -1120,7 +1109,6 @@ SR_PRIV struct dev_context *dslogic_dev_new(void)
 	devc->cur_samplerate = 0;
 	devc->limit_samples = 0;
 	devc->capture_ratio = 0;
-	devc->continuous_mode = FALSE;
 	devc->clock_edge = DS_EDGE_RISING;
 
 	return devc;
@@ -1442,14 +1430,7 @@ static size_t to_bytes_per_ms(const struct sr_dev_inst *sdi)
 	const struct dev_context *const devc = sdi->priv;
 	const size_t ch_count = enabled_channel_count(sdi);
 
-	if (devc->continuous_mode)
 		return (devc->cur_samplerate * ch_count) / (1000 * 8);
-
-
-	/* If we're in buffered mode, the transfer rate is not so important,
-	 * but we expect to get at least 10% of the high-speed USB bandwidth.
-	 */
-	return 35000000 / (1000 * 10);
 }
 
 static size_t get_buffer_size(const struct sr_dev_inst *sdi)

--- a/src/hardware/dreamsourcelab-dslogic/protocol.c
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.c
@@ -731,6 +731,10 @@ static void deinterleave_buffer(const uint8_t *src, size_t length,
 	uint64_t last_data[NUM_CHANNELS];
 	bool first_loop = TRUE;
 	unsigned int idx;
+
+	/* initially memset first samples of destination buffer to avoid
+	recording uninitialized garbage for channels which are not enabled */
+	memset(dst_ptr, 0, DSLOGIC_ATOMIC_SAMPLES * sizeof(uint16_t));
 	/* for first iteration, force last_data to be different */
 	for (unsigned int i = 0; i < channel_count; i++)
 		last_data[i] = ~src_ptr[i];

--- a/src/hardware/dreamsourcelab-dslogic/protocol.c
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.c
@@ -753,7 +753,7 @@ static void deinterleave_buffer(const uint8_t *src, size_t length,
 			if (channel_mask & (1 << channel)) {
 				if (last_data[idx] != src_ptr[idx]) {
 					for (unsigned int bit = 0; bit != DSLOGIC_ATOMIC_SAMPLES; bit++) {
-						if (src_ptr[channel] & (UINT64_C(1) << bit))
+						if (src_ptr[idx] & (UINT64_C(1) << bit))
 							dst_ptr[bit] |= (1 << channel);
 						else
 							dst_ptr[bit] &= ~(uint16_t)(1 << channel);

--- a/src/hardware/dreamsourcelab-dslogic/protocol.h
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.h
@@ -56,6 +56,7 @@
 #define DSLOGIC_U3PRO16_FPGA_FIRMWARE "dreamsourcelab-dslogic-u3pro16-fpga.fw"
 
 #define DSLOGIC_CAPS_ADF4360 (1 << 8)
+#define DSLOGIC_CAPS_USB30   (1 << 7)
 
 enum dslogic_operation_modes {
 	DS_OP_NORMAL,

--- a/src/hardware/dreamsourcelab-dslogic/protocol.h
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.h
@@ -65,8 +65,6 @@ enum dslogic_operation_modes {
 };
 
 enum dslogic_data_processing_states {
-	DS_DATA_PROC_IDLE,
-	DS_DATA_PROC_START_REQ,
 	DS_DATA_PROC_RUNNING,
 	DS_DATA_PROC_ABORT_REQ,
 	DS_DATA_PROC_MAX_SAMPLES_REACHED,
@@ -164,7 +162,7 @@ struct dev_context {
 	int clock_edge;
 	double cur_threshold;
 	GThread *thread_handle;
-	struct libusb_transfer *completed_transfer;
+	GQueue *finished_transfers;
 	GMutex data_proc_mutex;
 	GCond data_proc_state_cond;
 	enum dslogic_data_processing_states data_proc_state;

--- a/src/hardware/dreamsourcelab-dslogic/protocol.h
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.h
@@ -76,8 +76,9 @@ enum dslogic_edge_modes {
 };
 
 enum dslogic_api_version {
-	DS_API_V1,
-	DS_API_V2
+	DS_API_V1 = 1,
+	DS_API_V2 = 2,
+	DS_API_V_UNKNOWN = 0xff
 };
 
 struct dslogic_version {
@@ -119,7 +120,6 @@ struct dslogic_profile {
 	uint64_t mem_depth;
 	uint32_t usb_buffer_duration_ms;
 	uint32_t block_size;
-	enum dslogic_api_version api_version;
 	uint64_t max_samplerate;
 	uint64_t half_samplerate;
     uint64_t quarter_samplerate;
@@ -128,6 +128,7 @@ struct dslogic_profile {
 
 struct dev_context {
 	const struct dslogic_profile *profile;
+	enum dslogic_api_version api_version;
 	/*
 	 * Since we can't keep track of a DSLogic device after upgrading
 	 * the firmware (it renumerates into a different device address
@@ -171,6 +172,7 @@ struct dev_context {
 
 SR_PRIV int dslogic_fpga_firmware_upload(const struct sr_dev_inst *sdi);
 SR_PRIV int dslogic_set_voltage_threshold(const struct sr_dev_inst *sdi, double threshold);
+SR_PRIV enum dslogic_api_version dslogic_detect_api_version(libusb_device *usbdev);
 SR_PRIV int dslogic_dev_open(struct sr_dev_inst *sdi, struct sr_dev_driver *di);
 SR_PRIV struct dev_context *dslogic_dev_new(void);
 SR_PRIV int dslogic_acquisition_start(const struct sr_dev_inst *sdi);

--- a/src/hardware/dreamsourcelab-dslogic/protocol.h
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.h
@@ -41,7 +41,8 @@
 #define NUM_CHANNELS		16
 #define NUM_TRIGGER_STAGES	16
 
-#define DSLOGIC_REQUIRED_VERSION_MAJOR	1
+#define DSLOGIC_REQUIRED_VERSION_MAJOR_V1	1
+#define DSLOGIC_REQUIRED_VERSION_MAJOR_V2	2
 
 /* 6 delay states of up to 256 clock ticks */
 #define MAX_SAMPLE_DELAY	(6 * 256)
@@ -52,6 +53,9 @@
 #define DSLOGIC_PRO_FPGA_FIRMWARE "dreamsourcelab-dslogic-pro-fpga.fw"
 #define DSLOGIC_PLUS_FPGA_FIRMWARE "dreamsourcelab-dslogic-plus-fpga.fw"
 #define DSLOGIC_BASIC_FPGA_FIRMWARE "dreamsourcelab-dslogic-basic-fpga.fw"
+#define DSLOGIC_U3PRO16_FPGA_FIRMWARE "dreamsourcelab-dslogic-u3pro16-fpga.fw"
+
+#define DSLOGIC_CAPS_ADF4360 (1 << 8)
 
 enum dslogic_operation_modes {
 	DS_OP_NORMAL,
@@ -73,6 +77,11 @@ enum dslogic_edge_modes {
 	DS_EDGE_FALLING,
 };
 
+enum dslogic_api_version {
+	DS_API_V1,
+	DS_API_V2
+};
+
 struct dslogic_version {
 	uint8_t major;
 	uint8_t minor;
@@ -91,7 +100,6 @@ struct dslogic_trigger_pos {
 	uint32_t remain_cnt_l;
 	uint32_t remain_cnt_h;
 	uint32_t status;
-	uint8_t first_block[488];
 };
 
 struct dslogic_profile {
@@ -111,6 +119,13 @@ struct dslogic_profile {
 
 	/* Memory depth in bits. */
 	uint64_t mem_depth;
+	uint32_t usb_buffer_duration_ms;
+	uint32_t block_size;
+	enum dslogic_api_version api_version;
+	uint64_t max_samplerate;
+	uint64_t half_samplerate;
+    uint64_t quarter_samplerate;
+	uint8_t max_predivider;
 };
 
 struct dev_context {

--- a/src/hardware/dreamsourcelab-dslogic/protocol.h
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.h
@@ -160,7 +160,6 @@ struct dev_context {
 	uint16_t mode;
 	uint32_t trigger_pos;
 	gboolean external_clock;
-	gboolean continuous_mode;
 	int clock_edge;
 	double cur_threshold;
 	GThread *thread_handle;

--- a/src/hardware/dreamsourcelab-dslogic/protocol.h
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.h
@@ -147,7 +147,7 @@ struct dev_context {
 
 	gboolean acq_aborted;
 
-	unsigned int sent_samples;
+	uint64_t sent_samples;
 	int submitted_transfers;
 	int empty_transfer_count;
 

--- a/src/hardware/dreamsourcelab-dslogic/protocol.h
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.h
@@ -168,6 +168,7 @@ struct dev_context {
 	GMutex data_proc_mutex;
 	GCond data_proc_state_cond;
 	enum dslogic_data_processing_states data_proc_state;
+	uint64_t samples_captured;
 };
 
 SR_PRIV int dslogic_fpga_firmware_upload(const struct sr_dev_inst *sdi);

--- a/src/hardware/dreamsourcelab-dslogic/protocol.h
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.h
@@ -60,6 +60,14 @@ enum dslogic_operation_modes {
 	DS_OP_LOOPBACK_TEST,
 };
 
+enum dslogic_data_processing_states {
+	DS_DATA_PROC_IDLE,
+	DS_DATA_PROC_START_REQ,
+	DS_DATA_PROC_RUNNING,
+	DS_DATA_PROC_ABORT_REQ,
+	DS_DATA_PROC_MAX_SAMPLES_REACHED,
+};
+
 enum dslogic_edge_modes {
 	DS_EDGE_RISING,
 	DS_EDGE_FALLING,
@@ -140,6 +148,11 @@ struct dev_context {
 	gboolean continuous_mode;
 	int clock_edge;
 	double cur_threshold;
+	GThread *thread_handle;
+	struct libusb_transfer *completed_transfer;
+	GMutex data_proc_mutex;
+	GCond data_proc_state_cond;
+	enum dslogic_data_processing_states data_proc_state;
 };
 
 SR_PRIV int dslogic_fpga_firmware_upload(const struct sr_dev_inst *sdi);

--- a/src/hardware/dreamsourcelab-dslogic/protocol.h
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.h
@@ -160,6 +160,7 @@ struct dev_context {
 	uint16_t mode;
 	uint32_t trigger_pos;
 	gboolean external_clock;
+	gboolean continuous_mode;
 	int clock_edge;
 	double cur_threshold;
 	GThread *thread_handle;


### PR DESCRIPTION
This PR adds support for DSLogic U3Pro16 to libsigrok.
It is a logic analyzer with up to 1GHz sample rate 16 channels, buffered and streaming mode support and USB3 interface.

The support has been added to existing dreamsourcelab-dslogic driver with some runtime diversity since the U3Pro16 has a new API which is not fully backward-compatible with the legacy dreamsource logic devices.

In addition, the generic part of the driver got some performance updates in the deinterleaving function and a dedicated worker thread to process/deinterlave samples while processing already the next USB transfer.