### PR TITLE
Adalm2k

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -234,6 +234,12 @@ src_libdrivers_tail_la_SOURCES = src/driver_list_stop.c
 
 src_libdrivers_la_SOURCES = src/drivers.c
 
+if HW_ADALM2K_DRIVER
+src_libdrivers_la_SOURCES += \
+	src/hardware/adalm2k-driver/protocol.h \
+	src/hardware/adalm2k-driver/protocol.c \
+	src/hardware/adalm2k-driver/api.c
+endif
 if HW_AGILENT_DMM
 src_libdrivers_la_SOURCES += \
 	src/hardware/agilent-dmm/protocol.h \

--- a/configure.ac
+++ b/configure.ac
@@ -304,6 +304,7 @@ m4_define([_SR_DRIVER], [
 m4_define([SR_DRIVER],
 	[_SR_DRIVER([$1], [$2], m4_expand([AS_TR_CPP([HW_$2])]), [$3])])
 
+SR_DRIVER([adalm2k-driver], [adalm2k-driver])
 SR_DRIVER([Agilent DMM], [agilent-dmm], [serial_comm])
 SR_DRIVER([Appa 55II], [appa-55ii], [serial_comm])
 SR_DRIVER([Arachnid Labs Re:load Pro], [arachnid-labs-re-load-pro], [serial_comm])

--- a/src/hardware/adalm2k-driver/api.c
+++ b/src/hardware/adalm2k-driver/api.c
@@ -1,0 +1,154 @@
+/*
+ * This file is part of the libsigrok project.
+ *
+ * Copyright (C) 2024 Sean W Jasin <swjasin03@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+#include "protocol.h"
+
+static struct sr_dev_driver adalm2k_driver_driver_info;
+
+static GSList *scan(struct sr_dev_driver *di, GSList *options)
+{
+	struct drv_context *drvc;
+	GSList *devices;
+
+	(void)options;
+
+	devices = NULL;
+	drvc = di->context;
+	drvc->instances = NULL;
+
+	/* TODO: scan for devices, either based on a SR_CONF_CONN option
+	 * or on a USB scan. */
+
+	return devices;
+}
+
+static int dev_open(struct sr_dev_inst *sdi)
+{
+	(void)sdi;
+
+	/* TODO: get handle from sdi->conn and open it. */
+
+	return SR_OK;
+}
+
+static int dev_close(struct sr_dev_inst *sdi)
+{
+	(void)sdi;
+
+	/* TODO: get handle from sdi->conn and close it. */
+
+	return SR_OK;
+}
+
+static int config_get(uint32_t key, GVariant **data,
+	const struct sr_dev_inst *sdi, const struct sr_channel_group *cg)
+{
+	int ret;
+
+	(void)sdi;
+	(void)data;
+	(void)cg;
+
+	ret = SR_OK;
+	switch (key) {
+	/* TODO */
+	default:
+		return SR_ERR_NA;
+	}
+
+	return ret;
+}
+
+static int config_set(uint32_t key, GVariant *data,
+	const struct sr_dev_inst *sdi, const struct sr_channel_group *cg)
+{
+	int ret;
+
+	(void)sdi;
+	(void)data;
+	(void)cg;
+
+	ret = SR_OK;
+	switch (key) {
+	/* TODO */
+	default:
+		ret = SR_ERR_NA;
+	}
+
+	return ret;
+}
+
+static int config_list(uint32_t key, GVariant **data,
+	const struct sr_dev_inst *sdi, const struct sr_channel_group *cg)
+{
+	int ret;
+
+	(void)sdi;
+	(void)data;
+	(void)cg;
+
+	ret = SR_OK;
+	switch (key) {
+	/* TODO */
+	default:
+		return SR_ERR_NA;
+	}
+
+	return ret;
+}
+
+static int dev_acquisition_start(const struct sr_dev_inst *sdi)
+{
+	/* TODO: configure hardware, reset acquisition state, set up
+	 * callbacks and send header packet. */
+
+	(void)sdi;
+
+	return SR_OK;
+}
+
+static int dev_acquisition_stop(struct sr_dev_inst *sdi)
+{
+	/* TODO: stop acquisition. */
+
+	(void)sdi;
+
+	return SR_OK;
+}
+
+static struct sr_dev_driver adalm2k_driver_driver_info = {
+	.name = "adalm2k-driver",
+	.longname = "adalm2k-driver",
+	.api_version = 1,
+	.init = std_init,
+	.cleanup = std_cleanup,
+	.scan = scan,
+	.dev_list = std_dev_list,
+	.dev_clear = std_dev_clear,
+	.config_get = config_get,
+	.config_set = config_set,
+	.config_list = config_list,
+	.dev_open = dev_open,
+	.dev_close = dev_close,
+	.dev_acquisition_start = dev_acquisition_start,
+	.dev_acquisition_stop = dev_acquisition_stop,
+	.context = NULL,
+};
+SR_REGISTER_DEV_DRIVER(adalm2k_driver_driver_info);

--- a/src/hardware/adalm2k-driver/api.c
+++ b/src/hardware/adalm2k-driver/api.c
@@ -17,13 +17,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <config.h>
-#include <iio/iio.h>
 #include "libsigrok/libsigrok.h"
 #include "protocol.h"
+#include <config.h>
+#include <iio/iio.h>
 
-#define M2K_VID     0x0456
-#define M2K_PID     0xb672 
+#define M2K_VID 0x0456
+#define M2K_PID 0xb672
 
 static const uint32_t scanopts[] = {
 	SR_CONF_CONN,
@@ -54,24 +54,15 @@ static const uint32_t devopts_cg_analog_channel[] = {
 	SR_CONF_TRIGGER_LEVEL | SR_CONF_GET | SR_CONF_SET,
 };
 
-static const uint32_t devopts_cg[] = {
-};
+static const uint32_t devopts_cg[] = {};
 
 static const int32_t trigger_matches[] = {
-	SR_TRIGGER_ZERO,
-	SR_TRIGGER_ONE,
-	SR_TRIGGER_RISING,
-	SR_TRIGGER_FALLING,
-	SR_TRIGGER_EDGE,
+	SR_TRIGGER_ZERO,	SR_TRIGGER_ONE,	 SR_TRIGGER_RISING,
+	SR_TRIGGER_FALLING, SR_TRIGGER_EDGE,
 };
 
 static const uint64_t samplerates[] = {
-	SR_KHZ(1),
-	SR_KHZ(10),
-	SR_KHZ(100),
-	SR_MHZ(1),
-	SR_MHZ(10),
-	SR_MHZ(100),
+	SR_KHZ(1), SR_KHZ(10), SR_KHZ(100), SR_MHZ(1), SR_MHZ(10), SR_MHZ(100),
 };
 
 static const char *trigger_sources[] = {
@@ -92,13 +83,15 @@ static const char *trigger_slopes[] = {
 
 static struct sr_dev_driver adalm2k_driver_driver_info;
 
-static GSList *scan(struct sr_dev_driver *di, GSList *options)
-{
+static GSList *scan(struct sr_dev_driver *di, GSList *options) {
 	struct drv_context *drvc;
-    struct dev_context *devc;
-    struct sr_dev_inst *sdi;
-    /* struct sr_usb_dev_inst *usb; */
-    struct sr_config *src;
+	struct dev_context *devc;
+	struct sr_dev_inst *sdi;
+    struct sr_channel_group *cg;
+    struct sr_channel *ch;
+    char channel_name[16];
+	/* struct sr_usb_dev_inst *usb; */
+	struct sr_config *src;
 
 	GSList *devices;
 
@@ -108,74 +101,83 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 	drvc = di->context;
 	drvc->instances = NULL;
 
-    // TODO: Clean this, very basic concept
-    if(iio_scan(NULL, "usb=0456:b672")) {
-        sr_dbg("Found M2K.");
-        sdi = g_malloc(sizeof(struct sr_dev_inst));
-        sdi->status = SR_ST_INITIALIZING;
-        sdi->vendor = g_strdup("Analog Devices");
-        sdi->model = g_strdup("M2K");
-        sdi->connection_id = 0;
-        sdi->conn = g_strdup("usb=0456:b672");
-        sdi->inst_type = SR_INST_USB;
-        sdi->driver = NULL;
-        sdi->session = NULL;
-        sdi->version = g_strdup("0.0.1");
-        sdi->channels = NULL;
-        sdi->serial_num = NULL;
-        sdi->channel_groups = NULL;
+	/* TODO: Clean this, very basic concept */
+    struct iio_scan *scan = iio_scan(NULL, "usb=0456:b672");
+    if(iio_scan_get_results_count(scan) > 0) {
+		sr_dbg("Found M2K.");
+		sdi = g_malloc(sizeof(struct sr_dev_inst));
+		sdi->status = SR_ST_INITIALIZING;
+		sdi->vendor = g_strdup("Analog Devices");
+		sdi->model = g_strdup("M2K");
+		sdi->connection_id = g_strdup(iio_scan_get_uri(scan, 0));
+		sdi->conn = g_strdup("usb=0456:b672");
+		sdi->inst_type = SR_INST_USB;
+		sdi->driver = NULL;
+		sdi->session = NULL;
+		sdi->version = g_strdup("0.0.1");
+		sdi->channels = NULL;
+		sdi->serial_num = NULL;
 
-        devc = g_malloc(sizeof(struct dev_context));
-        devc->m2k = NULL;
-        devc->logic_unitsize = 2;
-        devc->buffersize = 1 << 16;
-        devc->meaning.mq = SR_MQ_VOLTAGE;
-        devc->meaning.unit = SR_UNIT_VOLT;
-        devc->meaning.mqflags = 0;
-        
-        sdi->priv = devc;
-        devices = g_slist_append(devices, sdi);
-    }
+		cg = g_malloc0(sizeof(struct sr_channel_group));
+		cg->name = g_strdup("Logic");
+
+		for (int j = 0; j < DEFAULT_NUM_LOGIC_CHANNELS; j++) {
+			snprintf(channel_name, 16, "DIO%d", j);
+			ch = sr_channel_new(sdi, j, SR_CHANNEL_LOGIC, TRUE, channel_name);
+			cg->channels = g_slist_append(cg->channels, ch);
+		}
+		sdi->channel_groups = g_slist_append(NULL, cg);
+
+		devc = g_malloc(sizeof(struct dev_context));
+		devc->m2k = NULL;
+		devc->logic_unitsize = 2;
+		devc->buffersize = 1 << 16;
+		devc->meaning.mq = SR_MQ_VOLTAGE;
+		devc->meaning.unit = SR_UNIT_VOLT;
+		devc->meaning.mqflags = 0;
+
+		sdi->priv = devc;
+        sdi->inst_type = SR_INST_USB;
+		devices = g_slist_append(devices, sdi);
+	}
 
 	return std_scan_complete(di, devices);
 }
 
-static int dev_open(struct sr_dev_inst *sdi)
-{
+static int dev_open(struct sr_dev_inst *sdi) {
 	(void)sdi;
-    struct dev_context *devc;
-    devc = sdi->priv;
-    devc->m2k = iio_create_context(NULL, sdi->conn);
-    if (!devc->m2k) {
-        sr_err("Failed to open device");
-        return SR_ERR;
-    }
-
+	struct dev_context *devc;
+	devc = sdi->priv;
+	devc->m2k = iio_create_context(NULL, sdi->conn);
+	if (!devc->m2k) {
+		sr_err("Failed to open device");
+		return SR_ERR;
+	}
+	sr_dbg("OK");
 	return SR_OK;
 }
 
-static int dev_close(struct sr_dev_inst *sdi)
-{
+static int dev_close(struct sr_dev_inst *sdi) {
 	(void)sdi;
-    struct dev_context *devc;
-    devc = sdi->priv;
-    iio_context_destroy(devc->m2k);
-    if (devc->m2k) {
-        sr_err("Failed to close device");
-        return SR_ERR;
-    }
+	struct dev_context *devc;
+	devc = sdi->priv;
+	iio_context_destroy(devc->m2k);
+	if (devc->m2k) {
+		sr_err("Failed to close device");
+		return SR_ERR;
+	}
 
 	return SR_OK;
 }
 
 static int config_get(uint32_t key, GVariant **data,
-	const struct sr_dev_inst *sdi, const struct sr_channel_group *cg)
-{
-    unsigned int idx, capture_ratio, samplerate;
-    int delay;
-    gboolean analog_en, digital_en;
-    struct sr_channel *ch;
-    struct dev_context *devc;
+					  const struct sr_dev_inst *sdi,
+					  const struct sr_channel_group *cg) {
+	unsigned int idx, capture_ratio, samplerate;
+	int delay;
+	gboolean analog_en, digital_en;
+	struct sr_channel *ch;
+	struct dev_context *devc;
 
 	int ret;
 
@@ -183,36 +185,47 @@ static int config_get(uint32_t key, GVariant **data,
 	(void)data;
 	(void)cg;
 
-    if (!sdi) {
-        return SR_ERR_ARG;
-    }
+	if (!sdi) {
+		return SR_ERR_ARG;
+	}
 
 	ret = SR_OK;
 
-    devc = sdi->priv;
+	devc = sdi->priv;
+    sr_dbg("Getting configs");
 
 	switch (key) {
-    case SR_CONF_SAMPLERATE:
-        digital_en = adalm2k_driver_nb_enabled_channels(sdi, SR_CHANNEL_LOGIC) > 0;
-        if (digital_en) {
-
-            }
-        // TODO: samplerate = m2k_get_samplerate(sdi);
-        break;
-    case SR_CONF_LIMIT_SAMPLES:
-        *data = g_variant_new_uint64(devc->limit_samples);
-        break;
-    case SR_CONF_LIMIT_MSEC:
-        *data = g_variant_new_uint64(devc->limit_msec);
-        break;
-    case SR_CONF_AVERAGING:
-        *data = g_variant_new_boolean(devc->avg);
-        break;
-    case SR_CONF_AVG_SAMPLES:
-        *data = g_variant_new_uint64(devc->avg_samples);
-        break;
-    case SR_CONF_CAPTURE_RATIO:
-        break;
+	case SR_CONF_SAMPLERATE:
+        sr_dbg("SAMPLERATE");
+		digital_en =
+			adalm2k_driver_nb_enabled_channels(sdi, SR_CHANNEL_LOGIC) > 0;
+		if (digital_en) {
+		}
+        /* samplerate = 99999999; */
+		*data = g_variant_new_uint64(devc->samplerate);
+		/* TODO: samplerate = m2k_get_samplerate(sdi); */
+		/* TODO: add support for analog */
+		break;
+	case SR_CONF_LIMIT_SAMPLES:
+        sr_dbg("LIMIT SAMPLES");
+		*data = g_variant_new_uint64(devc->limit_samples);
+		break;
+	case SR_CONF_LIMIT_MSEC:
+        sr_dbg("LIMIT MSEC");
+		*data = g_variant_new_uint64(devc->limit_msec);
+		break;
+	case SR_CONF_AVERAGING:
+        sr_dbg("AVERAGING");
+		*data = g_variant_new_boolean(devc->avg);
+		break;
+	case SR_CONF_AVG_SAMPLES:
+        sr_dbg("AVG SAMPLES");
+		*data = g_variant_new_uint64(devc->avg_samples);
+		break;
+	case SR_CONF_CAPTURE_RATIO:
+        *data = g_variant_new_uint64(0);
+        sr_dbg("CAP RATIO");
+		break;
 	/* TODO */
 	default:
 		return SR_ERR_NA;
@@ -222,9 +235,10 @@ static int config_get(uint32_t key, GVariant **data,
 }
 
 static int config_set(uint32_t key, GVariant *data,
-	const struct sr_dev_inst *sdi, const struct sr_channel_group *cg)
-{
-    struct sr_channel *ch;
+					  const struct sr_dev_inst *sdi,
+					  const struct sr_channel_group *cg) {
+	struct sr_channel *ch;
+	struct dev_context *devc;
 
 	int ret;
 
@@ -232,10 +246,40 @@ static int config_set(uint32_t key, GVariant *data,
 	(void)data;
 	(void)cg;
 
+	devc = sdi->priv;
+
 	ret = SR_OK;
+    sr_dbg("Setting configs");
 	switch (key) {
-        /* TODO */
-		default:
+	case SR_CONF_SAMPLERATE:
+        sr_dbg("SAMPLERATE");
+        devc->samplerate = g_variant_get_uint64(data);
+		/* TODO: implement analog */
+		break;
+	case SR_CONF_LIMIT_SAMPLES:
+        sr_dbg("LIMIT SAMPLES");
+		devc->limit_samples = g_variant_get_uint64(data);
+		devc->limit_msec = 0;
+		break;
+	case SR_CONF_LIMIT_MSEC:
+        sr_dbg("LIMIT MSEC");
+		devc->limit_msec = g_variant_get_uint64(data);
+		devc->limit_samples = 0;
+		break;
+	case SR_CONF_CAPTURE_RATIO:
+        sr_dbg("CAP RATIO");
+		break;
+	case SR_CONF_AVERAGING:
+        sr_dbg("AVERAGING");
+		devc->avg = g_variant_get_boolean(data);
+		break;
+	case SR_CONF_AVG_SAMPLES:
+        sr_dbg("AVG SAMPLES");
+		devc->avg_samples = g_variant_get_uint64(data);
+		break;
+	/* TODO */
+	default:
+        sr_dbg("ERR");
 		ret = SR_ERR_NA;
 	}
 
@@ -243,46 +287,49 @@ static int config_set(uint32_t key, GVariant *data,
 }
 
 static int config_list(uint32_t key, GVariant **data,
-                       const struct sr_dev_inst *sdi,
-                       const struct sr_channel_group *cg) {
-    int ret;
-
-    (void)sdi;
-    (void)data;
-    (void)cg;
-
-    ret = SR_OK;
-    switch (key) {
-    case SR_CONF_SCAN_OPTIONS:
-        break;
-    case SR_CONF_DEVICE_OPTIONS:
-        return STD_CONFIG_LIST(key, data, sdi, cg, scanopts, drvopts, devopts);
-    case SR_CONF_SAMPLERATE:
-        *data = std_gvar_samplerates(ARRAY_AND_SIZE(samplerates));
-        break;
-    case SR_CONF_TRIGGER_MATCH:
-        *data = std_gvar_array_i32(ARRAY_AND_SIZE(trigger_matches));
-        break;
-
-    default:
-        return SR_ERR_NA;
-    }
-
-    return ret;
-}
-
-static int dev_acquisition_start(const struct sr_dev_inst *sdi)
-{
-	/* TODO: configure hardware, reset acquisition state, set up
-	 * callbacks and send header packet. */
+					   const struct sr_dev_inst *sdi,
+					   const struct sr_channel_group *cg) {
+	int ret;
 
 	(void)sdi;
+	(void)data;
+	(void)cg;
+
+	ret = SR_OK;
+    sr_dbg("Listing configs");
+	switch (key) {
+	case SR_CONF_SCAN_OPTIONS:
+		break;
+	case SR_CONF_DEVICE_OPTIONS:
+		return STD_CONFIG_LIST(key, data, sdi, cg, scanopts, drvopts, devopts);
+        break;
+	case SR_CONF_SAMPLERATE:
+		*data = std_gvar_samplerates(ARRAY_AND_SIZE(samplerates));
+		break;
+	case SR_CONF_TRIGGER_MATCH:
+		*data = std_gvar_array_i32(ARRAY_AND_SIZE(trigger_matches));
+		break;
+	default:
+		return SR_ERR_NA;
+	}
+
+	return ret;
+}
+
+static int dev_acquisition_start(const struct sr_dev_inst *sdi) {
+	/* TODO: configure hardware, reset acquisition state, set up
+	 * callbacks and send header packet. */
+    struct dev_context *devc;
+
+	(void)sdi;
+
+    devc = sdi->priv;
+
 
 	return SR_OK;
 }
 
-static int dev_acquisition_stop(struct sr_dev_inst *sdi)
-{
+static int dev_acquisition_stop(struct sr_dev_inst *sdi) {
 	/* TODO: stop acquisition. */
 
 	(void)sdi;

--- a/src/hardware/adalm2k-driver/api.c
+++ b/src/hardware/adalm2k-driver/api.c
@@ -18,13 +18,22 @@
  */
 
 #include <config.h>
+#include <iio/iio.h>
 #include "protocol.h"
+
+#define M2K_VID     0x0456
+#define M2K_PID     0xb672 
 
 static struct sr_dev_driver adalm2k_driver_driver_info;
 
 static GSList *scan(struct sr_dev_driver *di, GSList *options)
 {
 	struct drv_context *drvc;
+    struct dev_context *devc;
+    struct sr_dev_inst *sdi;
+    struct sr_usb_dev_inst *usb;
+    struct sr_config *src;
+
 	GSList *devices;
 
 	(void)options;
@@ -33,10 +42,24 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 	drvc = di->context;
 	drvc->instances = NULL;
 
+    if(!iio_scan(NULL, "usb=0456:b672")) {
+        sr_dbg("Found M2K.");
+        sdi = g_malloc(sizeof(struct sr_dev_inst));
+        sdi->status = SR_ST_INITIALIZING;
+        sdi->vendor = g_strdup("Analog Devices");
+        sdi->model = g_strdup("M2K");
+        sdi->connection_id = 0;
+
+        devc = g_malloc(sizeof(struct dev_context));
+        sdi->priv = devc;
+        devices = g_slist_append(devices, sdi);
+    }
+
+
 	/* TODO: scan for devices, either based on a SR_CONF_CONN option
 	 * or on a USB scan. */
 
-	return devices;
+	return std_scan_complete(di, devices);
 }
 
 static int dev_open(struct sr_dev_inst *sdi)

--- a/src/hardware/adalm2k-driver/protocol.c
+++ b/src/hardware/adalm2k-driver/protocol.c
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the libsigrok project.
+ *
+ * Copyright (C) 2024 Sean W Jasin <swjasin03@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+#include "protocol.h"
+
+SR_PRIV int adalm2k_driver_receive_data(int fd, int revents, void *cb_data)
+{
+	const struct sr_dev_inst *sdi;
+	struct dev_context *devc;
+
+	(void)fd;
+
+	sdi = cb_data;
+	if (!sdi)
+		return TRUE;
+
+	devc = sdi->priv;
+	if (!devc)
+		return TRUE;
+
+	if (revents == G_IO_IN) {
+		/* TODO */
+	}
+
+	return TRUE;
+}

--- a/src/hardware/adalm2k-driver/protocol.c
+++ b/src/hardware/adalm2k-driver/protocol.c
@@ -20,6 +20,25 @@
 #include <config.h>
 #include "protocol.h"
 
+SR_PRIV int adalm2k_driver_nb_enabled_channels(const struct sr_dev_inst *sdi, int type)
+{
+	struct sr_channel *ch;
+	int nb_channels;
+	GSList *l;
+
+	nb_channels = 0;
+
+	for (l = sdi->channels; l; l = l->next) {
+		ch = l->data;
+		if (ch->type == type) {
+			if (ch->enabled) {
+				nb_channels++;
+			}
+		}
+	}
+	return nb_channels;
+}
+
 SR_PRIV int adalm2k_driver_receive_data(int fd, int revents, void *cb_data)
 {
 	const struct sr_dev_inst *sdi;

--- a/src/hardware/adalm2k-driver/protocol.h
+++ b/src/hardware/adalm2k-driver/protocol.h
@@ -28,9 +28,14 @@
 
 #define LOG_PREFIX "adalm2k-driver"
 
+#define DEFAULT_NUM_LOGIC_CHANNELS               16
+#define DEFAULT_NUM_ANALOG_CHANNELS               2
+#define MAX_NEG_DELAY                         -8192
+
 // NOTE: Credit to @teoperisanu github https://github.com/teoperisanu/libsigrok/blob/master/src/hardware/adalm2000/protocol.h
 struct dev_context {
     struct iio_context *m2k;
+    uint64_t samplerate;
     uint64_t start_time;
 	int64_t spent_us;
 	uint64_t limit_msec;

--- a/src/hardware/adalm2k-driver/protocol.h
+++ b/src/hardware/adalm2k-driver/protocol.h
@@ -20,6 +20,7 @@
 #ifndef LIBSIGROK_HARDWARE_ADALM2K_DRIVER_PROTOCOL_H
 #define LIBSIGROK_HARDWARE_ADALM2K_DRIVER_PROTOCOL_H
 
+#include <iio/iio.h>
 #include <stdint.h>
 #include <glib.h>
 #include <libsigrok/libsigrok.h>
@@ -27,8 +28,31 @@
 
 #define LOG_PREFIX "adalm2k-driver"
 
+// NOTE: Credit to @teoperisanu github https://github.com/teoperisanu/libsigrok/blob/master/src/hardware/adalm2000/protocol.h
 struct dev_context {
+    struct iio_context *m2k;
+    uint64_t start_time;
+	int64_t spent_us;
+	uint64_t limit_msec;
+	uint64_t limit_frames;
+	uint64_t limit_samples;
+	uint64_t sent_samples;
+	uint64_t buffersize;
+	uint32_t logic_unitsize;
+	gboolean avg;
+	uint64_t avg_samples;
+    
+    // TODO: Learn what this stuff does 
+    struct sr_datafeed_analog packet;
+    struct sr_analog_encoding encoding;
+    struct sr_analog_meaning meaning;
+    struct sr_analog_spec spec;
 };
+
+// TODO: And this stuff
+SR_PRIV int adalm2000_nb_enabled_channels(const struct sr_dev_inst *sdi, int type);
+
+SR_PRIV int adalm2000_convert_trigger(const struct sr_dev_inst *sdi);
 
 SR_PRIV int adalm2k_driver_receive_data(int fd, int revents, void *cb_data);
 

--- a/src/hardware/adalm2k-driver/protocol.h
+++ b/src/hardware/adalm2k-driver/protocol.h
@@ -31,10 +31,14 @@
 #define DEFAULT_NUM_LOGIC_CHANNELS               16
 #define DEFAULT_NUM_ANALOG_CHANNELS               2
 #define MAX_NEG_DELAY                         -8192
+#define M2K_LA "m2k-logic-analyzer"
+#define M2K_TX "m2k-logic-analyzer-tx"
+#define M2K_RX "m2k-logic-analyzer-rx"
 
 // NOTE: Credit to @teoperisanu github https://github.com/teoperisanu/libsigrok/blob/master/src/hardware/adalm2000/protocol.h
 struct dev_context {
     struct iio_context *m2k;
+    struct iio_channels_mask *mask;
     uint64_t samplerate;
     uint64_t start_time;
 	int64_t spent_us;
@@ -55,10 +59,16 @@ struct dev_context {
 };
 
 // TODO: And this stuff
+SR_PRIV int adalm2k_driver_set_samplerate(const struct sr_dev_inst *sdi);
+
+SR_PRIV int adalm2k_driver_enable_channel(const struct sr_dev_inst *sdi, int index);
+
 SR_PRIV int adalm2k_driver_nb_enabled_channels(const struct sr_dev_inst *sdi, int type);
 
 SR_PRIV int adalm2000_convert_trigger(const struct sr_dev_inst *sdi);
 
 SR_PRIV int adalm2k_driver_receive_data(int fd, int revents, void *cb_data);
+
+SR_PRIV uint8_t * adalm2k_driver_get_samples(struct sr_dev_inst *sdi, long samples);
 
 #endif

--- a/src/hardware/adalm2k-driver/protocol.h
+++ b/src/hardware/adalm2k-driver/protocol.h
@@ -1,0 +1,35 @@
+/*
+ * This file is part of the libsigrok project.
+ *
+ * Copyright (C) 2024 Sean W Jasin <swjasin03@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBSIGROK_HARDWARE_ADALM2K_DRIVER_PROTOCOL_H
+#define LIBSIGROK_HARDWARE_ADALM2K_DRIVER_PROTOCOL_H
+
+#include <stdint.h>
+#include <glib.h>
+#include <libsigrok/libsigrok.h>
+#include "libsigrok-internal.h"
+
+#define LOG_PREFIX "adalm2k-driver"
+
+struct dev_context {
+};
+
+SR_PRIV int adalm2k_driver_receive_data(int fd, int revents, void *cb_data);
+
+#endif

--- a/src/hardware/adalm2k-driver/protocol.h
+++ b/src/hardware/adalm2k-driver/protocol.h
@@ -69,6 +69,6 @@ SR_PRIV int adalm2000_convert_trigger(const struct sr_dev_inst *sdi);
 
 SR_PRIV int adalm2k_driver_receive_data(int fd, int revents, void *cb_data);
 
-SR_PRIV uint8_t * adalm2k_driver_get_samples(struct sr_dev_inst *sdi, long samples);
+/* SR_PRIV uint8_t * adalm2k_driver_get_samples(struct sr_dev_inst *sdi, long samples); */
 
 #endif

--- a/src/hardware/adalm2k-driver/protocol.h
+++ b/src/hardware/adalm2k-driver/protocol.h
@@ -50,7 +50,7 @@ struct dev_context {
 };
 
 // TODO: And this stuff
-SR_PRIV int adalm2000_nb_enabled_channels(const struct sr_dev_inst *sdi, int type);
+SR_PRIV int adalm2k_driver_nb_enabled_channels(const struct sr_dev_inst *sdi, int type);
 
 SR_PRIV int adalm2000_convert_trigger(const struct sr_dev_inst *sdi);
 


### PR DESCRIPTION
# Adalm2k
Added support for the [Adalm2k](https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/adalm2000.html). 
Initial support was written but never finished #97 
Requires [libiio v1.0](https://github.com/analogdevicesinc/libiio)
## Features
- 16 Digital Inputs
- 100M sampling rate
## Missing
- Support for real time sampling
- Analog support
- Changing trigger method
## Tested
- 1kHz square wave @ 100M 10M 1M 100k 10k
- Disabling/Enabling channels
- N/A
## Bugs
- If the number of samples is too large, the buffer will fail to send
- Unknown