### PR TITLE
SUMP/OLS Enhancements

### DIFF
--- a/src/hardware/openbench-logic-sniffer/api.c
+++ b/src/hardware/openbench-logic-sniffer/api.c
@@ -387,7 +387,16 @@ static int config_list(uint32_t key, GVariant **data,
 		return STD_CONFIG_LIST(key, data, sdi, cg, scanopts, drvopts,
 				       devopts);
 	case SR_CONF_SAMPLERATE:
-		*data = std_gvar_samplerates_steps(ARRAY_AND_SIZE(samplerates));
+		if (!sdi)
+			return SR_ERR_ARG;
+		devc = sdi->priv;
+		uint64_t samplerates_ovrd[3];
+		samplerates_ovrd[0] = samplerates[0];
+		samplerates_ovrd[1] = samplerates[1];
+		samplerates_ovrd[2] = samplerates[2];
+		if (devc->max_samplerate)
+			samplerates_ovrd[1] = devc->max_samplerate;
+		*data = std_gvar_samplerates_steps(ARRAY_AND_SIZE(samplerates_ovrd));
 		break;
 	case SR_CONF_TRIGGER_MATCH:
 		*data = std_gvar_array_i32(ARRAY_AND_SIZE(trigger_matches));

--- a/src/hardware/openbench-logic-sniffer/api.c
+++ b/src/hardware/openbench-logic-sniffer/api.c
@@ -150,6 +150,7 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 	g_usleep(RESPONSE_DELAY_US);
 
 	if (serial_has_receive_data(serial) == 0) {
+		serial_close(serial);
 		sr_dbg("Didn't get any ID reply.");
 		return NULL;
 	}
@@ -157,11 +158,13 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 	num_read =
 		serial_read_blocking(serial, buf, 4, serial_timeout(serial, 4));
 	if (num_read < 0) {
+		serial_close(serial);
 		sr_err("Getting ID reply failed (%d).", num_read);
 		return NULL;
 	}
 
 	if (strncmp(buf, "1SLO", 4) && strncmp(buf, "1ALS", 4)) {
+		serial_close(serial);
 		GString *id = sr_hexdump_new((uint8_t *)buf, num_read);
 
 		sr_err("Invalid ID reply (got %s).", id->str);


### PR DESCRIPTION
1) Properly close serial port after a failed SUMP/OLS scan, so it can be retried without restarting the application
2) Properly enumerate the valid samplerates based on returned max_samplerate metadata (rather than using hard-coded default) -- This should address this bugzilla from 2019 http://sigrok.org/bugzilla/show_bug.cgi?id=1465

Tested on linux in pulseview with Bus pirate fw 7.1 from https://github.com/BusPirate/Bus_Pirate and Arduino logic analyzer from https://github.com/gillham/logic_analyzer