### PR TITLE
SDM3055 Support

### DIFF
--- a/contrib/60-libsigrok.rules
+++ b/contrib/60-libsigrok.rules
@@ -272,7 +272,9 @@ ATTRS{idVendor}=="21a9", ATTRS{idProduct}=="1006", ENV{ID_SIGROK}="1"
 # f4ec:ee3a: E.g. SDS1052DL+ scope
 # f4ec:ee38: E.g. SDS1104X-E scope
 # f4ed:ee3a: E.g. SDS1202X-E scope or SDG1010 waveform generator
+# f4ec:ee38: E.g. SDM3055 Multimeter
 ATTRS{idVendor}=="f4ec", ATTRS{idProduct}=="ee3a", ENV{ID_SIGROK}="1"
+ATTRS{idVendor}=="f4ec", ATTRS{idProduct}=="ee38", ENV{ID_SIGROK}="1"
 ATTRS{idVendor}=="f4ed", ATTRS{idProduct}=="ee3a", ENV{ID_SIGROK}="1"
 
 # sigrok FX2 LA (8ch)

--- a/src/hardware/scpi-dmm/api.c
+++ b/src/hardware/scpi-dmm/api.c
@@ -199,6 +199,20 @@ static const struct mqopt_item mqopts_owon_xdm2041[] = {
 	{ SR_MQ_CAPACITANCE, 0, "CAP", "CAP", NO_DFLT_PREC, FLAGS_NONE, },
 };
 
+static const struct mqopt_item mqopts_siglent_sdm3055[] = {
+	{ SR_MQ_VOLTAGE, SR_MQFLAG_DC, "VOLT:DC", "VOLT ", NO_DFLT_PREC, FLAGS_NONE, },
+	{ SR_MQ_VOLTAGE, SR_MQFLAG_AC, "VOLT:AC", "VOLT:AC ", NO_DFLT_PREC, FLAGS_NONE, },
+	{ SR_MQ_CURRENT, SR_MQFLAG_DC, "CURR:DC", "CURR ", NO_DFLT_PREC, FLAGS_NONE, },
+	{ SR_MQ_CURRENT, SR_MQFLAG_AC, "CURR:AC", "CURR:AC ", NO_DFLT_PREC, FLAGS_NONE, },
+	{ SR_MQ_RESISTANCE, 0, "RES", "RES ", NO_DFLT_PREC, FLAGS_NONE, },
+	{ SR_MQ_RESISTANCE, SR_MQFLAG_FOUR_WIRE, "FRES", "FRES ", NO_DFLT_PREC, FLAGS_NONE, },
+	{ SR_MQ_CONTINUITY, 0, "CONT", "CONT", -1, FLAGS_NONE, },
+	{ SR_MQ_VOLTAGE, SR_MQFLAG_DC | SR_MQFLAG_DIODE, "DIOD", "DIOD", -4, FLAGS_NONE, },
+	{ SR_MQ_FREQUENCY, 0, "FREQ", "FREQ ", NO_DFLT_PREC, FLAGS_NONE, },
+	{ SR_MQ_TIME, 0, "PER", "PER ", NO_DFLT_PREC, FLAGS_NONE, },
+	{ SR_MQ_CAPACITANCE, 0, "CAP", "CAP", NO_DFLT_PREC, FLAGS_NONE, },
+};
+
 SR_PRIV const struct scpi_dmm_model models[] = {
 	{
 		"Agilent", "34405A",
@@ -279,6 +293,14 @@ SR_PRIV const struct scpi_dmm_model models[] = {
 		scpi_dmm_get_meas_gwinstek,
 		ARRAY_AND_SIZE(devopts_generic),
 		0, 0, 0, 1e9, TRUE,
+		NULL, NULL, NULL,
+	},
+	{
+		"Siglent", "SDM3055",
+		1, 5, cmdset_hp, ARRAY_AND_SIZE(mqopts_siglent_sdm3055),
+		scpi_dmm_get_meas_agilent,
+		ARRAY_AND_SIZE(devopts_generic),
+		0, 0, 0, 0, FALSE,
 		NULL, NULL, NULL,
 	},
 };

--- a/src/scpi/scpi.c
+++ b/src/scpi/scpi.c
@@ -38,6 +38,7 @@ static const char *scpi_vendors[][2] = {
 	{ "Keysight Technologies", "Keysight" },
 	{ "PHILIPS", "Philips" },
 	{ "RIGOL TECHNOLOGIES", "Rigol" },
+	{ "Siglent Technologies", "Siglent" },
 };
 
 /**


### PR DESCRIPTION
This PR adds support for the SDM3055 multimeter as an scpi-dmm device.

All functionality was tested with `smuview` with TCP. The log out of it looks right as well. I also tested it with USB initially (a while ago), but I can re-test it again before this gets merged.

I will probably add the other two sibling meters (SDM3045X and the SDM3065X), but I will have no way to test those unless someone wants to volunteer to do so, in which case it is much appreciated.
