### PR TITLE
dmm/bm??x: Add Wayback Machine links to brymen documentation

### DIFF
--- a/src/dmm/bm52x.c
+++ b/src/dmm/bm52x.c
@@ -26,6 +26,7 @@
  * http://www.brymen.com/Download2.html
  * http://www.brymen.com/PD02BM520s_protocolDL.html
  * http://www.brymen.com/images/DownloadList/ProtocolList/BM520-BM520s_List/BM520-BM520s-10000-count-professional-dual-display-mobile-logging-DMMs-protocol.zip
+ * http://web.archive.org/web/20180119175327/http://brymen.com/product-html/images/DownloadList/ProtocolList/BM520-BM520s_List/BM520-BM520s-10000-count-professional-dual-display-mobile-logging-DMMs-protocol.zip
  *
  * This parser was initially created for BM520s devices and tested with
  * BM525s. The Brymen BM820s family of devices uses the same protocol,

--- a/src/dmm/bm85x.c
+++ b/src/dmm/bm85x.c
@@ -27,6 +27,7 @@
  * http://www.brymen.com/Download2.html
  * http://www.brymen.com/PD02BM850s_protocolDL.html
  * http://www.brymen.com/images/DownloadList/ProtocolList/BM850-BM850a-BM850s_List/BM850-BM850a-BM850s-500000-count-DMM-protocol-BC85X-BC85Xa.zip
+ * http://web.archive.org/web/20180119175500/http://brymen.com/product-html/images/DownloadList/ProtocolList/BM850-BM850a-BM850s_List/BM850-BM850a-BM850s-500000-count-DMM-protocol-BC85X-BC85Xa.zip
  *
  * Implementor's notes on the protocol:
  * - The BM85x devices require a low RTS pulse after COM port open and

--- a/src/dmm/bm86x.c
+++ b/src/dmm/bm86x.c
@@ -26,6 +26,7 @@
  * http://www.brymen.com/Download2.html
  * http://www.brymen.com/PD02BM860s_protocolDL.html
  * http://www.brymen.com/images/DownloadList/ProtocolList/BM860-BM860s_List/BM860-BM860s-500000-count-dual-display-DMMs-protocol.pdf
+ * http://web.archive.org/web/20191231053213/http://www.brymen.com/images/DownloadList/ProtocolList/BM860-BM860s_List/BM860-BM860s-500000-count-dual-display-DMMs-protocol.pdf
  */
 
 #include <config.h>


### PR DESCRIPTION
While checking if a DMM could use an existing driver I found those URLs to be broken.