### PR TITLE
korad-kaxxxxp: Added support for TENMA 72-2705 V6.6 (1Ch, 30v, 3A)

### DIFF
--- a/src/hardware/korad-kaxxxxp/api.c
+++ b/src/hardware/korad-kaxxxxp/api.c
@@ -88,6 +88,8 @@ static const struct korad_kaxxxxp_model models[] = {
 		"TENMA 72-2535 V2.1", 1, {0, 31, 0.01}, {0, 3.1, 0.001}},
 	{TENMA_72_2710_V66, "Tenma", "72-2710",
 		"TENMA 72-2710 V6.6", 1, {0, 31, 0.01}, {0, 5.1, 0.001}},
+	{TENMA_72_2705_V66, "Tenma", "72-2705",
+		"TENMA 72-2705 V6.6", 1, {0, 31, 0.01}, {0, 3.1, 0.001}},
 	{STAMOS_SLS31_V20, "Stamos Soldering", "S-LS-31",
 		"S-LS-31 V2.0", 1, {0, 31, 0.01}, {0, 5.1, 0.001}},
 	{KORAD_KD6005P, "Korad", "KD6005P",

--- a/src/hardware/korad-kaxxxxp/protocol.h
+++ b/src/hardware/korad-kaxxxxp/protocol.h
@@ -51,6 +51,7 @@ enum {
 	TENMA_72_2540_V52,
 	TENMA_72_2535_V21,
 	TENMA_72_2710_V66,
+	TENMA_72_2705_V66,
 	STAMOS_SLS31_V20,
 	KORAD_KD6005P,
 	/* Support for future devices with this protocol. */


### PR DESCRIPTION
Tested with hardware.