### PR TITLE
Ols improvements 2024 part1

### DIFF
--- a/src/hardware/openbench-logic-sniffer/api.c
+++ b/src/hardware/openbench-logic-sniffer/api.c
@@ -457,10 +457,10 @@ static int dev_acquisition_start(const struct sr_dev_inst *sdi)
 		return SR_ERR;
 
 	/* Reset all operational states. */
-	devc->rle_count = devc->raw_sample_buf_size = 0;
-	devc->num_samples = devc->num_bytes = 0;
-	devc->cnt_bytes = devc->cnt_samples = devc->cnt_samples_rle = 0;
-	memset(devc->sample, 0, 4);
+	devc->rle_count = devc->sample_buf_size = 0;
+	devc->cnt_samples = devc->raw_sample_size = 0;
+	devc->cnt_rx_bytes = devc->cnt_rx_raw_samples = 0;
+	memset(devc->raw_sample, 0, 4);
 
 	std_session_send_df_header(sdi);
 

--- a/src/hardware/openbench-logic-sniffer/api.c
+++ b/src/hardware/openbench-logic-sniffer/api.c
@@ -457,7 +457,7 @@ static int dev_acquisition_start(const struct sr_dev_inst *sdi)
 		return SR_ERR;
 
 	/* Reset all operational states. */
-	devc->rle_count = devc->num_transfers = 0;
+	devc->rle_count = devc->raw_sample_buf_size = 0;
 	devc->num_samples = devc->num_bytes = 0;
 	devc->cnt_bytes = devc->cnt_samples = devc->cnt_samples_rle = 0;
 	memset(devc->sample, 0, 4);

--- a/src/hardware/openbench-logic-sniffer/api.c
+++ b/src/hardware/openbench-logic-sniffer/api.c
@@ -465,9 +465,10 @@ static int dev_acquisition_start(const struct sr_dev_inst *sdi)
 	std_session_send_df_header(sdi);
 
 	/* If the device stops sending for longer than it takes to send a byte,
-	 * that means it's finished. But wait at least 100 ms to be safe.
+	 * that means it's finished. Since the device can be used over a slow
+	 * network link, give it 10 seconds to reply.
 	 */
-	return serial_source_add(sdi->session, serial, G_IO_IN, 100,
+	return serial_source_add(sdi->session, serial, G_IO_IN, 10 * 1000,
 				 ols_receive_data, (struct sr_dev_inst *)sdi);
 }
 

--- a/src/hardware/openbench-logic-sniffer/api.c
+++ b/src/hardware/openbench-logic-sniffer/api.c
@@ -457,7 +457,7 @@ static int dev_acquisition_start(const struct sr_dev_inst *sdi)
 		return SR_ERR;
 
 	/* Reset all operational states. */
-	devc->rle_count = devc->sample_buf_size = 0;
+	devc->rle_count = 0;
 	devc->cnt_samples = devc->raw_sample_size = 0;
 	devc->cnt_rx_bytes = devc->cnt_rx_raw_samples = 0;
 	memset(devc->raw_sample, 0, 4);

--- a/src/hardware/openbench-logic-sniffer/api.c
+++ b/src/hardware/openbench-logic-sniffer/api.c
@@ -191,6 +191,7 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 	devc = g_malloc0(sizeof(*devc));
 	sdi->priv = devc;
 	devc->trigger_at_smpl = OLS_NO_TRIGGER;
+	devc->trigger_rle_at_smpl_from_end = OLS_NO_TRIGGER;
 	devc->channel_names = sr_parse_probe_names(probe_names,
 		ols_channel_names, ARRAY_SIZE(ols_channel_names),
 		ARRAY_SIZE(ols_channel_names), &ch_max);
@@ -458,6 +459,7 @@ static int dev_acquisition_start(const struct sr_dev_inst *sdi)
 
 	/* Reset all operational states. */
 	devc->rle_count = 0;
+	devc->trigger_rle_at_smpl_from_end = OLS_NO_TRIGGER;
 	devc->cnt_samples = devc->raw_sample_size = 0;
 	devc->cnt_rx_bytes = devc->cnt_rx_raw_samples = 0;
 	memset(devc->raw_sample, 0, 4);

--- a/src/hardware/openbench-logic-sniffer/protocol.c
+++ b/src/hardware/openbench-logic-sniffer/protocol.c
@@ -376,8 +376,8 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 	struct sr_datafeed_packet packet;
 	struct sr_datafeed_logic logic;
 	uint32_t sample;
+	int num_bytes_read, bytes_left_to_read;
 	unsigned int i, j, num_changroups;
-	unsigned char byte;
 	gboolean received_a_byte;
 
 	(void)fd;
@@ -399,13 +399,21 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 	}
 
 	received_a_byte = FALSE;
-	while (revents == G_IO_IN &&
-	       serial_read_nonblocking(serial, &byte, 1) == 1) {
+	bytes_left_to_read = 64 * 1024; /* in this function call; give event loop a chance to run, too */
+	while (revents == G_IO_IN && bytes_left_to_read >= 0 &&
+	       (num_bytes_read = serial_read_nonblocking(
+			serial, devc->raw_sample + devc->raw_sample_size,
+			num_changroups - devc->raw_sample_size)) > 0) {
 		received_a_byte = TRUE;
-		devc->cnt_rx_bytes++;
+		devc->cnt_rx_bytes += num_bytes_read;
+		devc->raw_sample_size += num_bytes_read;
+		bytes_left_to_read -= num_bytes_read;
 
-		devc->raw_sample[devc->raw_sample_size++] = byte;
-		sr_spew("Received byte 0x%.2x.", byte);
+		sr_spew("Received data. Current sample: %.2x%.2x%.2x%.2x (%u bytes)",
+			devc->raw_sample[0], devc->raw_sample[1],
+			devc->raw_sample[2], devc->raw_sample[3],
+			devc->raw_sample_size);
+
 		if (devc->raw_sample_size == num_changroups) {
 			unsigned int samples_to_write, new_sample_buf_size;
 

--- a/src/hardware/openbench-logic-sniffer/protocol.c
+++ b/src/hardware/openbench-logic-sniffer/protocol.c
@@ -609,6 +609,7 @@ ols_set_basic_trigger_stage(const struct ols_basic_trigger_desc *trigger_desc,
 SR_PRIV int ols_prepare_acquisition(const struct sr_dev_inst *sdi)
 {
 	int ret;
+	uint32_t readcount, delaycount;
 
 	struct dev_context *devc = sdi->priv;
 	struct sr_serial_dev_inst *serial = sdi->conn;
@@ -624,13 +625,12 @@ SR_PRIV int ols_prepare_acquisition(const struct sr_dev_inst *sdi)
 	}
 
 	/*
-	 * Limit readcount to prevent reading past the end of the hardware
-	 * buffer. Rather read too many samples than too few.
+	 * Limit the number of samples to what the hardware can do.
+	 * The sample count is always a multiple of four.
 	 */
-	uint32_t samplecount =
-		MIN(devc->max_samples / num_changroups, devc->limit_samples);
-	uint32_t readcount = (samplecount + 3) / 4;
-	uint32_t delaycount;
+	uint32_t exact_samplecount = MIN(devc->max_samples / num_changroups, devc->limit_samples);
+	devc->limit_samples = (exact_samplecount + 3) / 4 * 4;
+	readcount = devc->limit_samples / 4;
 
 	/* Basic triggers. */
 	struct ols_basic_trigger_desc basic_trigger_desc;

--- a/src/hardware/openbench-logic-sniffer/protocol.c
+++ b/src/hardware/openbench-logic-sniffer/protocol.c
@@ -362,7 +362,7 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 	struct sr_datafeed_packet packet;
 	struct sr_datafeed_logic logic;
 	uint32_t sample;
-	int num_changroups, offset, j;
+	int num_changroups, j;
 	unsigned int i;
 	unsigned char byte;
 
@@ -406,6 +406,8 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 		devc->sample[devc->num_bytes++] = byte;
 		sr_spew("Received byte 0x%.2x.", byte);
 		if (devc->num_bytes == num_changroups) {
+			unsigned int samples_to_write;
+
 			devc->cnt_samples++;
 			devc->cnt_samples_rle++;
 			/*
@@ -435,13 +437,6 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 					devc->num_bytes = 0;
 					return TRUE;
 				}
-			}
-			devc->num_samples += devc->rle_count + 1;
-			if (devc->num_samples > devc->limit_samples) {
-				/* Save us from overrunning the buffer. */
-				devc->rle_count -=
-					devc->num_samples - devc->limit_samples;
-				devc->num_samples = devc->limit_samples;
 			}
 
 			if (num_changroups < 4) {
@@ -476,17 +471,15 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 					devc->sample[1], devc->sample[0]);
 			}
 
-			/*
-			 * the OLS sends its sample buffer backwards.
-			 * store it in reverse order here, so we can dump
-			 * this on the session bus later.
-			 * Here cropping to devc->unitsize happens
-			 */
-			offset = (devc->limit_samples - devc->num_samples) * devc->unitsize;
-			for (i = 0; i <= devc->rle_count; i++) {
-				memcpy(devc->raw_sample_buf + offset + (i * devc->unitsize),
+			/* Here cropping to devc->unitsize happens */
+			samples_to_write = devc->rle_count + 1;
+			for (i = 0; i < samples_to_write; i++)
+				memcpy(devc->raw_sample_buf +
+					       (devc->num_samples + i) * devc->unitsize,
 				       devc->sample, devc->unitsize);
-			}
+
+			devc->num_samples += samples_to_write;
+
 			memset(devc->sample, 0, 4);
 			devc->num_bytes = 0;
 			devc->rle_count = 0;
@@ -500,6 +493,21 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 		sr_dbg("Received %d bytes, %d samples, %d decompressed samples.",
 		       devc->cnt_bytes, devc->cnt_samples,
 		       devc->cnt_samples_rle);
+
+		/*
+		 * The OLS sends its sample buffer backwards.
+		 * Flip it back before sending it on the session bus.
+		 */
+		for (i = 0; i < devc->num_samples / 2; i++) {
+			uint8_t temp[devc->unitsize];
+			memcpy(temp, &devc->raw_sample_buf[devc->unitsize * i], devc->unitsize);
+			memmove(&devc->raw_sample_buf[devc->unitsize * i],
+				&devc->raw_sample_buf[devc->unitsize * (devc->num_samples - i - 1)],
+				devc->unitsize);
+			memcpy(&devc->raw_sample_buf[devc->unitsize * (devc->num_samples - i - 1)],
+			       temp, devc->unitsize);
+		}
+
 		if (devc->trigger_at_smpl != OLS_NO_TRIGGER) {
 			/*
 			 * A trigger was set up, so we need to tell the frontend

--- a/src/hardware/openbench-logic-sniffer/protocol.c
+++ b/src/hardware/openbench-logic-sniffer/protocol.c
@@ -434,7 +434,12 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 					sr_dbg("RLE count: %u.",
 					       devc->rle_count);
 					devc->raw_sample_size = 0;
-					return TRUE;
+
+					/*
+					 * Even on the rare occasion that the sampling ends with an RLE message,
+					 * the acquisition should end immediately, without any timeout.
+					 */
+					goto process_and_forward;
 				}
 			}
 
@@ -504,8 +509,15 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 			devc->raw_sample_size = 0;
 			devc->rle_count = 0;
 		}
-	} else {
+	}
+
+process_and_forward:
+	if (revents != G_IO_IN ||
+	    devc->cnt_rx_raw_samples == devc->limit_samples) {
 		unsigned int num_pre_trigger_samples;
+
+		if (devc->cnt_rx_raw_samples != devc->limit_samples)
+			sr_warn("Finished with unexpected sample count. Timeout?");
 
 		/*
 		 * This is the main loop telling us a timeout was reached, or

--- a/src/hardware/openbench-logic-sniffer/protocol.c
+++ b/src/hardware/openbench-logic-sniffer/protocol.c
@@ -615,8 +615,7 @@ SR_PRIV int ols_prepare_acquisition(const struct sr_dev_inst *sdi)
 			return SR_ERR;
 
 		delaycount = readcount * (1 - devc->capture_ratio / 100.0);
-		devc->trigger_at_smpl = (readcount - delaycount) * 4 -
-					basic_trigger_desc.num_stages;
+		devc->trigger_at_smpl = (readcount - delaycount) * 4 - 1;
 		for (int i = 0; i < basic_trigger_desc.num_stages; i++) {
 			sr_dbg("Setting OLS stage %d trigger.", i);
 			if ((ret = ols_set_basic_trigger_stage(

--- a/src/hardware/openbench-logic-sniffer/protocol.c
+++ b/src/hardware/openbench-logic-sniffer/protocol.c
@@ -571,6 +571,7 @@ SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data)
 
 		g_free(devc->sample_buf);
 		devc->sample_buf = 0;
+		devc->sample_buf_size = 0;
 
 		serial_flush(serial);
 		abort_acquisition(sdi);

--- a/src/hardware/openbench-logic-sniffer/protocol.c
+++ b/src/hardware/openbench-logic-sniffer/protocol.c
@@ -73,14 +73,30 @@ static int ols_send_longdata(struct sr_serial_dev_inst *serial, uint8_t command,
 
 SR_PRIV int ols_send_reset(struct sr_serial_dev_inst *serial)
 {
-	unsigned int i;
+	int i, ret, delay_ms;
+	char dummy[16];
+
+	/* Drain all data so that the remote side is surely listening. */
+	while ((ret = serial_read_nonblocking(serial, &dummy, 16)) > 0)
+		;
+	if (ret != SR_OK)
+		return ret;
 
 	for (i = 0; i < 5; i++) {
-		if (send_shortcommand(serial, CMD_RESET) != SR_OK)
-			return SR_ERR;
+		if ((ret = send_shortcommand(serial, CMD_RESET)) != SR_OK)
+			return ret;
 	}
 
-	return SR_OK;
+	/*
+	 * Remove all stray output that arrived in between.
+	 * This is likely to happen when RLE is being used because
+	 * the device seems to return a bit more data than we request.
+	 */
+	delay_ms = serial_timeout(serial, 16);
+	while ((ret = serial_read_blocking(serial, &dummy, 16, delay_ms)) > 0)
+		;
+
+	return ret;
 }
 
 /* Configures the channel mask based on which channels are enabled. */
@@ -344,13 +360,11 @@ SR_PRIV int ols_set_samplerate(const struct sr_dev_inst *sdi,
 
 SR_PRIV void abort_acquisition(const struct sr_dev_inst *sdi)
 {
-	struct sr_serial_dev_inst *serial;
+	struct sr_serial_dev_inst *serial = sdi->conn;
 
-	serial = sdi->conn;
 	ols_send_reset(serial);
 
 	serial_source_remove(sdi->session, serial);
-
 	std_session_send_df_end(sdi);
 }
 

--- a/src/hardware/openbench-logic-sniffer/protocol.h
+++ b/src/hardware/openbench-logic-sniffer/protocol.h
@@ -114,6 +114,7 @@ struct dev_context {
 	uint64_t limit_samples;
 	uint64_t capture_ratio;
 	int trigger_at_smpl;
+	int trigger_rle_at_smpl_from_end;
 	uint16_t capture_flags;
 
 	unsigned int cnt_rx_bytes; /* number of bytes received */
@@ -143,6 +144,7 @@ SR_PRIV int ols_get_metadata(struct sr_dev_inst *sdi);
 SR_PRIV int ols_set_samplerate(const struct sr_dev_inst *sdi,
 			       uint64_t samplerate);
 SR_PRIV void abort_acquisition(const struct sr_dev_inst *sdi);
+SR_PRIV void set_rle_trigger_point_if_unset(struct dev_context *devc);
 SR_PRIV int ols_receive_data(int fd, int revents, void *cb_data);
 
 #endif

--- a/src/hardware/openbench-logic-sniffer/protocol.h
+++ b/src/hardware/openbench-logic-sniffer/protocol.h
@@ -116,7 +116,6 @@ struct dev_context {
 	int trigger_at_smpl;
 	uint16_t capture_flags;
 
-	unsigned int num_transfers;
 	unsigned int num_samples;
 	int num_bytes;
 	int cnt_bytes;
@@ -126,6 +125,7 @@ struct dev_context {
 	unsigned int rle_count;
 	unsigned char sample[4];
 	unsigned char *raw_sample_buf;
+	unsigned int raw_sample_buf_size;
 
 	uint16_t unitsize;
 };

--- a/src/hardware/openbench-logic-sniffer/protocol.h
+++ b/src/hardware/openbench-logic-sniffer/protocol.h
@@ -116,16 +116,16 @@ struct dev_context {
 	int trigger_at_smpl;
 	uint16_t capture_flags;
 
-	unsigned int num_samples;
-	int num_bytes;
-	int cnt_bytes;
-	int cnt_samples;
-	int cnt_samples_rle;
+	unsigned int cnt_rx_bytes; /* number of bytes received */
+	unsigned int raw_sample_size; /* valid bytes in raw_sample[4] */
+	unsigned char
+		raw_sample[4]; /* raw sample, assembled from received bytes */
+	unsigned int cnt_rx_raw_samples; /* number of raw samples received */
 
 	unsigned int rle_count;
-	unsigned char sample[4];
-	unsigned char *raw_sample_buf;
-	unsigned int raw_sample_buf_size;
+	unsigned char *sample_buf;
+	unsigned int sample_buf_size;
+	unsigned int cnt_samples; /* number of final samples in sample_buf */
 
 	uint16_t unitsize;
 };


### PR DESCRIPTION
Assorted changes to the OpenBench Logic Sniffer driver:
* Adjust pre-trigger delay
* Read and process samples in larger chunks
* Make reading and resetting more robust
* Clean up driver
* Correctly determine trigger point when using RLE