### PR TITLE
Agilent 54621d device driver

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -226,6 +226,12 @@ src_libdrivers_tail_la_SOURCES = src/driver_list_stop.c
 
 src_libdrivers_la_SOURCES = src/drivers.c
 
+if HW_AGILENT_54621D
+src_libdrivers_la_SOURCES += \
+	src/hardware/agilent-54621d/protocol.h \
+	src/hardware/agilent-54621d/protocol.c \
+	src/hardware/agilent-54621d/api.c
+endif
 if HW_AGILENT_DMM
 src_libdrivers_la_SOURCES += \
 	src/hardware/agilent-dmm/protocol.h \

--- a/configure.ac
+++ b/configure.ac
@@ -290,6 +290,7 @@ m4_define([_SR_DRIVER], [
 m4_define([SR_DRIVER],
 	[_SR_DRIVER([$1], [$2], m4_expand([AS_TR_CPP([HW_$2])]), [$3])])
 
+SR_DRIVER([Agilent 54621D], [agilent-54621d])
 SR_DRIVER([Agilent DMM], [agilent-dmm], [serial_comm])
 SR_DRIVER([Appa 55II], [appa-55ii], [serial_comm])
 SR_DRIVER([Arachnid Labs Re:load Pro], [arachnid-labs-re-load-pro], [serial_comm])

--- a/src/hardware/agilent-54621d/api.c
+++ b/src/hardware/agilent-54621d/api.c
@@ -1,0 +1,692 @@
+/*
+ * This file is part of the libsigrok project.
+ *
+ * Copyright (C) 2022 Daniel <1824222@stud.hs-mannheim.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+#include "protocol.h"
+#include "scpi.h"
+
+static struct sr_dev_driver agilent_54621d_driver_info;
+
+static const char *manufacturers[] = {
+	"AGILENT TECHNOLOGIES",
+};
+
+static const uint32_t scanopts[] = {
+	SR_CONF_CONN,
+	SR_CONF_SERIALCOMM,
+};
+
+static const uint32_t drvopts[] = {
+	SR_CONF_OSCILLOSCOPE,
+	SR_CONF_LOGIC_ANALYZER,
+};
+
+enum {
+	CG_INVALID = -1,
+	CG_NONE,
+	CG_ANALOG,
+	CG_DIGITAL,
+};
+
+static struct sr_dev_inst *probe_device(struct sr_scpi_dev_inst *scpi)
+{
+	struct sr_dev_inst *sdi;
+	struct dev_context *devc;
+	struct sr_scpi_hw_info *hw_info;
+
+	if (sr_scpi_get_hw_id(scpi, &hw_info) != SR_OK) {
+		sr_info("Couldn't  get IDN response.");
+		goto fail;
+	}
+
+	if (std_str_idx_s(hw_info->manufacturer, ARRAY_AND_SIZE(manufacturers)) < 0)
+		goto fail;
+
+	sdi = g_malloc0(sizeof(struct sr_dev_inst));
+	sdi->vendor = g_strdup(hw_info->manufacturer);
+	sdi->model = g_strdup(hw_info->model);
+	sdi->version = g_strdup(hw_info->firmware_version);
+	sdi->serial_num = g_strdup(hw_info->serial_number);
+	sdi->driver = &agilent_54621d_driver_info;
+	sdi->inst_type = SR_INST_SCPI;
+	sdi->conn = scpi;
+
+	sr_scpi_hw_info_free(hw_info);
+	hw_info = NULL;
+
+	devc = g_malloc0(sizeof(struct dev_context));
+
+	sdi->priv = devc;
+
+	if (agilent_54621d_init_device(sdi) != SR_OK)
+		goto fail;
+
+	return sdi;
+
+fail:
+	sr_scpi_hw_info_free(hw_info);
+	sr_dev_inst_free(sdi);
+	g_free(devc);
+
+	return NULL;
+}
+
+static GSList *scan(struct sr_dev_driver *di, GSList *options)
+{
+	sr_info("Scanning for agilent 54621d");
+	return sr_scpi_scan(di->context, options, probe_device);
+}
+
+static int dev_open(struct sr_dev_inst *sdi)
+{
+	int ret;
+	struct sr_scpi_dev_inst *scpi = sdi->conn;
+
+	if ((ret = sr_scpi_open(scpi)) < 0) {
+		sr_err("Failed to open SCPI device: %s.", sr_strerror(ret));
+		return SR_ERR;
+	}
+
+	if ((ret = agilent_54621d_scope_state_get(sdi)) < 0) {
+		sr_err("Failed to get device config: %s.", sr_strerror(ret));
+		return SR_ERR;
+	}
+
+	return SR_OK;
+}
+
+static int dev_close(struct sr_dev_inst *sdi)
+{
+	return sr_scpi_close(sdi->conn);
+}
+
+static int check_channel_group(struct dev_context *devc,
+			     const struct sr_channel_group *cg)
+{
+	const struct scope_config *model;
+
+	model = devc->model_config;
+
+	if (!cg)
+		return CG_NONE;
+
+	if (std_cg_idx(cg, devc->analog_groups, model->analog_channels) >= 0)
+		return CG_ANALOG;
+
+	if (std_cg_idx(cg, devc->digital_groups, model->digital_pods) >= 0)
+		return CG_DIGITAL;
+
+	sr_err("Invalid channel group specified.");
+
+	return CG_INVALID;
+}
+
+static int config_get(uint32_t key, GVariant **data,
+	const struct sr_dev_inst *sdi, const struct sr_channel_group *cg)
+{
+	int cg_type, idx, i;
+	struct dev_context *devc;
+	const struct scope_config *model;
+	struct scope_state *state;
+
+	if (!sdi)
+		return SR_ERR_ARG;
+
+	devc = sdi->priv;
+
+	if ((cg_type = check_channel_group(devc, cg)) == CG_INVALID)
+		return SR_ERR;
+
+	model = devc->model_config;
+	state = devc->model_state;
+
+	switch (key) {
+		case SR_CONF_NUM_HDIV:
+			*data = g_variant_new_int32(model->num_xdivs);
+			break;
+		case SR_CONF_TIMEBASE:
+			*data = g_variant_new("(tt)", (*model->timebases)[state->timebase][0],
+						(*model->timebases)[state->timebase][1]);
+			break;
+		case SR_CONF_NUM_VDIV:
+			if (!cg)
+				return SR_ERR_CHANNEL_GROUP;
+			if (cg_type != CG_ANALOG)
+				return SR_ERR_NA;
+			if (std_cg_idx(cg, devc->analog_groups, model->analog_channels) < 0)
+				return SR_ERR_ARG;
+			*data = g_variant_new_int32(model->num_ydivs);
+			break;
+		case SR_CONF_VDIV:
+			if (!cg)
+				return SR_ERR_CHANNEL_GROUP;
+			if (cg_type != CG_ANALOG)
+				return SR_ERR_NA;
+			if ((idx = std_cg_idx(cg, devc->analog_groups, model->analog_channels)) < 0)
+				return SR_ERR_ARG;
+			*data = g_variant_new("(tt)",
+						(*model->vdivs)[state->analog_channels[idx].vdiv][0],
+						(*model->vdivs)[state->analog_channels[idx].vdiv][1]);
+			break;
+		case SR_CONF_TRIGGER_SOURCE:
+			*data = g_variant_new_string((*model->trigger_sources)[state->trigger_source]);
+			break;
+		case SR_CONF_TRIGGER_SLOPE:
+			*data = g_variant_new_string((*model->trigger_slopes)[state->trigger_slope]);
+			break;
+		case SR_CONF_PEAK_DETECTION:
+			*data = g_variant_new_boolean(state->peak_detection);
+			break;
+		case SR_CONF_HORIZ_TRIGGERPOS:
+			*data = g_variant_new_double(state->horiz_triggerpos);
+			break;
+		case SR_CONF_ENABLED:
+			sr_info("get channel enabled");
+			if (!cg)
+				return SR_ERR_CHANNEL_GROUP;
+			if (cg_type == CG_DIGITAL){
+				sr_info("get digital channel enabled");
+				if ((idx = std_cg_idx(cg, devc->digital_groups, model->digital_pods)) < 0)
+					return SR_ERR_ARG;
+				*data = g_variant_new_boolean(state->digital_pods[idx].state);
+			}
+			else if (cg_type == CG_ANALOG){
+				sr_info("get analog channel enabled");
+				if ((idx = std_cg_idx(cg, devc->analog_groups, model->analog_channels)) < 0)
+					return SR_ERR_ARG;
+				*data = g_variant_new_boolean(state->analog_channels[idx].state);
+			} else {
+				return SR_ERR;
+			}
+			break;
+		case SR_CONF_COUPLING:
+			if (!cg)
+				return SR_ERR_CHANNEL_GROUP;
+			if (cg_type != CG_ANALOG)
+				return SR_ERR_NA;
+			if ((idx = std_cg_idx(cg, devc->analog_groups, model->analog_channels)) < 0)
+				return SR_ERR_ARG;
+			*data = g_variant_new_string((*model->coupling_options)[state->analog_channels[idx].coupling]);
+			break;
+		case SR_CONF_SAMPLERATE:
+			*data = g_variant_new_uint64(state->sample_rate);
+			break;
+		case SR_CONF_LOGIC_THRESHOLD:
+			if (!cg)
+				return SR_ERR_CHANNEL_GROUP;
+			if (cg_type != CG_DIGITAL)
+				return SR_ERR_NA;
+			if (!model)
+				return SR_ERR_ARG;
+			if ((idx = std_cg_idx(cg, devc->digital_groups, model->digital_pods)) < 0)
+				return SR_ERR_ARG;
+			*data = g_variant_new_string((*model->logic_threshold)[state->digital_pods[idx].threshold]);
+			break;
+		case SR_CONF_LOGIC_THRESHOLD_CUSTOM:
+			if (!cg)
+				return SR_ERR_CHANNEL_GROUP;
+			if (cg_type != CG_DIGITAL)
+				return SR_ERR_NA;
+			if (!model)
+				return SR_ERR_ARG;
+			if ((idx = std_cg_idx(cg, devc->digital_groups, model->digital_pods)) < 0)
+				return SR_ERR_ARG;
+			*data = g_variant_new_double(state->digital_pods[idx].user_threshold);
+			break;
+		case SR_CONF_LIMIT_SAMPLES:
+			*data = g_variant_new_uint64(devc->samples_limit);
+			break;
+		//ToDo: Check if all options are implemented
+		default:
+			sr_err("could not find requested parameter: %d", key);
+			return SR_ERR_NA;
+	}
+
+	return SR_OK;
+}
+
+static int config_set(uint32_t key, GVariant *data,
+	const struct sr_dev_inst *sdi, const struct sr_channel_group *cg)
+{
+	int ret, cg_type, idx, i, j;
+	char command[MAX_COMMAND_SIZE], command2[MAX_COMMAND_SIZE];
+	char float_str[30], *tmp_str;
+	struct dev_context *devc;
+	const struct scope_config *model;
+	struct scope_state *state;
+	double tmp_d, tmp_d2;
+	gboolean update_sample_rate, tmp_bool;
+
+	if (!sdi)
+		return SR_ERR_ARG;
+
+	devc = sdi->priv;
+
+	if ((cg_type = check_channel_group(devc, cg)) == CG_INVALID)
+		return SR_ERR;
+
+	model = devc->model_config;
+	state = devc->model_state;
+	update_sample_rate = FALSE;
+
+	switch (key) {
+	case SR_CONF_LIMIT_SAMPLES:
+		devc->samples_limit = g_variant_get_uint64(data);
+		ret = SR_OK;
+		break;
+	case SR_CONF_VDIV:
+		if (!cg)
+			return SR_ERR_CHANNEL_GROUP;
+		if ((idx = std_u64_tuple_idx(data, *model->vdivs, model->num_vdivs)) < 0)
+			return SR_ERR_ARG;
+		if ((j = std_cg_idx(cg, devc->analog_groups, model->analog_channels)) < 0)
+			return SR_ERR_ARG;
+		g_ascii_formatd(float_str, sizeof(float_str), "%E",
+			(float) (*model->vdivs)[idx][0] / (*model->vdivs)[idx][1]);
+		g_snprintf(command, sizeof(command),
+			   (*model->scpi_dialect)[SCPI_CMD_SET_VERTICAL_SCALE],
+			   j + 1, float_str);
+		if (sr_scpi_send(sdi->conn, command) != SR_OK ||
+		    sr_scpi_get_opc(sdi->conn) != SR_OK)
+			return SR_ERR;
+		state->analog_channels[j].vdiv = idx;
+		ret = SR_OK;
+		break;
+	case SR_CONF_TIMEBASE:
+		if ((idx = std_u64_tuple_idx(data, *model->timebases, model->num_timebases)) < 0)
+			return SR_ERR_ARG;
+		g_ascii_formatd(float_str, sizeof(float_str), "%E",
+			(float) (*model->timebases)[idx][0] / (*model->timebases)[idx][1]);
+		g_snprintf(command, sizeof(command),
+			(*model->scpi_dialect)[SCPI_CMD_SET_TIMEBASE],
+			float_str);
+		if (sr_scpi_send(sdi->conn, command) != SR_OK ||
+			sr_scpi_get_opc(sdi->conn) != SR_OK)
+			return SR_ERR;
+		state->timebase = idx;
+		ret = SR_OK;
+		update_sample_rate = TRUE;
+		break;
+	case SR_CONF_HORIZ_TRIGGERPOS:
+		tmp_d = g_variant_get_double(data);
+		if (tmp_d < 0.0 || tmp_d > 1.0)
+			return SR_ERR;
+		tmp_d2 = -(tmp_d - 0.5) *
+			((double) (*model->timebases)[state->timebase][0] /
+			(*model->timebases)[state->timebase][1])
+			 * model->num_xdivs;
+		g_ascii_formatd(float_str, sizeof(float_str), "%E", tmp_d2);
+		g_snprintf(command, sizeof(command),
+			   (*model->scpi_dialect)[SCPI_CMD_SET_HORIZ_TRIGGERPOS],
+			   float_str);
+		if (sr_scpi_send(sdi->conn, command) != SR_OK ||
+		    sr_scpi_get_opc(sdi->conn) != SR_OK)
+			return SR_ERR;
+		state->horiz_triggerpos = tmp_d;
+		ret = SR_OK;
+		break;
+	case SR_CONF_TRIGGER_SOURCE:
+		if ((idx = std_str_idx(data, *model->trigger_sources, model->num_trigger_sources)) < 0)
+			return SR_ERR_ARG;
+		g_snprintf(command, sizeof(command),
+			   (*model->scpi_dialect)[SCPI_CMD_SET_TRIGGER_SOURCE],
+			   (*model->trigger_sources)[idx]);
+		if (sr_scpi_send(sdi->conn, command) != SR_OK ||
+		    sr_scpi_get_opc(sdi->conn) != SR_OK)
+			return SR_ERR;
+		state->trigger_source = idx;
+		ret = SR_OK;
+		break;
+	case SR_CONF_TRIGGER_SLOPE:
+		if ((idx = std_str_idx(data, *model->trigger_slopes, model->num_trigger_slopes)) < 0)
+			return SR_ERR_ARG;
+		g_snprintf(command, sizeof(command),
+			   (*model->scpi_dialect)[SCPI_CMD_SET_TRIGGER_SLOPE],
+			   (*model->trigger_slopes)[idx]);
+		if (sr_scpi_send(sdi->conn, command) != SR_OK ||
+		    sr_scpi_get_opc(sdi->conn) != SR_OK)
+			return SR_ERR;
+		state->trigger_slope = idx;
+		ret = SR_OK;
+		break;
+	case SR_CONF_PEAK_DETECTION:
+		tmp_bool = g_variant_get_boolean(data);
+		g_snprintf(command, sizeof(command),
+			   (*model->scpi_dialect)[SCPI_CMD_SET_PEAK_DETECTION],
+			   tmp_bool ? "AUTO" : "OFF");
+		if (sr_scpi_send(sdi->conn, command) != SR_OK ||
+		    sr_scpi_get_opc(sdi->conn) != SR_OK)
+			return SR_ERR;
+		/* Peak Detection automatically switches off High Resolution mode. */
+		if (tmp_bool) {
+			g_snprintf(command, sizeof(command),
+				   (*model->scpi_dialect)[SCPI_CMD_SET_HIGH_RESOLUTION],
+				   "OFF");
+			if (sr_scpi_send(sdi->conn, command) != SR_OK ||
+					 sr_scpi_get_opc(sdi->conn) != SR_OK)
+				return SR_ERR;
+			state->high_resolution = FALSE;
+		}
+		state->peak_detection = tmp_bool;
+		ret = SR_OK;
+		break;
+	case SR_CONF_ENABLED:
+		if (!cg)
+			return SR_ERR_CHANNEL_GROUP;
+		if (cg_type == CG_DIGITAL){
+			if ((j = std_cg_idx(cg, devc->digital_groups, model->digital_pods)) < 0)
+				return SR_ERR_ARG;
+			//enable digital channel
+		}
+		else if (cg_type == CG_ANALOG){
+			if ((j = std_cg_idx(cg, devc->analog_groups, model->analog_channels)) < 0)
+				return SR_ERR_ARG;
+			g_snprintf(command, sizeof(command), (*model->scpi_dialect)[SCPI_CMD_SET_ANALOG_CHAN_STATE], j+1, g_variant_get_boolean(data));
+			if(sr_scpi_send(sdi->conn, command) != SR_OK || sr_scpi_get_opc(sdi->conn) != SR_OK)
+				return SR_ERR;
+			state->analog_channels[j].state = g_variant_get_boolean(data);
+			update_sample_rate = TRUE;
+			ret = SR_OK;
+			//enable analog channel
+		} else {
+			return SR_ERR;
+		}
+		break;
+	case SR_CONF_COUPLING:
+		if (!cg)
+			return SR_ERR_CHANNEL_GROUP;
+		if ((idx = std_str_idx(data, *model->coupling_options, model->num_coupling_options)) < 0)
+			return SR_ERR_ARG;
+		if ((j = std_cg_idx(cg, devc->analog_groups, model->analog_channels)) < 0)
+			return SR_ERR_ARG;
+		g_snprintf(command, sizeof(command),
+			   (*model->scpi_dialect)[SCPI_CMD_SET_COUPLING],
+			   j + 1, (*model->coupling_options)[idx]);
+		if (sr_scpi_send(sdi->conn, command) != SR_OK ||
+		    sr_scpi_get_opc(sdi->conn) != SR_OK)
+			return SR_ERR;
+		state->analog_channels[j].coupling = idx;
+		ret = SR_OK;
+		break;	
+	case SR_CONF_LOGIC_THRESHOLD:
+		if (!cg)
+			return SR_ERR_CHANNEL_GROUP;
+		if (cg_type != CG_DIGITAL)
+			return SR_ERR_NA;
+		if (!model)
+			return SR_ERR_ARG;
+		if ((idx = std_str_idx(data, *model->logic_threshold, model->num_logic_threshold)) < 0)
+			return SR_ERR_ARG;
+		if ((j = std_cg_idx(cg, devc->digital_groups, model->digital_pods)) < 0)
+			return SR_ERR_ARG;
+                /* Check if the threshold command is based on the POD or digital channel index. */
+		if (model->logic_threshold_for_pod)
+			i = j + 1;
+		else
+			i = j * DIGITAL_CHANNELS_PER_POD;
+		g_snprintf(command, sizeof(command),
+			   (*model->scpi_dialect)[SCPI_CMD_SET_DIG_POD_THRESHOLD],
+			   i, (*model->logic_threshold)[idx]);
+		if (sr_scpi_send(sdi->conn, command) != SR_OK ||
+		    sr_scpi_get_opc(sdi->conn) != SR_OK)
+			return SR_ERR;
+		state->digital_pods[j].threshold = idx;
+		ret = SR_OK;
+		break;
+	case SR_CONF_LOGIC_THRESHOLD_CUSTOM:
+		if (!cg)
+			return SR_ERR_CHANNEL_GROUP;
+		if (cg_type != CG_DIGITAL)
+			return SR_ERR_NA;
+		if (!model)
+			return SR_ERR_ARG;
+		if ((j = std_cg_idx(cg, devc->digital_groups, model->digital_pods)) < 0)
+			return SR_ERR_ARG;
+		tmp_d = g_variant_get_double(data);
+		if (tmp_d < -2.0 || tmp_d > 8.0)
+			return SR_ERR;
+		g_ascii_formatd(float_str, sizeof(float_str), "%E", tmp_d);
+		/* Check if the threshold command is based on the POD or digital channel index. */
+		if (model->logic_threshold_for_pod)
+			idx = j + 1;
+		else
+			idx = j * DIGITAL_CHANNELS_PER_POD;
+		/* Try to support different dialects exhaustively. */
+		for (i = 0; i < model->num_logic_threshold; i++) {
+			if (!strcmp("USER2", (*model->logic_threshold)[i])) {
+				g_snprintf(command, sizeof(command),
+					   (*model->scpi_dialect)[SCPI_CMD_SET_DIG_POD_USER_THRESHOLD],
+					   idx, 2, float_str); /* USER2 */
+				g_snprintf(command2, sizeof(command2),
+					   (*model->scpi_dialect)[SCPI_CMD_SET_DIG_POD_THRESHOLD],
+					   idx, "USER2");
+				break;
+			}
+			if (!strcmp("USER", (*model->logic_threshold)[i])) {
+				g_snprintf(command, sizeof(command),
+					   (*model->scpi_dialect)[SCPI_CMD_SET_DIG_POD_USER_THRESHOLD],
+					   idx, float_str);
+				g_snprintf(command2, sizeof(command2),
+					   (*model->scpi_dialect)[SCPI_CMD_SET_DIG_POD_THRESHOLD],
+					   idx, "USER");
+				break;
+			}
+			if (!strcmp("MAN", (*model->logic_threshold)[i])) {
+				g_snprintf(command, sizeof(command),
+					   (*model->scpi_dialect)[SCPI_CMD_SET_DIG_POD_USER_THRESHOLD],
+					   idx, float_str);
+				g_snprintf(command2, sizeof(command2),
+					   (*model->scpi_dialect)[SCPI_CMD_SET_DIG_POD_THRESHOLD],
+					   idx, "MAN");
+				break;
+			}
+		}
+		if (sr_scpi_send(sdi->conn, command) != SR_OK ||
+		    sr_scpi_get_opc(sdi->conn) != SR_OK)
+			return SR_ERR;
+		if (sr_scpi_send(sdi->conn, command2) != SR_OK ||
+		    sr_scpi_get_opc(sdi->conn) != SR_OK)
+			return SR_ERR;
+		state->digital_pods[j].user_threshold = tmp_d;
+		ret = SR_OK;
+		break;
+	default:
+		ret = SR_ERR_NA;
+		break;
+	}
+
+	if (ret == SR_OK && update_sample_rate)
+		ret = agilent_54621d_update_sample_rate(sdi);
+
+	return ret;
+}
+
+static int config_list(uint32_t key, GVariant **data,
+	const struct sr_dev_inst *sdi, const struct sr_channel_group *cg)
+{
+	int ret;
+
+	int cg_type = CG_NONE;
+	struct dev_context *devc = NULL;
+	const struct scope_config *model = NULL;
+
+	if (sdi) {
+		devc = sdi->priv;
+		if ((cg_type = check_channel_group(devc, cg)) == CG_INVALID)
+			return SR_ERR;
+
+		model = devc->model_config;
+	}
+
+	ret = SR_OK;
+	switch (key) {
+		case SR_CONF_SCAN_OPTIONS:
+			*data = std_gvar_array_u32(ARRAY_AND_SIZE(scanopts));
+			break;
+		case SR_CONF_DEVICE_OPTIONS:
+			if (!cg) {
+				if (model)
+					*data = std_gvar_array_u32(*model->devopts, model->num_devopts);
+				else
+					*data = std_gvar_array_u32(ARRAY_AND_SIZE(drvopts));
+			} else if (cg_type == CG_ANALOG) {
+				*data = std_gvar_array_u32(*model->devopts_cg_analog, model->num_devopts_cg_analog);
+			} else if (cg_type == CG_DIGITAL) {
+				*data = std_gvar_array_u32(*model->devopts_cg_digital, model->num_devopts_cg_digital);
+			} else {
+				*data = std_gvar_array_u32(NULL, 0);
+			}
+			break;
+		case SR_CONF_COUPLING:
+			if (!cg)
+				return SR_ERR_CHANNEL_GROUP;
+			if (!model)
+				return SR_ERR_ARG;
+			*data = g_variant_new_strv(*model->coupling_options, model->num_coupling_options);
+			break;
+		case SR_CONF_TRIGGER_SOURCE:
+			if (!model)
+				return SR_ERR_ARG;
+			*data = g_variant_new_strv(*model->trigger_sources, model->num_trigger_sources);
+			break;
+		case SR_CONF_TRIGGER_SLOPE:
+			if (!model)
+				return SR_ERR_ARG;
+			*data = g_variant_new_strv(*model->trigger_slopes, model->num_trigger_slopes);
+			break;
+		case SR_CONF_TIMEBASE:
+			if (!model)
+				return SR_ERR_ARG;
+			*data = std_gvar_tuple_array(*model->timebases, model->num_timebases);
+			break;
+		case SR_CONF_VDIV:
+			if (!cg)
+				return SR_ERR_CHANNEL_GROUP;
+			if (!model)
+				return SR_ERR_ARG;
+			*data = std_gvar_tuple_array(*model->vdivs, model->num_vdivs);
+			break;
+		case SR_CONF_LOGIC_THRESHOLD:
+			if (!cg)
+				return SR_ERR_CHANNEL_GROUP;
+			if (!model)
+				return SR_ERR_ARG;
+			*data = g_variant_new_strv(*model->logic_threshold, model->num_logic_threshold);
+			break;
+	/* TODO Check if all relevant option are present here */
+	default:
+		sr_info("Trying to query for config list for:");
+		return SR_ERR_NA;
+	}
+
+	return ret;
+}
+
+
+static int dev_acquisition_start(const struct sr_dev_inst *sdi)
+{
+	GSList *l;
+	struct sr_channel *ch;
+	struct dev_context *devc;
+	struct sr_scpi_dev_inst *scpi;
+	struct scope_state *state;
+	const struct scope_config *model;
+	int ret;
+	char *cmd;
+	gboolean state_changed;
+
+	scpi = sdi->conn;
+	devc = sdi->priv;
+	state = devc->model_state;
+	model = devc->model_config;
+
+	devc->num_samples = 0;
+	devc->num_frames = 0;
+
+	devc->enabled_channels = NULL;
+	state_changed = FALSE;
+
+	for (l = sdi->channels; l; l = l->next) {
+		ch = l->data;
+		sr_dbg("initializing channel %s", ch->name);
+		if(ch->type == SR_CHANNEL_ANALOG) {
+			if(ch->enabled)
+				devc->enabled_channels = g_slist_append(devc->enabled_channels, ch);
+			//Enable/disable channel if neccessary
+			if(ch->enabled != state->analog_channels[ch->index].state) {
+				if( sr_scpi_send(scpi, (*model->scpi_dialect)[SCPI_CMD_SET_ANALOG_CHAN_STATE], ch->index + 1, ch->enabled ? "ON" : "OFF") != SR_OK || 
+						sr_scpi_get_opc(scpi) != SR_OK)
+					return SR_ERR;
+				state->analog_channels[ch->index].state = ch->enabled;
+				state_changed = TRUE;
+			}	
+		} else if (ch->type == SR_CHANNEL_LOGIC) {
+			devc->enabled_channels = g_slist_append(devc->enabled_channels, ch);
+			//Enable/disable channel if neccessary
+			if(ch->enabled != state->digital_channels[ch->index]) {
+				if( sr_scpi_send(scpi, (*model->scpi_dialect)[SCPI_CMD_SET_DIG_CHAN_STATE], ch->index, ch->enabled ? "ON" : "OFF") != SR_OK || 
+						sr_scpi_get_opc(scpi) != SR_OK)
+					return SR_ERR;
+				state->digital_channels[ch->index] = ch->enabled;
+				state_changed = TRUE;
+			}
+		}	
+	}
+
+	//Sample rate needs to be updated if channels have been changed, since in some channel configurations sample rate is reduced
+	if(state_changed)
+		if(agilent_54621d_update_sample_rate(sdi) != SR_OK)
+			return SR_ERR;
+
+	//ToDo: Start capture
+
+	std_session_send_df_header(sdi);
+
+	return SR_OK;
+
+}
+
+static int dev_acquisition_stop(struct sr_dev_inst *sdi)
+{
+	/* TODO: stop acquisition. */
+
+	(void)sdi;
+
+	return SR_OK;
+}
+
+static struct sr_dev_driver agilent_54621d_driver_info = {
+	.name = "agilent-54621d",
+	.longname = "Agilent 54621D",
+	.api_version = 1,
+	.init = std_init,
+	.cleanup = std_cleanup,
+	.scan = scan,
+	.dev_list = std_dev_list,
+	.dev_clear = std_dev_clear,
+	.config_get = config_get,
+	.config_set = config_set,
+	.config_list = config_list,
+	.dev_open = dev_open,
+	.dev_close = dev_close,
+	.dev_acquisition_start = dev_acquisition_start,
+	.dev_acquisition_stop = dev_acquisition_stop,
+	.context = NULL,
+};
+SR_REGISTER_DEV_DRIVER(agilent_54621d_driver_info);

--- a/src/hardware/agilent-54621d/protocol.c
+++ b/src/hardware/agilent-54621d/protocol.c
@@ -1,0 +1,712 @@
+/*
+ * This file is part of the libsigrok project.
+ *
+ * Copyright (C) 2022 Daniel <1824222@stud.hs-mannheim.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+#include "protocol.h"
+#include "scpi.h"
+
+#define MAX_COMMAND_SIZE 128
+#define LOGIC_GET_THRESHOLD_SETTING "USER" //Threshold Setting that should be reported by the driver. Has to be included in logic_threshold. Has to be done in that hacky way since the device does only report threshold voltage level, yet not threshold setting
+
+static const char *agilent_scpi_dialect[] = {
+	[SCPI_CMD_GET_DIG_DATA]		      = ":FORM UINT,8;:POD%d:DATA?",
+	[SCPI_CMD_GET_TIMEBASE]		      = ":TIM:SCAL?",				//OK
+	[SCPI_CMD_SET_TIMEBASE]		      = ":TIM:SCAL %s",				//OK
+	[SCPI_CMD_GET_COUPLING]		      = ":CHAN%d:COUP?",			//OK
+	[SCPI_CMD_SET_COUPLING]		      = ":CHAN%d:COUP %s",			//OK
+	[SCPI_CMD_GET_SAMPLE_RATE]	      = ":ACQ:SRAT?",				//OK
+	[SCPI_CMD_GET_ANALOG_DATA]	      = ":FORM:BORD %s;" \
+					        ":FORM REAL,32;:CHAN%d:DATA?",
+	[SCPI_CMD_GET_VERTICAL_SCALE]	      = ":CHAN%d:SCAL?",		//OK
+	[SCPI_CMD_SET_VERTICAL_SCALE]	      = ":CHAN%d:SCAL %s",		//OK
+	[SCPI_CMD_GET_DIG_POD_STATE]	      = ":POD%d:DISP?",			//Fixed
+	[SCPI_CMD_SET_DIG_POD_STATE]	      = ":POD%d:DISP %d",		//Fixed
+	[SCPI_CMD_GET_TRIGGER_SOURCE]	      = ":TRIG:SOUR?",			//Fixed
+	[SCPI_CMD_SET_TRIGGER_SOURCE]	      = ":TRIG:SOUR %s",		//Fixed
+	[SCPI_CMD_GET_TRIGGER_SLOPE]	      = ":TRIG:SLOP?",			//Fixed
+	[SCPI_CMD_SET_TRIGGER_SLOPE]	      = ":TRIG:MODE EDGE;:TRIG:SLOP %s", 	//Fixed ?
+	[SCPI_CMD_GET_TRIGGER_PATTERN]	      = ":TRIG:A:PATT:SOUR?",
+	[SCPI_CMD_SET_TRIGGER_PATTERN]	      = ":TRIG:A:TYPE LOGIC;" \
+					        ":TRIG:A:PATT:FUNC AND;" \
+					        ":TRIG:A:PATT:COND \"TRUE\";" \
+					        ":TRIG:A:PATT:MODE OFF;" \
+					        ":TRIG:A:PATT:SOUR \"%s\"",
+	[SCPI_CMD_GET_HIGH_RESOLUTION]	      = ":ACQ:HRES?",
+	[SCPI_CMD_SET_HIGH_RESOLUTION]	      = ":ACQ:HRES %s",
+	[SCPI_CMD_GET_PEAK_DETECTION]	      = ":ACQ:TYPE?",				//Fixed
+	[SCPI_CMD_SET_PEAK_DETECTION]	      = ":ACQ:TYPE PEAK",			//Fixed
+	[SCPI_CMD_GET_DIG_CHAN_STATE]	      = ":DIG%d:DISP?",				//Fixed
+	[SCPI_CMD_SET_DIG_CHAN_STATE]	      = ":DIG%d:DISP %s",			//Fixed
+	[SCPI_CMD_GET_VERTICAL_OFFSET]	      = ":CHAN%d:OFFS?",			//Fixed
+	[SCPI_CMD_GET_HORIZ_TRIGGERPOS]	      = ":TIM:POS?",				//OK
+	[SCPI_CMD_SET_HORIZ_TRIGGERPOS]	      = ":TIM:POS %s",				//OK
+	[SCPI_CMD_GET_ANALOG_CHAN_STATE]      = ":CHAN%d:DISP?",			//Fixed
+	[SCPI_CMD_SET_ANALOG_CHAN_STATE]      = ":CHAN%d:DISP %s",			//Fixed
+	[SCPI_CMD_GET_PROBE_UNIT]	      	  = ":CHAN%d:UNIT?",			//Fixed
+	[SCPI_CMD_GET_DIG_POD_THRESHOLD]      = ":POD%d:THR?",				//OK
+	[SCPI_CMD_SET_DIG_POD_THRESHOLD]      = ":POD%d:THR %s",			//OK
+};
+
+static const uint32_t devopts[] = {
+	SR_CONF_OSCILLOSCOPE,
+	SR_CONF_SAMPLERATE | SR_CONF_GET,
+	SR_CONF_TIMEBASE | SR_CONF_GET | SR_CONF_SET | SR_CONF_LIST,
+	SR_CONF_NUM_HDIV | SR_CONF_GET,
+	SR_CONF_HORIZ_TRIGGERPOS | SR_CONF_GET | SR_CONF_SET,
+	SR_CONF_TRIGGER_SOURCE | SR_CONF_GET | SR_CONF_SET | SR_CONF_LIST,
+	SR_CONF_TRIGGER_SLOPE | SR_CONF_GET | SR_CONF_SET | SR_CONF_LIST,
+	SR_CONF_TRIGGER_LEVEL | SR_CONF_GET | SR_CONF_SET,
+//	SR_CONF_TRIGGER_PATTERN | SR_CONF_GET | SR_CONF_SET,			//ToDo: Implement pattern trigger
+	SR_CONF_PEAK_DETECTION | SR_CONF_GET | SR_CONF_SET,
+//	SR_CONF_AVERAGING | SR_CONF_GET | SR_CONF_SET,
+	SR_CONF_AVG_SAMPLES | SR_CONF_GET | SR_CONF_SET | SR_CONF_LIST,
+	SR_CONF_LIMIT_SAMPLES | SR_CONF_GET | SR_CONF_SET,				//The device doesn't actually support limiting samples, but will allways capture the maximum available amout of samples. However the driver can selectively transfere a subset of samples inorder to reduce transfer times.
+};
+
+static const uint32_t devopts_cg_analog[] = {
+	SR_CONF_NUM_VDIV | SR_CONF_GET,
+	SR_CONF_VDIV | SR_CONF_GET | SR_CONF_SET | SR_CONF_LIST,
+	SR_CONF_COUPLING | SR_CONF_GET | SR_CONF_SET | SR_CONF_LIST,
+	SR_CONF_ENABLED | SR_CONF_GET | SR_CONF_SET,
+	//SR_CONF_PROBE_FACTOR | SR_CONF_GET | SR_CONF_SET | SR_CONF_LIST,
+};
+
+static const uint32_t devopts_cg_digital[] = {
+	SR_CONF_LOGIC_THRESHOLD | SR_CONF_GET | SR_CONF_SET | SR_CONF_LIST,
+	SR_CONF_LOGIC_THRESHOLD_CUSTOM | SR_CONF_GET | SR_CONF_SET,
+	SR_CONF_ENABLED | SR_CONF_GET | SR_CONF_SET,
+};
+
+static const char *coupling_options[] = {
+	"AC",
+	"DC",
+	"GND",
+	//Agilent 5464x Scopes also allow 50Ohm Termination, however this is configured using the termination command. If someone wants to implement support for that you need to figure out the best way to do that 
+};
+
+static const char *scope_trigger_slopes[] = {
+	"POS",
+	"NEG",
+};
+
+static const char *logic_threshold[] = {
+	"USER",
+	"TTL",
+	"ECL",
+	"CMOS",
+};
+
+static const char *trigger_sources[] = {
+	"CHAN1", "CHAN2",
+	"LINE", "EXT", "NONE",
+	"DIG0", "DIG1", "DIG2", "DIG3", "DIG4", "DIG5", "DIG6", "DIG7", "DIG8", "DIG9", "DIG10", "DIG11", "DIG12", "DIG13", "DIG14", "DIG15",
+};
+
+/* This is not currently used */
+static const char *trigger_mode[] = {
+	"EDGE",
+	"GLIT",
+	"PATT",
+	"CAN",
+	"DUR",
+	"IIC",
+	"LIN",
+	"SEQ",
+	"SPI",
+	"TV",
+	"USB",
+};
+
+static const uint64_t scope_timebases[][2] = {
+	/* nanoseconds */
+	{ 5, 1000000000 },
+	{ 10, 1000000000 },
+	{ 20, 1000000000 },
+	{ 50, 1000000000 },
+	{ 100, 1000000000 },
+	{ 500, 1000000000 },
+	/* microseconds */
+	{ 1, 1000000 },
+	{ 2, 1000000 },
+	{ 5, 1000000 },
+	{ 10, 1000000 },
+	{ 20, 1000000 },
+	{ 50, 1000000 },
+	{ 100, 1000000 },
+	{ 200, 1000000 },
+	{ 500, 1000000 },
+	/* milliseconds */
+	{ 1, 1000 },
+	{ 2, 1000 },
+	{ 5, 1000 },
+	{ 10, 1000 },
+	{ 20, 1000 },
+	{ 50, 1000 },
+	{ 100, 1000 },
+	{ 200, 1000 },
+	{ 500, 1000 },
+	/* seconds */
+	{ 1, 1 },
+	{ 2, 1 },
+	{ 5, 1 },
+	{ 10, 1 },
+	{ 20, 1 },
+	{ 50, 1 },
+};
+
+static const uint64_t vdivs[][2] = {
+	/* millivolts */
+	{ 1, 1000 },
+	{ 2, 1000 },
+	{ 5, 1000 },
+	{ 10, 1000 },
+	{ 20, 1000 },
+	{ 50, 1000 },
+	{ 100, 1000 },
+	{ 200, 1000 },
+	{ 500, 1000 },
+	/* volts */
+	{ 1, 1 },
+	{ 2, 1 },
+	{ 5, 1 },
+	{ 10, 1 },
+	{ 20, 1 },
+	{ 50, 1 },
+	{ 100, 1 },
+};
+
+static const char *scope_analog_channel_names[] = {
+	"CH1", "CH2",
+};
+
+static const char *scope_digital_channel_names[] = {
+	"D0", "D1", "D2", "D3", "D4", "D5", "D6", "D7",
+	"D8", "D9", "D10", "D11", "D12", "D13", "D14", "D15",	
+}; 
+
+static struct scope_config scope_models[] = {
+	{
+		/* Agilent 54621D/54622D Models only differ in Bandwidth; everything else should be the same*/
+		.name = {"54621D", "54622D", NULL},
+		.analog_channels = 2,
+		.digital_channels = 16,
+
+		.analog_names = &scope_analog_channel_names,
+		.digital_names = &scope_digital_channel_names,
+
+		.devopts = &devopts,
+		.num_devopts = ARRAY_SIZE(devopts),
+
+		.devopts_cg_analog = &devopts_cg_analog,
+		.num_devopts_cg_analog = ARRAY_SIZE(devopts_cg_analog),
+
+		.devopts_cg_digital = &devopts_cg_digital,
+		.num_devopts_cg_digital = ARRAY_SIZE(devopts_cg_digital),
+
+		.digital_pods = 2,
+
+		.coupling_options = &coupling_options,
+		.num_coupling_options = ARRAY_SIZE(coupling_options),
+
+		.logic_threshold = &logic_threshold,
+		.num_logic_threshold = ARRAY_SIZE(logic_threshold),
+		.logic_threshold_for_pod = TRUE,
+
+		.trigger_sources = &trigger_sources,
+		.num_trigger_sources = ARRAY_SIZE(trigger_sources),
+
+		.trigger_slopes = &scope_trigger_slopes,
+		.num_trigger_slopes = ARRAY_SIZE(scope_trigger_slopes),
+
+		.timebases = &scope_timebases,
+		.num_timebases = ARRAY_SIZE(scope_timebases),
+
+		.vdivs = &vdivs,
+		.num_vdivs = ARRAY_SIZE(vdivs),
+
+		.num_xdivs = 10,
+		.num_ydivs = 8,
+
+		.scpi_dialect = &agilent_scpi_dialect,
+	},
+	//ToDo: Implement other scope models
+};
+
+SR_PRIV int agilent_54621d_receive_data(int fd, int revents, void *cb_data)
+{
+	const struct sr_dev_inst *sdi;
+	struct dev_context *devc;
+
+	(void)fd;
+
+	sdi = cb_data;
+	if (!sdi)
+		return TRUE;
+
+	devc = sdi->priv;
+	if (!devc)
+		return TRUE;
+
+	if (revents == G_IO_IN) {
+		/* TODO */
+	}
+
+	return TRUE;
+}
+
+SR_PRIV int agilent_54621d_update_sample_rate(const struct sr_dev_inst *sdi)
+{
+	struct dev_context *devc;
+	struct scope_state *state;
+	const struct scope_config *config;
+	uint64_t tmp_int;
+
+	devc = sdi->priv;
+	config = devc->model_config;
+	state = devc->model_state;
+
+	if (sr_scpi_get_int(sdi->conn,
+			      (*config->scpi_dialect)[SCPI_CMD_GET_SAMPLE_RATE],
+			      &tmp_int) != SR_OK)
+		return SR_ERR;
+
+	state->sample_rate = tmp_int;
+
+
+
+	return SR_OK;
+}
+
+SR_PRIV int agilent_54621d_init_device(struct sr_dev_inst *sdi)
+{
+	int model_index;
+	unsigned int i, j, group;
+	struct sr_channel *ch;
+	struct dev_context *devc;
+	const char *cg_name;
+	int ret;
+
+	devc = sdi->priv;
+	model_index = -1;
+
+	/* find model  */
+	for(i = 0; i < ARRAY_SIZE(scope_models); i++) {
+		for(j = 0; scope_models[i].name[j]; j++) {
+			if(!strcmp(sdi->model, scope_models[i].name[j])) {
+				model_index = i;
+			}
+		}
+		if(model_index != -1)
+			break;
+	}
+
+	if(model_index == -1){
+		sr_dbg("Unsupported device.");
+		return SR_ERR_NA;
+	}
+
+	devc->analog_groups = g_malloc0(sizeof(struct sr_channel_group*) *scope_models[model_index].analog_channels);
+	devc->digital_groups = g_malloc0(sizeof(struct sr_channel_group*) *scope_models[model_index].digital_pods);
+	if(!devc->analog_groups || !devc->digital_groups){
+		g_free(devc->analog_groups);
+		g_free(devc->digital_groups);
+		return SR_ERR_MALLOC;
+	}
+
+	/* Add analog channels. */
+	for (i = 0; i < scope_models[model_index].analog_channels; i++) {
+		ch = sr_channel_new(sdi, i, SR_CHANNEL_ANALOG, TRUE,
+			   (*scope_models[model_index].analog_names)[i]);
+
+		cg_name = (*scope_models[model_index].analog_names)[i];
+		devc->analog_groups[i] = sr_channel_group_new(sdi, cg_name, NULL);
+		devc->analog_groups[i]->channels = g_slist_append(NULL, ch);
+	}
+
+	/* Add digital channel groups. */
+	ret = SR_OK;
+	for (i = 0; i < scope_models[model_index].digital_pods; i++) {
+		devc->digital_groups[i] = sr_channel_group_new(sdi, NULL, NULL);
+		if (!devc->digital_groups[i]) {
+			ret = SR_ERR_MALLOC;
+			break;
+		}
+		devc->digital_groups[i]->name = g_strdup_printf("POD%d", i + 1);
+	}
+	if (ret != SR_OK)
+		return ret;
+
+	/* Add digital channels. */
+	for (i = 0; i < scope_models[model_index].digital_channels; i++) {
+		ch = sr_channel_new(sdi, i, SR_CHANNEL_LOGIC, TRUE,
+			   (*scope_models[model_index].digital_names)[i]);
+
+		group = i / DIGITAL_CHANNELS_PER_POD;
+		devc->digital_groups[group]->channels = g_slist_append(
+			devc->digital_groups[group]->channels, ch);
+	}
+
+	devc->model_config = &scope_models[model_index];
+	devc->samples_limit = 2000;
+	devc->frame_limit = 0;
+
+	if (!(devc->model_state = scope_state_new(devc->model_config)))
+		return SR_ERR_MALLOC;
+
+
+	return SR_OK;
+}
+
+static struct scope_state *scope_state_new(const struct scope_config *config) {
+	struct scope_state *state;
+
+	state = g_malloc0(sizeof(struct scope_state));
+	state->analog_channels = g_malloc0_n(config->analog_channels, sizeof(struct analog_channel_state));
+	state->digital_channels = g_malloc0_n(config->digital_channels, sizeof(gboolean) * MAX_DIGITAL_CHANNEL_COUNT);			//ToDo: Why ony one bool size for the digital channel state? Shouldn't it be 1bool per channel?
+	state->digital_pods = g_malloc0_n(config->digital_pods, sizeof(struct digital_pod_state));
+
+	return state;
+}
+
+SR_PRIV int agilent_54621d_scope_state_get(struct sr_dev_inst *sdi)
+{
+	struct dev_context *devc;
+	struct scope_state *state;
+	const struct scope_config *config;
+	float tmp_float;
+	unsigned int i;
+	char *tmp_str;
+
+	devc = sdi->priv;
+	config = devc->model_config;
+	state = devc->model_state;
+
+	sr_info("Fetching scope state");
+
+	//get analog channel state
+	if (analog_channel_state_get(sdi, config, state) != SR_OK)
+		return SR_ERR;
+
+	//get digital channel state
+	if (digital_channel_state_get(sdi, config, state) != SR_OK)
+		return SR_ERR;
+
+	//get timebase
+	if (sr_scpi_get_string(sdi->conn,
+			(*config->scpi_dialect)[SCPI_CMD_GET_TIMEBASE],
+			&tmp_str) != SR_OK)
+		return SR_ERR;
+
+	if (array_float_get(tmp_str, ARRAY_AND_SIZE(scope_timebases), &i) != SR_OK) {
+		g_free(tmp_str);
+		sr_err("Could not determine array index for time base.");
+		return SR_ERR;
+	}
+	g_free(tmp_str);
+
+	state->timebase = i;
+
+	//get trigger horizontal position
+	if(sr_scpi_get_float(sdi->conn, (*config->scpi_dialect)[SCPI_CMD_GET_HORIZ_TRIGGERPOS], &tmp_float) != SR_OK)
+		return SR_ERR;
+	
+	state->horiz_triggerpos = tmp_float /
+		(((double) (*config->timebases)[state->timebase][0] /
+		  (*config->timebases)[state->timebase][1]) * config->num_xdivs);
+	state->horiz_triggerpos -= 0.5;
+	state->horiz_triggerpos *= -1;
+	//ToDo: This might be dependent on time ref setting
+
+	if (scope_state_get_array_option(sdi->conn,	(*config->scpi_dialect)[SCPI_CMD_GET_TRIGGER_SOURCE], config->trigger_sources, config->num_trigger_sources, &state->trigger_source) != SR_OK)
+		return SR_ERR;
+
+	if (scope_state_get_array_option(sdi->conn, (*config->scpi_dialect)[SCPI_CMD_GET_TRIGGER_SLOPE], config->trigger_slopes, config->num_trigger_slopes, &state->trigger_slope) != SR_OK)
+		return SR_ERR;
+
+	//ToDo: get trigger pattern
+	//documentation for reading the trigger pattern is a little wonky so I need to test how this is done
+	strncpy(state->trigger_pattern, "0000000000000000000000", MAX_ANALOG_CHANNEL_COUNT + MAX_DIGITAL_CHANNEL_COUNT); 
+
+
+	//ToDo: get current resolution
+	//Default resolution is 8bit. aquiring at 8 bit also can increase transfer speed, since only a byte of data per point has to be transmitted
+	//Resolution is a function of sweep speed and number of averages
+	//Resolution > 8bit if acq mode == avg && (timebase >= 5us/div || num_avg>1) 
+	state->high_resolution = FALSE;
+
+
+	//get peak detection
+	if (sr_scpi_get_string(sdi->conn,
+			     (*config->scpi_dialect)[SCPI_CMD_GET_PEAK_DETECTION],
+			     &tmp_str) != SR_OK)
+		return SR_ERR;
+	if (!strcmp("PEAK", tmp_str))
+		state->peak_detection = TRUE;
+	else
+		state->peak_detection = FALSE;
+	g_free(tmp_str);
+
+	if(agilent_54621d_update_sample_rate(sdi) != SR_OK)
+		return SR_ERR;
+
+	sr_info("Fetching finished.");
+
+	scope_state_dump(config, state);
+
+	return SR_OK;
+}
+
+static int scope_state_get_array_option(struct sr_scpi_dev_inst *scpi, const char *command, const char *(*array)[], unsigned int n, int *result)
+{
+	char *tmp;
+	int idx;
+
+	if (sr_scpi_get_string(scpi, command, &tmp) != SR_OK)
+		return SR_ERR;
+
+	if ((idx = std_str_idx_s(tmp, *array, n)) < 0) {
+		g_free(tmp);
+		return SR_ERR_ARG;
+	}
+
+	*result = idx;
+
+	g_free(tmp);
+
+	return SR_OK;
+}
+
+
+/*
+*This function is a helper function to output the scope configuration to the info log
+*
+*
+*
+*/
+static void scope_state_dump(const struct scope_config *config, struct scope_state *state)
+{
+	unsigned int i;
+	char *tmp;
+
+	for (i = 0; i < config->analog_channels; i++) {
+		tmp = sr_voltage_string((*config->vdivs)[state->analog_channels[i].vdiv][0],
+					     (*config->vdivs)[state->analog_channels[i].vdiv][1]);
+		sr_info("State of analog channel %d -> %s : %s (coupling) %s (vdiv) %2.2e (offset)",
+			i + 1, state->analog_channels[i].state ? "On" : "Off",
+			(*config->coupling_options)[state->analog_channels[i].coupling],
+			tmp, state->analog_channels[i].vertical_offset);
+	}
+
+	for (i = 0; i < config->digital_channels; i++) {
+		sr_info("State of digital channel %d -> %s", i,
+			state->digital_channels[i] ? "On" : "Off");
+	}
+
+	for (i = 0; i < config->digital_pods; i++) {
+		if (!strncmp("USER", (*config->logic_threshold)[state->digital_pods[i].threshold], 4) ||
+		    !strcmp("MAN", (*config->logic_threshold)[state->digital_pods[i].threshold]))
+			sr_info("State of digital POD %d -> %s : %E (threshold)", i + 1,
+				state->digital_pods[i].state ? "On" : "Off",
+				state->digital_pods[i].user_threshold);
+		else
+			sr_info("State of digital POD %d -> %s : %s (threshold)", i + 1,
+				state->digital_pods[i].state ? "On" : "Off",
+				(*config->logic_threshold)[state->digital_pods[i].threshold]);
+	}
+
+	tmp = sr_period_string((*config->timebases)[state->timebase][0],
+			       (*config->timebases)[state->timebase][1]);
+	sr_info("Current timebase: %s", tmp);
+	g_free(tmp);
+
+	tmp = sr_samplerate_string(state->sample_rate);
+	sr_info("Current samplerate: %s", tmp);
+	g_free(tmp);
+
+	if (!strcmp("PATT", (*config->trigger_sources)[state->trigger_source]))
+		sr_info("Current trigger: %s (pattern), %.2f (offset)",
+			state->trigger_pattern,
+			state->horiz_triggerpos);
+	else // Edge (slope) trigger
+		sr_info("Current trigger: %s (source), %s (slope) %.2f (offset)",
+			(*config->trigger_sources)[state->trigger_source],
+			(*config->trigger_slopes)[state->trigger_slope],
+			state->horiz_triggerpos);
+}
+
+/**
+ * This function takes a value of the form "2.000E-03" and returns the index
+ * of an array where a matching pair was found.
+ *
+ * @param value The string to be parsed.
+ * @param array The array of s/f pairs.
+ * @param array_len The number of pairs in the array.
+ * @param result The index at which a matching pair was found.
+ *
+ * @return SR_ERR on any parsing error, SR_OK otherwise.
+ */
+static int array_float_get(gchar *value, const uint64_t array[][2], int array_len, unsigned int *result)
+{
+	struct sr_rational rval;
+	struct sr_rational aval;
+
+	if (sr_parse_rational(value, &rval) != SR_OK)
+		return SR_ERR;
+
+	for (int i = 0; i < array_len; i++) {
+		sr_rational_set(&aval, array[i][0], array[i][1]);
+		if (sr_rational_eq(&rval, &aval)) {
+			*result = i;
+			return SR_OK;
+		}
+	}
+
+	return SR_ERR;
+}
+
+static struct sr_channel *get_channel_by_index_and_type(GSList *channel_lhead,
+							int index, int type)
+{
+	while (channel_lhead) {
+		struct sr_channel *ch = channel_lhead->data;
+		if (ch->index == index && ch->type == type)
+			return ch;
+
+		channel_lhead = channel_lhead->next;
+	}
+
+	return 0;
+}
+
+static int analog_channel_state_get(struct sr_dev_inst *sdi, const struct scope_config *config, struct scope_state *state)
+{
+	unsigned int i, j;
+	char command[MAX_COMMAND_SIZE];
+	char *tmp_str;
+	struct sr_channel *ch;
+	struct sr_scpi_dev_inst *scpi = sdi->conn;
+
+	for(i = 0; i < config->analog_channels; i++){
+		//get channel enabled (visible)
+		g_snprintf(command, sizeof(command), (*config->scpi_dialect)[SCPI_CMD_GET_ANALOG_CHAN_STATE], i+1);
+
+		if(sr_scpi_get_bool(scpi, command, &state->analog_channels[i].state) != SR_OK)
+			return SR_ERR;
+		
+		ch = get_channel_by_index_and_type(sdi->channels, i, SR_CHANNEL_ANALOG);
+		if(ch)
+			ch->enabled = state->analog_channels[i].state;
+		
+		//get vertical scale (v/div)
+		g_snprintf(command, sizeof(command), (*config->scpi_dialect)[SCPI_CMD_GET_VERTICAL_SCALE], i+1);
+
+		if(sr_scpi_get_string(scpi, command, &tmp_str) != SR_OK)
+			return SR_ERR;
+
+		if(array_float_get(tmp_str, *(config->vdivs), config->num_vdivs, &j) != SR_OK){
+			g_free(tmp_str);
+			sr_err("could not determine array index for vertical div scale.");
+			return SR_ERR;
+		}
+
+		g_free(tmp_str);
+		state->analog_channels[i].vdiv = j;
+
+		//Get vertical offset
+		g_snprintf(command, sizeof(command),
+			   (*config->scpi_dialect)[SCPI_CMD_GET_VERTICAL_OFFSET],
+			   i + 1);
+
+		if (sr_scpi_get_float(scpi, command,
+				     &state->analog_channels[i].vertical_offset) != SR_OK)
+			return SR_ERR;
+
+		//get coupling
+		g_snprintf(command, sizeof(command),
+			   (*config->scpi_dialect)[SCPI_CMD_GET_COUPLING],
+			   i + 1);
+
+		if (scope_state_get_array_option(scpi, command, config->coupling_options,
+					 config->num_coupling_options,
+					 &state->analog_channels[i].coupling) != SR_OK)
+			return SR_ERR;
+
+		//get Unit (Amp/Volt)
+		g_snprintf(command, sizeof(command),
+			   (*config->scpi_dialect)[SCPI_CMD_GET_PROBE_UNIT],
+			   i + 1);
+
+		if (sr_scpi_get_string(scpi, command, &tmp_str) != SR_OK)
+			return SR_ERR;
+
+		if (tmp_str[0] == 'A')
+			state->analog_channels[i].probe_unit = 'A';
+		else
+			state->analog_channels[i].probe_unit = 'V';
+		g_free(tmp_str);
+	}
+
+	return SR_OK;
+}
+
+static int digital_channel_state_get(struct sr_dev_inst *sdi, const struct scope_config *config, struct scope_state *state)
+{
+	unsigned int i, user_index;
+	char command[MAX_COMMAND_SIZE];
+	struct sr_channel *ch;
+	struct sr_scpi_dev_inst *scpi = sdi->conn;
+
+	//get enabled channels
+	for (i = 0; i < config->digital_channels; i++) {
+		g_snprintf(command, sizeof(command),
+			   (*config->scpi_dialect)[SCPI_CMD_GET_DIG_CHAN_STATE],
+			   i);
+
+		if (sr_scpi_get_bool(scpi, command,
+				     &state->digital_channels[i]) != SR_OK)
+			return SR_ERR;
+
+		ch = get_channel_by_index_and_type(sdi->channels, i, SR_CHANNEL_LOGIC);
+		if (ch)
+			ch->enabled = state->digital_channels[i];
+	}
+
+	for (user_index = 0; user_index < ARRAY_SIZE(logic_threshold); user_index++){
+		if(!strcmp(logic_threshold[i], LOGIC_GET_THRESHOLD_SETTING))
+			break;
+	}
+
+	for (i = 0; i < config->digital_pods; i++){
+		//get enabled pods
+		g_snprintf(command, sizeof(command), (*config->scpi_dialect)[SCPI_CMD_GET_DIG_POD_STATE], i+1);
+		if (sr_scpi_get_bool(scpi, command, &state->digital_pods[i].state) != SR_OK)
+			return SR_ERR;
+
+		//get logic threshold
+		//the device driver will allways report logic threshold to be "USER" with the currently set actual level saved as user level, since the device only reports current voltage but not the current setting		
+		state->digital_pods[i].threshold = user_index;
+		g_snprintf(command, sizeof(command), (*config->scpi_dialect)[SCPI_CMD_GET_DIG_POD_THRESHOLD], i+1);
+		
+		if(sr_scpi_get_float(scpi, command, &state->digital_pods[i].user_threshold) != SR_OK)
+			return SR_ERR;
+		
+	}
+	return SR_OK;
+}
+

--- a/src/hardware/agilent-54621d/protocol.h
+++ b/src/hardware/agilent-54621d/protocol.h
@@ -171,13 +171,7 @@ SR_PRIV int agilent_54621d_request_data(const struct sr_dev_inst *sdi);
 SR_PRIV int agilent_54621d_init_device(struct sr_dev_inst *sdi);
 SR_PRIV int agilent_54621d_scope_state_get(struct sr_dev_inst *sdi);
 SR_PRIV int agilent_54621d_update_sample_rate(const struct sr_dev_inst *sdi);
-static struct scope_state *scope_state_new(const struct scope_config *config);
 
-static int analog_channel_state_get(struct sr_dev_inst *sdi, const struct scope_config *config, struct scope_state *state);
-static int digital_channel_state_get(struct sr_dev_inst *sdi, const struct scope_config *config, struct scope_state *state);
-static int array_float_get(gchar *value, const uint64_t array[][2], int array_len, unsigned int *result);
-static void scope_state_dump(const struct scope_config *config, struct scope_state *state);
-static int scope_state_get_array_option(struct sr_scpi_dev_inst *scpi, const char *command, const char *(*array)[], unsigned int n, int *result);
 //static int wait_for_capture_complete(const struct sr_dev_inst *sdi);
 
 #endif

--- a/src/hardware/agilent-54621d/protocol.h
+++ b/src/hardware/agilent-54621d/protocol.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the libsigrok project.
  *
- * Copyright (C) 2022 Daniel <1824222@stud.hs-mannheim.de>
+ * Copyright (C) 2022 Daniel Echt <taragor83@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -174,7 +174,7 @@ SR_PRIV int agilent_54621d_request_data(const struct sr_dev_inst *sdi);
 SR_PRIV int agilent_54621d_init_device(struct sr_dev_inst *sdi);
 SR_PRIV int agilent_54621d_scope_state_get(struct sr_dev_inst *sdi);
 SR_PRIV int agilent_54621d_update_sample_rate(const struct sr_dev_inst *sdi);
+SR_PRIV void agilent_54621d_scope_state_free(struct scope_state *state);
 
-//static int wait_for_capture_complete(const struct sr_dev_inst *sdi);
 
 #endif

--- a/src/hardware/agilent-54621d/protocol.h
+++ b/src/hardware/agilent-54621d/protocol.h
@@ -1,0 +1,153 @@
+/*
+ * This file is part of the libsigrok project.
+ *
+ * Copyright (C) 2022 Daniel <1824222@stud.hs-mannheim.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBSIGROK_HARDWARE_AGILENT_54621D_PROTOCOL_H
+#define LIBSIGROK_HARDWARE_AGILENT_54621D_PROTOCOL_H
+
+#include <stdint.h>
+#include <glib.h>
+#include <string.h>
+#include <libsigrok/libsigrok.h>
+#include "libsigrok-internal.h"
+#include "scpi.h"
+
+#define LOG_PREFIX "agilent-54621d"
+#define MAX_COMMAND_SIZE		128
+
+#define DIGITAL_CHANNELS_PER_POD    8
+#define MAX_INSTRUMENT_VERSIONS		10
+#define MAX_ANALOG_CHANNEL_COUNT    4
+#define MAX_DIGITAL_CHANNEL_COUNT   16
+#define MAX_DIGITAL_POD_COUNT       2
+#define MAX_DIGITAL_GROUP_COUNT		2
+
+
+struct scope_config {
+	const char *name[MAX_INSTRUMENT_VERSIONS];
+	const uint8_t analog_channels;
+	const uint8_t digital_channels;
+	uint8_t digital_pods;
+
+	const char *(*analog_names)[];
+	const char *(*digital_names)[];
+
+	const uint32_t (*devopts)[];
+	const uint8_t num_devopts;
+
+	const uint32_t (*devopts_cg_analog)[];
+	const uint8_t num_devopts_cg_analog;
+
+	const uint32_t (*devopts_cg_digital)[];
+	const uint8_t num_devopts_cg_digital;
+
+	const char *(*coupling_options)[];
+	const uint8_t num_coupling_options;
+
+	const char *(*logic_threshold)[];
+	const uint8_t num_logic_threshold;
+	const gboolean logic_threshold_for_pod;
+
+	const char *(*trigger_sources)[];
+	const uint8_t num_trigger_sources;
+
+	const char *(*trigger_slopes)[];
+	const uint8_t num_trigger_slopes;
+
+	const uint64_t (*timebases)[][2];
+	const uint8_t num_timebases;
+
+	const uint64_t (*vdivs)[][2];
+	const uint8_t num_vdivs;
+
+	unsigned int num_xdivs;
+	const unsigned int num_ydivs;
+
+	const char *(*scpi_dialect)[];
+};
+
+struct analog_channel_state {
+    int coupling;
+
+    int vdiv;
+    float vertical_offset;
+
+    gboolean state;
+    char probe_unit;
+};
+
+struct digital_pod_state {
+    gboolean state;
+
+    int threshold;
+    float user_threshold;
+};
+
+struct scope_state {
+	struct analog_channel_state *analog_channels;
+	gboolean *digital_channels;
+	struct digital_pod_state *digital_pods;
+
+	int timebase;
+	float horiz_triggerpos;
+
+	int trigger_source;
+	int trigger_slope;
+	char trigger_pattern[MAX_ANALOG_CHANNEL_COUNT + MAX_DIGITAL_CHANNEL_COUNT + 1];
+
+	gboolean high_resolution;
+	gboolean peak_detection;
+
+	uint64_t sample_rate;
+};
+
+struct dev_context {
+    const void *model_config;
+    void *model_state;
+
+	/* Device properties */
+	const float minTimebase;
+	const float maxTimebase;
+
+    struct sr_channel_group **analog_groups;
+    struct sr_channel_group **digital_groups;
+
+    GSList *enabled_channels;
+    GSList *current_channel;
+    uint64_t num_samples;
+    uint64_t num_frames;
+
+    uint64_t samples_limit;
+    uint64_t frame_limit;
+
+    size_t pod_count;
+    GByteArray *logic_data;
+};
+
+SR_PRIV int agilent_54621d_receive_data(int fd, int revents, void *cb_data);
+SR_PRIV int agilent_54621d_init_device(struct sr_dev_inst *sdi);
+SR_PRIV int agilent_54621d_scope_state_get(struct sr_dev_inst *sdi);
+SR_PRIV int agilent_54621d_update_sample_rate(const struct sr_dev_inst *sdi);
+static struct scope_state *scope_state_new(const struct scope_config *config);
+static int analog_channel_state_get(struct sr_dev_inst *sdi, const struct scope_config *config, struct scope_state *state);
+static int digital_channel_state_get(struct sr_dev_inst *sdi, const struct scope_config *config, struct scope_state *state);
+static int array_float_get(gchar *value, const uint64_t array[][2], int array_len, unsigned int *result);
+static void scope_state_dump(const struct scope_config *config, struct scope_state *state);
+static int scope_state_get_array_option(struct sr_scpi_dev_inst *scpi, const char *command, const char *(*array)[], unsigned int n, int *result);
+
+#endif

--- a/src/hardware/agilent-54621d/protocol.h
+++ b/src/hardware/agilent-54621d/protocol.h
@@ -164,6 +164,9 @@ struct dev_context {
 	float *data;
 	int failcount;
 	GByteArray *logic_data;
+	uint64_t trigger_at_sample;
+	gboolean trigger_sent;
+	int refPos;
 };
 
 SR_PRIV int agilent_54621d_receive_data(int fd, int revents, void *cb_data);

--- a/src/scpi/scpi.c
+++ b/src/scpi/scpi.c
@@ -66,6 +66,7 @@ static int parse_strict_bool(const char *str, gboolean *ret)
 		*ret = TRUE;
 		return SR_OK;
 	} else if (!g_strcmp0(str, "0") ||
+		   !g_strcmp0(str, "+0") ||
 		   !g_ascii_strncasecmp(str, "n", 1) ||
 		   !g_ascii_strncasecmp(str, "f", 1) ||
 		   !g_ascii_strncasecmp(str, "no", 2) ||

--- a/src/scpi/scpi.c
+++ b/src/scpi/scpi.c
@@ -57,6 +57,7 @@ static int parse_strict_bool(const char *str, gboolean *ret)
 		return SR_ERR_ARG;
 
 	if (!g_strcmp0(str, "1") ||
+	    !g_strcmp0(str, "+1") ||
 	    !g_ascii_strncasecmp(str, "y", 1) ||
 	    !g_ascii_strncasecmp(str, "t", 1) ||
 	    !g_ascii_strncasecmp(str, "yes", 3) ||


### PR DESCRIPTION
This is my implementation of a device driver for the Agilent 54621d mixed signal oscilloscope. 
The driver allows to configure the device and download data from memory or single shot mode.

Downloading data is done in a hacky way: 
The device natively only allows downloading either upto 2k Points from the display buffer or the entire captured waveform (upto 8M points). Downloading the entire waveform takes ages (~10Minutes per channel) since the Device only allows upto 57600Baud. To speed up download time I've implemented Downloading so it zooms and pans the captured waveform to use the Scopes display decimation filter to downsample to the requested sample rate and then download chunks of 2k points until the requested number of points is downloaded.

I'm planning to implement high resolution mode and pattern trigger, but other than that the driver is finished from my point of view.

It can be generalized to work with all devices of the 546xx family, however I've not yet gotten around to doing that and cannot test the other devices. (Might be able to get access to a 54624a)


