### PR TITLE
hantek-dso: add "forced" trigger source that captures frames without waiting for trigger

### DIFF
--- a/src/hardware/hantek-dso/api.c
+++ b/src/hardware/hantek-dso/api.c
@@ -168,8 +168,7 @@ static const uint64_t vdivs[][2] = {
 };
 
 static const char *trigger_sources[] = {
-	"CH1", "CH2", "EXT",
-	/* TODO: forced */
+	"CH1", "CH2", "EXT", "forced"
 };
 
 static const char *trigger_slopes[] = {
@@ -859,8 +858,10 @@ static int handle_event(int fd, int revents, void *cb_data)
 				break;
 			if (dso_enable_trigger(sdi) != SR_OK)
 				break;
-//			if (dso_force_trigger(sdi) != SR_OK)
-//				break;
+			if (!strcmp("forced", devc->triggersource)) {
+				if (dso_force_trigger(sdi) != SR_OK)
+					break;
+			}
 			sr_dbg("Successfully requested next chunk.");
 		}
 		break;

--- a/src/hardware/hantek-dso/protocol.c
+++ b/src/hardware/hantek-dso/protocol.c
@@ -280,7 +280,7 @@ static int dso2250_set_trigger_samplerate(const struct sr_dev_inst *sdi)
 		tmp = 3;
 	else if (!strcmp("CH1", devc->triggersource))
 		tmp = 2;
-	else if (!strcmp("EXT", devc->triggersource))
+	else if (!strcmp("EXT", devc->triggersource) || !strcmp("forced", devc->triggersource))
 		tmp = 0;
 	else {
 		sr_err("Invalid trigger source: '%s'.", devc->triggersource);
@@ -426,7 +426,7 @@ SR_PRIV int dso_set_trigger_samplerate(const struct sr_dev_inst *sdi)
 		tmp = 0;
 	else if (!strcmp("CH1", devc->triggersource))
 		tmp = 1;
-	else if (!strcmp("EXT", devc->triggersource))
+	else if (!strcmp("EXT", devc->triggersource) || !strcmp("forced", devc->triggersource))
 		tmp = 2;
 	else {
 		sr_err("Invalid trigger source: '%s'.", devc->triggersource);


### PR DESCRIPTION
This special trigger source mimics the trigger mode that is called
"Auto" in the original Hantek's "DSO2090 Software" and in
https://github.com/OpenHantek/OpenHantek6022 open-source project.
In the original https://github.com/OpenHantek/openhantek open-source
project the trigger mode is called "Wait/Force".

This feature can be used to immediately capture a single frame.
Example usage with sigrok-cli:
```
sigrok-cli --driver hantek-dso --frames 1 --config triggersource=forced
```

This enables us to use the oscilloscope for data logging in scripts.

Only after I implemented this I realized that if you have an extra probe,
you can set the triggersource to "EXT" and connect the EXT input
to the 1kHz calibration signal output on the back of the device
and that will trigger every millisecond. However, I still think that
the "forced" trigger source can be useful.