### PR TITLE
input/vcd: add option to manually specify & enforce a samplerate

### DIFF
--- a/src/input/vcd.c
+++ b/src/input/vcd.c
@@ -35,6 +35,9 @@
  *     timestamp 0.
  *   Value > 0: Start at the given timestamp.
  *
+ * samplerate: overwrite/manually specify the samplerate for this VCD file
+ *   and ignore timescale sections.
+ * 
  * downsample: Divide the samplerate by the given factor. This can
  *   speed up operation on long captures.
  *
@@ -123,6 +126,7 @@
 struct context {
 	struct vcd_user_opt {
 		size_t maxchannels; /* sigrok channels (output) */
+		uint64_t samplerate;
 		uint64_t downsample;
 		uint64_t compress;
 		uint64_t skip_starttime;
@@ -694,6 +698,11 @@ static gboolean have_header(GString *buf)
 static int parse_timescale(struct context *inc, char *contents)
 {
 	uint64_t p, q;
+
+	if (inc->options.samplerate != 0) {
+		sr_info("Ignoring timescale section as the samplerate was manually overwritten!");
+		return SR_OK;
+	}
 
 	/*
 	 * The standard allows for values 1, 10 or 100
@@ -2108,6 +2117,13 @@ static int init(struct sr_input *in, GHashTable *options)
 	data = g_hash_table_lookup(options, "numchannels");
 	inc->options.maxchannels = g_variant_get_uint32(data);
 
+	data = g_hash_table_lookup(options, "samplerate_overwrite");
+	inc->options.samplerate = g_variant_get_uint64(data);
+	if (inc->options.samplerate != 0) {
+		// Set the samplerate
+		inc->samplerate = inc->options.samplerate;
+	}
+
 	data = g_hash_table_lookup(options, "downsample");
 	inc->options.downsample = g_variant_get_uint64(data);
 	if (inc->options.downsample < 1)
@@ -2244,6 +2260,7 @@ static int reset(struct sr_input *in)
 
 enum vcd_option_t {
 	OPT_NUM_CHANS,
+	OPT_SAMPLERATE,
 	OPT_DOWN_SAMPLE,
 	OPT_SKIP_COUNT,
 	OPT_COMPRESS,
@@ -2254,6 +2271,13 @@ static struct sr_option options[] = {
 	[OPT_NUM_CHANS] = {
 		"numchannels", "Max number of sigrok channels",
 		"The maximum number of sigrok channels to create for VCD input signals.",
+		NULL, NULL,
+	},
+	[OPT_SAMPLERATE] = {
+		"samplerate_overwrite", "Overwrite Samplerate",
+		"Overwrite the input file's samplerate, i.e. for frequencies not representable via timescale."
+		"By default the VCD file is searched for an timescale section to compute the samplerate."
+		"For values != 0 this value will be considered as the actual samplerate and the timescale section will be ignored.",
 		NULL, NULL,
 	},
 	[OPT_DOWN_SAMPLE] = {
@@ -2281,6 +2305,7 @@ static const struct sr_option *get_options(void)
 {
 	if (!options[0].def) {
 		options[OPT_NUM_CHANS].def = g_variant_ref_sink(g_variant_new_uint32(0));
+		options[OPT_SAMPLERATE].def = g_variant_ref_sink(g_variant_new_uint64(0));
 		options[OPT_DOWN_SAMPLE].def = g_variant_ref_sink(g_variant_new_uint64(1));
 		options[OPT_SKIP_COUNT].def = g_variant_ref_sink(g_variant_new_uint64(~UINT64_C(0)));
 		options[OPT_COMPRESS].def = g_variant_ref_sink(g_variant_new_uint64(0));


### PR DESCRIPTION
This PR is somewhat related to my other PR https://github.com/sigrokproject/libsigrok/pull/171, but independent!

My motivation for this feature is that cycle based simulation tools don't really care about the actual clock frequency and produce VCD dumpy with each time step corresponding to i.e. a clock change. If you want to use the created dump with pulseview then the `timescale` section is used to determine the period and to calculate the sample rate. In this case this value has not only nothing to do with the desired clock frequency (or sample rate) but it might not even be possible to represent the desired frequency with this method. This is due to the usage of integers to represent the period and time steps which can not as simple frequencies as 30 MHz (1/30 MHz = 33.333... µs as period). Hence, even for some simple clock signals the existing `timescale` field is not enough. Therefore, a new option was added to be able to overwrite the desired sample rate when importing a VCD trace. Another solution would have been the introduction of a custom section within the VCD file. I am not familiar with the VCD spec but I would expect this to not be standard compliant and needing more code modifications than the simple addition of another option. 

But if desired and preferred over the additional import option, then I am willing adjust the code to parse a custom section that can specify the sample rate directly instead of the period.

Oh and btw, I have tested this PR in combination with my other PR https://github.com/sigrokproject/libsigrok/pull/171 to analyze simulated USB interactions while using the protocol decoders.