### PR TITLE
Add long command processing time for Velleman PS3005DV1.3

### DIFF
--- a/src/hardware/korad-kaxxxxp/api.c
+++ b/src/hardware/korad-kaxxxxp/api.c
@@ -72,6 +72,8 @@ static const struct korad_kaxxxxp_model models[] = {
 	{"Tenma", "72-2550", "", 1, volts_60, amps_3, 0},
 	{"Tenma", "72-2705", "", 1, volts_30, amps_3, 0},
 	{"Tenma", "72-2710", "", 1, volts_30, amps_5, 0},
+	{"Velleman", "PS3005D V1.3", "VELLEMANPS3005DV1.3" , 1, volts_30, amps_5,
+		KORAD_QUIRK_LONG_PROCESSING_TIME | KORAD_QUIRK_ID_TRAILING},
 	{"Velleman", "LABPS3005D", "", 1, volts_30, amps_5,
 		KORAD_QUIRK_LABPS_OVP_EN},
 	{"Velleman", "PS3005D", "", 1, volts_30, amps_5, 0},
@@ -327,7 +329,7 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 	sr_sw_limits_init(&devc->limits);
 	g_mutex_init(&devc->rw_mutex);
 	devc->model = model;
-	devc->req_sent_at = 0;
+	devc->next_req_time = 0;
 	devc->cc_mode_1_changed = FALSE;
 	devc->cc_mode_2_changed = FALSE;
 	devc->output_enabled_changed = FALSE;
@@ -516,7 +518,7 @@ static int dev_acquisition_start(const struct sr_dev_inst *sdi)
 	sr_sw_limits_acquisition_start(&devc->limits);
 	std_session_send_df_header(sdi);
 
-	devc->req_sent_at = 0;
+	devc->next_req_time = 0;
 	serial = sdi->conn;
 	serial_source_add(sdi->session, serial, G_IO_IN,
 			KAXXXXP_POLL_INTERVAL_MS,

--- a/src/hardware/korad-kaxxxxp/protocol.h
+++ b/src/hardware/korad-kaxxxxp/protocol.h
@@ -37,7 +37,8 @@ enum korad_quirks_flag {
 	KORAD_QUIRK_ID_NO_VENDOR = 1UL << 1,
 	KORAD_QUIRK_ID_TRAILING = 1UL << 2,
 	KORAD_QUIRK_ID_OPT_VERSION = 1UL << 3,
-	KORAD_QUIRK_ALL = (1UL << 4) - 1,
+	KORAD_QUIRK_LONG_PROCESSING_TIME = 1 << 4,
+	KORAD_QUIRK_ALL = (1UL << 5) - 1,
 };
 
 /* Information on single model */
@@ -70,7 +71,7 @@ struct dev_context {
 	const struct korad_kaxxxxp_model *model; /**< Model information. */
 
 	struct sr_sw_limits limits;
-	int64_t req_sent_at;
+	int64_t next_req_time;
 	GMutex rw_mutex;
 
 	float current;          /**< Last current value [A] read from device. */


### PR DESCRIPTION
The Velleman PS3005D V1.3 power supply ( driver korad_kaxxxxp ) seems to
have a quirky RS232 interface, that requires waiting a longer time after
some commands before being allowed to send a new command.
Failing to respect this delay means the new command will NOT be executed.
This is especially problematic as the actual driver would report "0.000" value
for current when the power supply failed to answer the IOUT? request,
despite the output current being non zero.

This commit adds a quirk for this specific revision, and introduces a longer
delay for the affected commands ( STATUS? + any set command ).
The behavior is unchanged for other models.