### PR TITLE
Add Siglent SDS E-series Support

### DIFF
--- a/contrib/60-libsigrok.rules
+++ b/contrib/60-libsigrok.rules
@@ -287,14 +287,14 @@ ATTRS{idVendor}=="21a9", ATTRS{idProduct}=="1005", ENV{ID_SIGROK}="1"
 ATTRS{idVendor}=="21a9", ATTRS{idProduct}=="1006", ENV{ID_SIGROK}="1"
 
 # Siglent USBTMC devices.
-# f4ec:ee3a: E.g. SDS1052DL+ scope
-# f4ec:ee38: E.g. SDS1104X-E scope or SDM3055 Multimeter
-# f4ed:ee3a: E.g. SDS1202X-E scope or SDG1010 waveform generator
 # f4ec:1012: E.g. SDS1104X-U scope
+# f4ec:ee38: E.g. SDS1104X-E scope or SDM3055 Multimeter
+# f4ec:ee3a: E.g. SDS1052DL+ scope
+# f4ed:ee3a: E.g. SDS1202X-E scope or SDG1010 waveform generator
+ATTRS{idVendor}=="f4ec", ATTRS{idProduct}=="1012", ENV{ID_SIGROK}="1"
 ATTRS{idVendor}=="f4ec", ATTRS{idProduct}=="ee38", ENV{ID_SIGROK}="1"
 ATTRS{idVendor}=="f4ec", ATTRS{idProduct}=="ee3a", ENV{ID_SIGROK}="1"
 ATTRS{idVendor}=="f4ed", ATTRS{idProduct}=="ee3a", ENV{ID_SIGROK}="1"
-ATTRS{idVendor}=="f4ec", ATTRS{idProduct}=="1012", ENV{ID_SIGROK}="1"
 
 # sigrok FX2 LA (8ch)
 # fx2grok-flat (before and after renumeration)

--- a/contrib/60-libsigrok.rules
+++ b/contrib/60-libsigrok.rules
@@ -290,9 +290,11 @@ ATTRS{idVendor}=="21a9", ATTRS{idProduct}=="1006", ENV{ID_SIGROK}="1"
 # f4ec:ee3a: E.g. SDS1052DL+ scope
 # f4ec:ee38: E.g. SDS1104X-E scope or SDM3055 Multimeter
 # f4ed:ee3a: E.g. SDS1202X-E scope or SDG1010 waveform generator
+# f4ec:1012: E.g. SDS1104X-U scope
 ATTRS{idVendor}=="f4ec", ATTRS{idProduct}=="ee38", ENV{ID_SIGROK}="1"
 ATTRS{idVendor}=="f4ec", ATTRS{idProduct}=="ee3a", ENV{ID_SIGROK}="1"
 ATTRS{idVendor}=="f4ed", ATTRS{idProduct}=="ee3a", ENV{ID_SIGROK}="1"
+ATTRS{idVendor}=="f4ec", ATTRS{idProduct}=="1012", ENV{ID_SIGROK}="1"
 
 # sigrok FX2 LA (8ch)
 # fx2grok-flat (before and after renumeration)

--- a/src/hardware/siglent-sds/api.c
+++ b/src/hardware/siglent-sds/api.c
@@ -170,7 +170,9 @@ enum series {
 	SDS1000X,
 	SDS1000XP,
 	SDS1000XE,
+	SDS1000XU,
 	SDS2000X,
+	SDS2000XE,
 };
 
 /* short name, full name */
@@ -194,8 +196,12 @@ static const struct siglent_sds_series supported_series[] = {
 		{ 50, 1 }, { 500, 100000 }, 14, 8, 14000363},
 	[SDS1000XE] = {VENDOR(SIGLENT), "SDS1000XE", ESERIES,
 		{ 50, 1 }, { 500, 100000 }, 14, 8, 14000363},
+	[SDS1000XU] = {VENDOR(SIGLENT), "SDS1000XU", ESERIES,
+		{ 50, 1 }, { 500, 100000 }, 14, 8, 14000363},
 	[SDS2000X] = {VENDOR(SIGLENT), "SDS2000X", SPO_MODEL,
 		{ 50, 1 }, { 500, 100000 }, 14, 8, 14000363},
+	[SDS2000XE] = {VENDOR(SIGLENT), "SDS2000XE", ESERIES,
+		{ 50, 1 }, { 500, 100000 }, 14, 8, 28000363},
 };
 
 #define SERIES(x) &supported_series[x]
@@ -219,6 +225,7 @@ static const struct siglent_sds_model supported_models[] = {
 	{ SERIES(SDS1000XE), "SDS1202X-E", { 1, 1000000000 }, 2, FALSE, 0 },
 	{ SERIES(SDS1000XE), "SDS1104X-E", { 1, 1000000000 }, 4, TRUE, 16 },
 	{ SERIES(SDS1000XE), "SDS1204X-E", { 1, 1000000000 }, 4, TRUE, 16 },
+	{ SERIES(SDS1000XU), "SDS1104X-U", { 1, 1000000000 }, 4, FALSE, 0},
 	{ SERIES(SDS2000X), "SDS2072X", { 2, 1000000000 }, 2, FALSE, 0 },
 	{ SERIES(SDS2000X), "SDS2074X", { 2, 1000000000 }, 4, FALSE, 0 },
 	{ SERIES(SDS2000X), "SDS2102X", { 2, 1000000000 }, 2, FALSE, 0 },
@@ -227,6 +234,8 @@ static const struct siglent_sds_model supported_models[] = {
 	{ SERIES(SDS2000X), "SDS2204X", { 2, 1000000000 }, 4, FALSE, 0 },
 	{ SERIES(SDS2000X), "SDS2302X", { 2, 1000000000 }, 2, FALSE, 0 },
 	{ SERIES(SDS2000X), "SDS2304X", { 2, 1000000000 }, 4, FALSE, 0 },
+	{ SERIES(SDS2000XE), "SDS2202X-E", { 2, 1000000000 }, 2, FALSE, 0 },
+	{ SERIES(SDS2000XE), "SDS2352X-E", { 2, 1000000000 }, 2, FALSE, 0 },
 };
 
 static struct sr_dev_driver siglent_sds_driver_info;


### PR DESCRIPTION
The current `main` branch of `libsigrok` is not able to retrieve samples from Siglent SDS E-series oscilloscopes. This change adds support.

### Background

This was previously submitted as [sigrokproject/libsigrok#118](https://github.com/sigrokproject/libsigrok/pull/118), but the PR was withdrawn by the author as there was no maintainer interest at the time.

Per the original PR, the following bugs are related to the change.

| Bug   | Description |
| ----- | ----------- |
| [1355](https://sigrok.org/bugzilla/show_bug.cgi?id=1355) |  Impossible to stop capture with Siglent SDS1104X-E |
| [1356](https://sigrok.org/bugzilla/show_bug.cgi?id=1356) | LIBUSB_ERROR_TIMEOUT and segfault when using Siglent SDS1104X-E over usb |
| [1242](https://sigrok.org/bugzilla/show_bug.cgi?id=1242) | Siglent SDS 1104X-E unable to connect |
| [1628](https://sigrok.org/bugzilla/show_bug.cgi?id=1628) | Pulseview - No data acquisition and crashing with Siglent 1104X-E data |

Various rebases of this change have been confirmed to work by different users, with a variety of scopes:

| Equipment  | Tested by  | Date/ref  |
| ----------- | --------- | ----- |
| SDS-1104X-E | @voneiden | [Feb 6 2021](https://github.com/sigrokproject/libsigrok/pull/118#issue-802680772) |
| SDS-1104X-U | @iommu | [October 2 2021](https://github.com/sigrokproject/libsigrok/pull/118#issuecomment-932672337) |
| SDS-1204X-E | @tomba | [October 29, 2022](https://github.com/sigrokproject/libsigrok/pull/118#issuecomment-1295775117) |
| SDS-1104X-E | @laf0rge | [November 16, 2022](https://github.com/sigrokproject/libsigrok/pull/118#issuecomment-1315798295) |
| SDS 1104X-E | @mike42 | August 30, 2024 |

These affordable devices are quite popular with hobbyists, so you wont have a problem finding somebody to test `siglent-sds` driver changes for regressions on this hardware in future.

Lastly, noting that this PR has failed to gain traction before, I'd like to mention that there is [considerable interest](https://github.com/sigrokproject/libsigrok/pulls?q=is%3Apr+siglent+) in these devices from prospective Sigrok contributors, but this is not matched by actual movement in the `siglent-sds` driver. If those with commit access are still not in a position to enhance/maintain this driver, then that's absolutely fine, but I would like to respectfully request that you expand the group of committers to ensure that the community is able to take this driver forward.

### Testing the change

I tested this on Linux (Debian testing).

This setup can be replicated by [installing build dependencies](https://sigrok.org/wiki/Linux), cloning sigrok-util, then building from source using the sigrok-cross-linux script, with the added step of patching some URL's to point to forks before running the build (patch: [use-libsigrok-fork.patch](https://github.com/user-attachments/files/30127907/use-libsigrok-fork.patch))

```bash
$ git clone git://sigrok.org/sigrok-util
$ cd sigrok-util
$ git apply -- use-libsigrok-fork.patch
$ cd cross-compile/linux
$ ./sigrok-cross-linux
```

This does end with a Pulseview test failure, which I believe to be an unrelated bug, see: [sigrokproject/pulseview#72](https://github.com/sigrokproject/pulseview/pull/72).

Then running:

```
$ LD_LIBRARY_PATH=$HOME/sr/lib/ $HOME/sr/bin/pulseview --dont-scan
```

And confirming `libsigrok` commit ID matches this PR.

![image](https://github.com/user-attachments/assets/974a37f9-a76d-46fb-bd54-7b7b24f2cbee)

### Testing via network connection

I'm able to scan/connect to my SDS1104X-E using Raw TCP, port 5025.

![image](https://github.com/user-attachments/assets/d489871f-d5ec-428a-8402-2bf14e0993d6)

On the scope, I have connected channels 1 & 3 to the calibration signal and pressed 'Auto Setup'. The screen looks like this:

![ScreenImg(1)](https://github.com/user-attachments/assets/56772ff2-7a1f-4da8-bb35-bb283bf5524e)

In sigrok, I can then press 'Run', and it retrieves the information.

![image](https://github.com/user-attachments/assets/aa6667d5-4b3b-42b7-b509-391caa95fb7a)

### Testing USB connectivity

I don't have my `udev` rules working so I'm running as root (sorry).

```
# LD_LIBRARY_PATH=/home/mike/sr/lib/ /home/mike/sr/bin/pulseview --driver siglent-sds --dont-scan
```

I had to reboot my scope here because it got stuck in a weird state, but the same capture works, just slowly.

![image](https://github.com/user-attachments/assets/db68f393-a263-4fb7-b678-6908536af4db)

### Contrast with current behaviour

I want to emphasise that this change does not implement every possible improvement, but does fix compatibility issues which prevent users from acquiring samples from this type of device.

In the current `master` branch, connecting over Ethernet allows data to be shown for the first channel (albeit very slowly), but the capture never completes, channels other than the first channel are never loaded, and stdout shows zillions of warnings in the form `WARNING: Received analog packet with 0 samples`.

![image](https://github.com/user-attachments/assets/2adf32b1-fc1e-4c7c-ac4c-e0defc1c329a)

The device can be discovered over USB, but similarly a capture never completes, with the only feedback being the message `sr: scpi_usbtmc: USBTMC invalid bulk in header.` appearing on stdout.

![image](https://github.com/user-attachments/assets/1532d6b0-005f-4a54-9b8f-556f5369c0a3)

### How you can help

- **Testing** - Do you own a Siglent SDS -E or -U series? I would appreciate it if you are able to attempt to replicate my testing above and report whether you are also now able to capture samples.
- **Regression testing** - The existing `siglent-sds` driver apparently supports [SDS1000X](https://sigrok.org/wiki/Siglent_SDS1000X_series) and [SDS2000X](https://sigrok.org/wiki/Siglent_SDS2000X_series) series devices. If you own one of these older devices (not "-E", "-U," or "HD"), then I would appreciate a comment as to whether the changes in this branch cause any regressions compared to the current `libsigrok` - `master`.
- **Code review & comments** - If you have feedback on how I could make this code more acceptable to the project then I'd like to hear it!
