### PR TITLE
Fix exceptions with u32 command line options because of incomplete bindings

### DIFF
--- a/bindings/cxx/ConfigKey_methods.cpp
+++ b/bindings/cxx/ConfigKey_methods.cpp
@@ -109,6 +109,17 @@ Glib::VariantBase ConfigKey::parse_string(std::string value, enum sr_datatype dt
 				throw Error(SR_ERR_ARG);
 			}
 			break;
+		case SR_T_UINT32:
+			try {
+				unsigned long tmp = stoul(value);
+				if (tmp > std::numeric_limits<uint32_t>::max()) {
+					throw std::out_of_range("stoui");
+				}
+				variant = g_variant_new_uint32(tmp);
+			} catch (invalid_argument&) {
+				throw Error(SR_ERR_ARG);
+			}
+			break;
 		default:
 			throw Error(SR_ERR_BUG);
 	}

--- a/bindings/cxx/classes.cpp
+++ b/bindings/cxx/classes.cpp
@@ -1565,6 +1565,8 @@ Glib::VariantBase Option::parse_string(string value)
 		dt = SR_T_FLOAT;
 	} else if (g_variant_is_of_type(tmpl, G_VARIANT_TYPE_INT32)) {
 		dt = SR_T_INT32;
+	} else if (g_variant_is_of_type(tmpl, G_VARIANT_TYPE_UINT32)) {
+		dt = SR_T_UINT32;
 	} else {
 		throw Error(SR_ERR_BUG);
 	}

--- a/bindings/python/sigrok/core/classes.i
+++ b/bindings/python/sigrok/core/classes.i
@@ -340,6 +340,8 @@ Glib::VariantBase python_to_variant_by_key(PyObject *input, const sigrok::Config
         return Glib::Variant<double>::create(PyFloat_AsDouble(input));
     else if (type == SR_T_INT32 && PyInt_Check(input))
         return Glib::Variant<gint32>::create(PyInt_AsLong(input));
+    else if (type == SR_T_UINT32 && PyInt_Check(input))
+        return Glib::Variant<guint32>::create(PyInt_AsLong(input));
     else if ((type == SR_T_RATIONAL_VOLT) && PyTuple_Check(input) && (PyTuple_Size(input) == 2)) {
         PyObject *numObj = PyTuple_GetItem(input, 0);
         PyObject *denomObj = PyTuple_GetItem(input, 1);
@@ -369,6 +371,8 @@ Glib::VariantBase python_to_variant_by_option(PyObject *input,
         return Glib::Variant<double>::create(PyFloat_AsDouble(input));
     else if (type == G_VARIANT_TYPE_INT32 && PyInt_Check(input))
         return Glib::Variant<gint32>::create(PyInt_AsLong(input));
+    else if (type == G_VARIANT_TYPE_UINT32 && PyInt_Check(input))
+        return Glib::Variant<guint32>::create(PyInt_AsLong(input));
     else
         throw sigrok::Error(SR_ERR_ARG);
 }

--- a/bindings/ruby/classes.i
+++ b/bindings/ruby/classes.i
@@ -236,6 +236,8 @@ Glib::VariantBase ruby_to_variant_by_key(VALUE input, const sigrok::ConfigKey *k
         return Glib::Variant<double>::create(RFLOAT_VALUE(input));
     else if (type == SR_T_INT32 && RB_TYPE_P(input, T_FIXNUM))
         return Glib::Variant<gint32>::create(NUM2INT(input));
+    else if (type == SR_T_UINT32 && RB_TYPE_P(input, T_FIXNUM))
+        return Glib::Variant<guint32>::create(NUM2UINT(input));
     else
         throw sigrok::Error(SR_ERR_ARG);
 }
@@ -261,6 +263,8 @@ Glib::VariantBase ruby_to_variant_by_option(VALUE input, std::shared_ptr<sigrok:
         return Glib::Variant<double>::create(RFLOAT_VALUE(input));
     else if (variant.is_of_type(Glib::VARIANT_TYPE_INT32) && RB_TYPE_P(input, T_FIXNUM))
         return Glib::Variant<gint32>::create(NUM2INT(input));
+    else if (variant.is_of_type(Glib::VARIANT_TYPE_UINT32) && RB_TYPE_P(input, T_FIXNUM))
+        return Glib::Variant<guint32>::create(NUM2UINT(input));
     else
         throw sigrok::Error(SR_ERR_ARG);
 }

--- a/include/libsigrok/libsigrok.h
+++ b/include/libsigrok/libsigrok.h
@@ -153,6 +153,7 @@ enum sr_datatype {
 	SR_T_DOUBLE_RANGE,
 	SR_T_INT32,
 	SR_T_MQ,
+	SR_T_UINT32,
 
 	/* Update sr_variant_type_get() (hwdriver.c) upon changes! */
 };

--- a/src/hwdriver.c
+++ b/src/hwdriver.c
@@ -331,6 +331,8 @@ SR_PRIV const GVariantType *sr_variant_type_get(int datatype)
 	switch (datatype) {
 	case SR_T_INT32:
 		return G_VARIANT_TYPE_INT32;
+	case SR_T_UINT32:
+		return G_VARIANT_TYPE_UINT32;
 	case SR_T_UINT64:
 		return G_VARIANT_TYPE_UINT64;
 	case SR_T_STRING:

--- a/src/input/trace32_ad.c
+++ b/src/input/trace32_ad.c
@@ -163,7 +163,7 @@ static int init(struct sr_input *in, GHashTable *options)
 
 	/* Calculate the desired timestamp scaling factor. */
 	inc->samplerate = 1000000 *
-		g_variant_get_uint32(g_hash_table_lookup(options, "samplerate"));
+		g_variant_get_uint64(g_hash_table_lookup(options, "samplerate"));
 
 	inc->timestamp_scale = ((1 / TIMESTAMP_RESOLUTION) / (double)inc->samplerate);
 
@@ -891,7 +891,7 @@ static const struct sr_option *get_options(void)
 		options[9].def = g_variant_ref_sink(g_variant_new_boolean(FALSE));
 		options[10].def = g_variant_ref_sink(g_variant_new_boolean(FALSE));
 		options[11].def = g_variant_ref_sink(g_variant_new_boolean(FALSE));
-		options[12].def = g_variant_ref_sink(g_variant_new_uint32(DEFAULT_SAMPLERATE));
+		options[12].def = g_variant_ref_sink(g_variant_new_uint64(DEFAULT_SAMPLERATE));
 	}
 
 	return options;


### PR DESCRIPTION
Python/Ruby bindings not tested, only C++ bindings with PulseView.

No fallback implementation of stoul() for Android added. Is this still needed or do current/supported versions provide it? And I didn't want to continue before checking whether I'm on the right way at all.