### PR TITLE
Add g_free after g_array_free if gboolean is False

### DIFF
--- a/src/drivers.c
+++ b/src/drivers.c
@@ -54,4 +54,5 @@ SR_API void sr_drivers_init(struct sr_context *ctx)
 #endif
 	ctx->driver_list = (struct sr_dev_driver **)array->data;
 	g_array_free(array, FALSE);
+	g_free(array->data);
 }

--- a/src/hardware/siglent-sds/protocol.c
+++ b/src/hardware/siglent-sds/protocol.c
@@ -411,9 +411,11 @@ static int siglent_sds_get_digital(const struct sr_dev_inst *sdi, struct sr_chan
 				/* Clear the buffers to prepare for the new samples */
 				if (ch->index < 8) {
 					g_array_free(data_low_channels, FALSE);
+					g_free(data_low_channels->data);
 					data_low_channels = g_array_new(FALSE, FALSE, sizeof(uint8_t));
 				} else {
 					g_array_free(data_high_channels, FALSE);
+					g_free(data_high_channels->data);
 					data_high_channels = g_array_new(FALSE, FALSE, sizeof(uint8_t));
 				}
 


### PR DESCRIPTION
In Glib's [g_array_free](https://docs.gtk.org/glib/type_func.Array.free.html) document, it said" _The element data if free_segment is FALSE, otherwise NULL. The element data should be freed using g_free()._ " So if the second parameter of g_array_free is FALSE, the array's element, i.e., array->data should be freed by g_free.