### PR TITLE
enables the "external clock" of  Zeroplus HW driver and fixes a hidden bug

### DIFF
--- a/src/hardware/zeroplus-logic-cube/analyzer.c
+++ b/src/hardware/zeroplus-logic-cube/analyzer.c
@@ -462,7 +462,7 @@ SR_PRIV void analyzer_configure(libusb_device_handle *devh)
 	gl_reg_write(devh, MEMORY_LENGTH, g_memory_size);
 
 	/* Sele_Inside_Outside_Clock */
-	if (g_clock_ext==0)
+	if (g_clock_ext == 0)
 		gl_reg_write(devh, CLOCK_SOURCE, 0x01);
 	else if (g_edge==0)
 			gl_reg_write(devh, CLOCK_SOURCE, 0x02);

--- a/src/hardware/zeroplus-logic-cube/analyzer.c
+++ b/src/hardware/zeroplus-logic-cube/analyzer.c
@@ -114,6 +114,9 @@ static int g_trigger_count = 1;
 static int g_filter_status[8] = { 0 };
 static int g_filter_enable = 0;
 
+static int g_clock_ext=0;
+static int g_edge=0;
+
 static int g_freq_value = 1;
 static int g_freq_scale = FREQ_SCALE_MHZ;
 static int g_memory_size = MEMORY_SIZE_8K;
@@ -459,7 +462,12 @@ SR_PRIV void analyzer_configure(libusb_device_handle *devh)
 	gl_reg_write(devh, MEMORY_LENGTH, g_memory_size);
 
 	/* Sele_Inside_Outside_Clock */
-	gl_reg_write(devh, CLOCK_SOURCE, 0x03);
+	if (g_clock_ext==0)
+		gl_reg_write(devh, CLOCK_SOURCE, 0x01);
+	else if (g_edge==0)
+			gl_reg_write(devh, CLOCK_SOURCE, 0x02);
+		else
+			gl_reg_write(devh, CLOCK_SOURCE, 0x0);
 
 	/* Set_Trigger_Status */
 	for (i = 0; i < 8; i++)
@@ -577,6 +585,12 @@ SR_PRIV void analyzer_add_filter(int channel, int type)
 SR_PRIV void analyzer_set_trigger_count(int count)
 {
 	g_trigger_count = count;
+}
+
+SR_PRIV void analyzer_set_clock(int ext, int edge)
+{
+	g_clock_ext=ext;
+	g_edge=edge;
 }
 
 SR_PRIV void analyzer_set_freq(int freq, int scale)

--- a/src/hardware/zeroplus-logic-cube/analyzer.c
+++ b/src/hardware/zeroplus-logic-cube/analyzer.c
@@ -464,7 +464,7 @@ SR_PRIV void analyzer_configure(libusb_device_handle *devh)
 	/* Sele_Inside_Outside_Clock */
 	if (g_clock_ext == 0)
 		gl_reg_write(devh, CLOCK_SOURCE, 0x01);
-	else if (g_edge==0)
+	else if (g_edge == 0)
 			gl_reg_write(devh, CLOCK_SOURCE, 0x02);
 		else
 			gl_reg_write(devh, CLOCK_SOURCE, 0x0);

--- a/src/hardware/zeroplus-logic-cube/analyzer.c
+++ b/src/hardware/zeroplus-logic-cube/analyzer.c
@@ -589,7 +589,7 @@ SR_PRIV void analyzer_set_trigger_count(int count)
 
 SR_PRIV void analyzer_set_clock(int ext, int edge)
 {
-	g_clock_ext=ext;
+	g_clock_ext = ext;
 	g_edge=edge;
 }
 

--- a/src/hardware/zeroplus-logic-cube/analyzer.h
+++ b/src/hardware/zeroplus-logic-cube/analyzer.h
@@ -74,6 +74,7 @@
 #define COMPRESSION_ENABLE	0x8001
 #define COMPRESSION_DOUBLE	0x8002
 
+SR_PRIV void analyzer_set_clock(int ext, int edge);
 SR_PRIV void analyzer_set_freq(int freq, int scale);
 SR_PRIV void analyzer_set_ramsize_trigger_address(unsigned int address);
 SR_PRIV void analyzer_set_triggerbar_address(unsigned int address);

--- a/src/hardware/zeroplus-logic-cube/api.c
+++ b/src/hardware/zeroplus-logic-cube/api.c
@@ -66,6 +66,13 @@ static const uint32_t devopts[] = {
 	SR_CONF_TRIGGER_MATCH | SR_CONF_LIST,
 	SR_CONF_CAPTURE_RATIO | SR_CONF_GET | SR_CONF_SET,
 	SR_CONF_VOLTAGE_THRESHOLD | SR_CONF_GET | SR_CONF_SET | SR_CONF_LIST,
+	SR_CONF_EXTERNAL_CLOCK | SR_CONF_GET | SR_CONF_SET,
+	SR_CONF_CLOCK_EDGE | SR_CONF_GET | SR_CONF_SET | SR_CONF_LIST,
+};
+
+static const char *ext_clock_edges[] = {
+	[LAPC_CLOCK_EDGE_RISING] = "rising",
+	[LAPC_CLOCK_EDGE_FALLING] = "falling",
 };
 
 static const int32_t trigger_matches[] = {
@@ -338,6 +345,7 @@ static int config_get(uint32_t key, GVariant **data,
 	const struct sr_dev_inst *sdi, const struct sr_channel_group *cg)
 {
 	struct dev_context *devc;
+	const char *clock_text;
 
 	(void)cg;
 
@@ -356,6 +364,13 @@ static int config_get(uint32_t key, GVariant **data,
 	case SR_CONF_VOLTAGE_THRESHOLD:
 		*data = std_gvar_tuple_double(devc->cur_threshold, devc->cur_threshold);
 		break;
+	case SR_CONF_EXTERNAL_CLOCK:
+		*data = g_variant_new_boolean(devc->use_ext_clock);
+		break;
+	case SR_CONF_CLOCK_EDGE:
+		clock_text = ext_clock_edges[devc->clock_edge];
+		*data = g_variant_new_string(clock_text);
+		break;
 	default:
 		return SR_ERR_NA;
 	}
@@ -367,6 +382,7 @@ static int config_set(uint32_t key, GVariant *data,
 	const struct sr_dev_inst *sdi, const struct sr_channel_group *cg)
 {
 	struct dev_context *devc;
+	int idx;
 	gdouble low, high;
 
 	(void)cg;
@@ -384,6 +400,17 @@ static int config_set(uint32_t key, GVariant *data,
 	case SR_CONF_VOLTAGE_THRESHOLD:
 		g_variant_get(data, "(dd)", &low, &high);
 		return set_voltage_threshold(devc, (low + high) / 2.0);
+	case SR_CONF_EXTERNAL_CLOCK:
+		devc->use_ext_clock = g_variant_get_boolean(data);
+		set_clock(devc->use_ext_clock,devc->clock_edge);
+		break;
+	case SR_CONF_CLOCK_EDGE:
+		idx = std_str_idx(data, ARRAY_AND_SIZE(ext_clock_edges));
+		if (idx < 0)
+			return SR_ERR_ARG;
+		devc->clock_edge = idx;
+		set_clock(devc->use_ext_clock,devc->clock_edge);
+		break;
 	default:
 		return SR_ERR_NA;
 	}
@@ -423,6 +450,10 @@ static int config_list(uint32_t key, GVariant **data,
 		devc = sdi->priv;
 		*data = std_gvar_tuple_u64(0, devc->max_sample_depth);
 		break;
+	case SR_CONF_CLOCK_EDGE:
+		*data = g_variant_new_strv(ARRAY_AND_SIZE(ext_clock_edges));
+		break;
+
 	default:
 		return SR_ERR_NA;
 	}

--- a/src/hardware/zeroplus-logic-cube/protocol.c
+++ b/src/hardware/zeroplus-logic-cube/protocol.c
@@ -21,6 +21,12 @@
 #include <math.h>
 #include "protocol.h"
 
+SR_PRIV void set_clock(int ext, int edge)
+{
+	analyzer_set_clock(ext, edge);
+}
+
+
 SR_PRIV unsigned int get_memory_size(int type)
 {
 	if (type == MEMORY_SIZE_8K)

--- a/src/hardware/zeroplus-logic-cube/protocol.h
+++ b/src/hardware/zeroplus-logic-cube/protocol.h
@@ -30,6 +30,11 @@
 
 #define LOG_PREFIX "zeroplus-logic-cube"
 
+enum ext_clock_edge_t {
+	LAPC_CLOCK_EDGE_RISING,
+	LAPC_CLOCK_EDGE_FALLING,
+};
+
 struct dev_context {
 	uint64_t cur_samplerate;
 	uint64_t max_samplerate;
@@ -45,8 +50,11 @@ struct dev_context {
 	uint64_t capture_ratio;
 	double cur_threshold;
 	const struct zp_model *prof;
+	gboolean use_ext_clock;
+	enum ext_clock_edge_t clock_edge;
 };
 
+SR_PRIV void set_clock(int ext, int edge);
 SR_PRIV unsigned int get_memory_size(int type);
 SR_PRIV int zp_set_samplerate(struct dev_context *devc, uint64_t samplerate);
 SR_PRIV int set_limit_samples(struct dev_context *devc, uint64_t samples);


### PR DESCRIPTION
This enables the "external clock mode" in the Zeroplus LAP-C Logic Cube driver (falling and rising edge), 
so that this mode also can also be used in sigrok-cli and pulseview
in the same code a hidden bug is corrected: the internal clock is chosen by

/* Sele_Inside_Outside_Clock */
gl_reg_write(devh, CLOCK_SOURCE, 0x01);

and not (original code in analyzer.c):

/* Sele_Inside_Outside_Clock */
gl_reg_write(devh, CLOCK_SOURCE, 0x03);

this was proven by "USB-sniffing" the vendor software