### PR TITLE
[WIP] rigol-ds: add DHO800 series

### DIFF
--- a/src/hardware/rigol-ds/api.c
+++ b/src/hardware/rigol-ds/api.c
@@ -185,6 +185,7 @@ enum series {
 	DS4000,
 	MSO5000,
 	MSO7000A,
+	DHO800,
 };
 
 /* short name, full name */
@@ -217,6 +218,8 @@ static const struct rigol_ds_series supported_series[] = {
 		{1000, 1}, {500, 1000000}, 10, 1000, 0},
 	[MSO7000A] = {VENDOR(AGILENT), "MSO7000A", PROTOCOL_V4, FORMAT_IEEE488_2,
 		{50, 1}, {2, 1000}, 10, 1000, 8000000},
+	[DHO800] = {VENDOR(RIGOL), "DHO800", PROTOCOL_V5, FORMAT_IEEE488_2,
+		{500, 1}, {500, 1000000}, 10, 1000 /* FIXME */, 25*1000*1000},
 };
 
 #define SERIES(x) &supported_series[x]
@@ -289,6 +292,10 @@ static const struct rigol_ds_model supported_models[] = {
 	{SERIES(MSO5000), "MSO5104", {1, 1000000000}, CH_INFO(4, true), std_cmd},
 	{SERIES(MSO5000), "MSO5204", {1, 1000000000}, CH_INFO(4, true), std_cmd},
 	{SERIES(MSO5000), "MSO5354", {1, 1000000000}, CH_INFO(4, true), std_cmd},
+	{SERIES(DHO800), "DHO802", {5, 1000*1000*1000}, CH_INFO(2, false), std_cmd},
+	{SERIES(DHO800), "DHO804", {5, 1000*1000*1000}, CH_INFO(4, false), std_cmd},
+	{SERIES(DHO800), "DHO812", {5, 1000*1000*1000}, CH_INFO(2, false), std_cmd},
+	{SERIES(DHO800), "DHO814", {5, 1000*1000*1000}, CH_INFO(4, false), std_cmd},
 	/* TODO: Digital channels are not yet supported on MSO7000A. */
 	{SERIES(MSO7000A), "MSO7034A", {2, 1000000000}, CH_INFO(4, false), mso7000a_cmd},
 };


### PR DESCRIPTION
Hello fellow DHO[89]00 owners,
I've seen multiple people asking for these devices in #sigrok on IRC. Unfortunately, I don't have time or motivation to finish the port ATM. The current patch simply adds the necessary IDs to find any DHO800 device when attached via USB - but not more than that and the protocol has changed a bit (IIRC I tested version 4 as well, the patch sets version 5).
I've tested with `LD_LIBRARY_PATH=.libs/ sigrok-cli  -d rigol-ds -l 5 --frames 1` and IIRC that simply times out. But at least it's a starting point if someone wanna beat me to it...