### PR TITLE
configure: differ between check and yes/no

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -281,8 +281,8 @@ sr_check_driver_deps() {
 
 AC_ARG_ENABLE([all-drivers],
 	[AS_HELP_STRING([--enable-all-drivers],
-			[enable all drivers by default [default=yes]])],
-	[], [enable_all_drivers=yes])
+			[enable all drivers by default [default=check]])],
+	[], [enable_all_drivers=check])
 
 ## _SR_DRIVER(Device name, driver-name, var-name, [dependencies...])
 m4_define([_SR_DRIVER], [
@@ -290,9 +290,14 @@ m4_define([_SR_DRIVER], [
 		[AS_HELP_STRING([--enable-$2], [enable $1 support])],
 		[$3=$enableval], [$3=$enable_all_drivers])
 
-	AS_IF([test "x[$]$3" = xyes], [sr_hw_info=yes[]m4_ifval([$4], [
+	AS_IF([test "x[$]$3" != xno],
+		[sr_hw_info=yes[]m4_ifval([$4], [
 		sr_check_driver_deps $4 \
-			|| $3=no sr_hw_info="no (missing: $sr_deps_missing)"
+			|| if test "x[$]$3" != xcheck; then
+				AC_MSG_ERROR([driver $2 is enabled, but deps are missing: $sr_deps_missing])
+			else
+				$3=no sr_hw_info="no (missing: $sr_deps_missing)"
+			fi;
 	])], [sr_hw_info='no (disabled)'])
 	sr_driver_summary_append "$2" "$sr_hw_info"
 


### PR DESCRIPTION
So far one could only specify yes/no (optionally for all drivers through --enable-all-drivers={yes,no}). However, even when stating a =yes, the dependency check would override it to a =no if the dependencies are missing.

This is a bit annoying for scripts since a script may specify --enable-foo-driver=yes but in fact the build may not contain `foo-driver` due to missing build dependencies. This is especially problematic for distro's which look like they currently do not build a defined driver set - which results in random drivers missing [1].

This fixes that by following the autoconf examples [2] that allow a third state `check`. With that `no` means no, `yes` means yes (raise an error if deps are unavailable) and `check` gracefully disables drivers with unavailable dependencies.

With that --enable-all-drivers can be used to ensure that all drivers are built in. Certain drivers can still be explicitly disabled by overriding the individual driver setting.

This way distros can specify --enable-all-drivers and new drivers with unmet dependencies will cause an error rather than silently getting dropped of the build.

[1] https://sigrok.org/bugzilla/show_bug.cgi?id=1699
[2] https://www.gnu.org/software/autoconf/manual/autoconf-2.67/html_node/External-Software.html#External-Software

To: sigrok-devel@lists.sourceforge.net
Cc: Daniel Thompson <daniel.thompson@linaro.org>