### PR TITLE
input/vcd: add parsing support for SV 'logic' type

### DIFF
--- a/src/input/vcd.c
+++ b/src/input/vcd.c
@@ -45,7 +45,7 @@
  * Based on Verilog standard IEEE Std 1364-2001 Version C
  *
  * Supported features:
- * - $var with 'wire' and 'reg' types of scalar variables
+ * - $var with 'wire', 'reg' and 'logic' types of scalar variables
  * - $timescale definition for samplerate
  * - multiple character variable identifiers
  * - same identifer used for multiple signals (identical values)
@@ -820,7 +820,7 @@ static int parse_header_var(struct context *inc, char *contents)
 	char **parts;
 	size_t length;
 	char *type, *size_txt, *id, *ref, *idx;
-	gboolean is_reg, is_wire, is_real, is_int;
+	gboolean is_reg, is_wire, is_logic, is_real, is_int;
 	gboolean is_str;
 	enum sr_channeltype ch_type;
 	size_t size, next_size;
@@ -848,11 +848,12 @@ static int parse_header_var(struct context *inc, char *contents)
 		idx = NULL;
 	is_reg = g_strcmp0(type, "reg") == 0;
 	is_wire = g_strcmp0(type, "wire") == 0;
+	is_logic = g_strcmp0(type, "logic") == 0;
 	is_real = g_strcmp0(type, "real") == 0;
 	is_int = g_strcmp0(type, "integer") == 0;
 	is_str = g_strcmp0(type, "string") == 0;
 
-	if (is_reg || is_wire) {
+	if (is_reg || is_wire || is_logic) {
 		ch_type = SR_CHANNEL_LOGIC;
 	} else if (is_real || is_int) {
 		ch_type = SR_CHANNEL_ANALOG;


### PR DESCRIPTION
Hi,
my use case is "simple":
I have SystemVerilog (SV) code with Verilator simulation that produces USB signals.
Verilator can create VCD traces that I want to import via PulseView and check with the awesome decoder implementations if everything is sound.
However, as I am using SV, I have primarily variables of type `logic` which the VCD parser does not recognize.
Hence, I need to manually edit my VCD traces to change the `$val` types from `logic` to `wire` or `reg` which is somewhat inconvenient.
Took me some time to figure out what's the problem here, as the only response that I got from PulseView was `No channels enabled.`.
The changes to add parsing support for the `logic` type is straight forward and should'nt cause problems.

Also, here is some minimal example of an VCD file for i.e. regression tests:
```
$scope module doesntMatter $end
$var logic 1 " D0 $end
$upscope $end
$enddefinitions $end
#1
$dumpvars
1"
$end
```