### PR TITLE
Add udev rules for Saleae devices.

### DIFF
--- a/contrib/60-libsigrok.rules
+++ b/contrib/60-libsigrok.rules
@@ -265,6 +265,13 @@ ATTRS{idVendor}=="0925", ATTRS{idProduct}=="3881", ENV{ID_SIGROK}="1"
 # Saleae Logic16
 ATTRS{idVendor}=="21a9", ATTRS{idProduct}=="1001", ENV{ID_SIGROK}="1"
 
+ATTRS{idVendor}=="21a9", ATTRS{idProduct}=="1003", ENV{ID_SIGROK}="1"
+
+ATTRS{idVendor}=="21a9", ATTRS{idProduct}=="1004", ENV{ID_SIGROK}="1"
+
+# Saleae Logic Pro 8
+ATTRS{idVendor}=="21a9", ATTRS{idProduct}=="1005", ENV{ID_SIGROK}="1"
+
 # Saleae Logic Pro 16
 ATTRS{idVendor}=="21a9", ATTRS{idProduct}=="1006", ENV{ID_SIGROK}="1"
 


### PR DESCRIPTION
These PIDs and VIDs are based on udev rules from Logic 2 app.

I can confirm the one for Saleae Logic Pro 8. The others should work as well since it comes from official hardware but I don't have HW to test so I can't add comments to which device they correspond.