### PR TITLE
Update usb.c to address Bug 1886 ("sr: usb: Failed to get libusb file descriptors.") on Windows

### DIFF
--- a/src/usb.c
+++ b/src/usb.c
@@ -262,10 +262,15 @@ static GSource *usb_source_new(struct sr_session *session,
 	const struct libusb_pollfd **upollfds, **upfd;
 
 	upollfds = libusb_get_pollfds(usb_ctx);
+	
+/* There are no filehandles in Windows */	
+#if !defined(__MINGW32__) 
 	if (!upollfds) {
 		sr_err("Failed to get libusb file descriptors.");
 		return NULL;
 	}
+#endif
+	
 	source = g_source_new(&usb_source_funcs, sizeof(struct usb_source));
 	usource = (struct usb_source *)source;
 
@@ -281,7 +286,9 @@ static GSource *usb_source_new(struct sr_session *session,
 	usource->session = session;
 	usource->usb_ctx = usb_ctx;
 	usource->pollfds = g_ptr_array_new_full(8, &usb_source_free_pollfd);
-
+	
+/* There are no filehandles in Windows */	
+#if !defined(__MINGW32__) 
 	for (upfd = upollfds; *upfd != NULL; upfd++)
 		usb_pollfd_added((*upfd)->fd, (*upfd)->events, usource);
 
@@ -292,7 +299,7 @@ static GSource *usb_source_new(struct sr_session *session,
 #endif
 	libusb_set_pollfd_notifiers(usb_ctx,
 		&usb_pollfd_added, &usb_pollfd_removed, usource);
-
+#endif
 	return source;
 }
 


### PR DESCRIPTION
Add Windows handling to usb.c.

Per https://libusb.sourceforge.io/api-1.0/group__libusb__poll.html

libusb_get_pollfds()
As file descriptors are a Unix-specific concept, this function is not available on Windows and will always return NULL.