### PR TITLE
support SWIG 4.2 and later

### DIFF
--- a/bindings/cxx/enums.py
+++ b/bindings/cxx/enums.py
@@ -73,8 +73,10 @@ header = open(os.path.join(outdirname, 'cxx/include/libsigrokcxx/enums.hpp'), 'w
 code = open(os.path.join(outdirname, 'cxx/enums.cpp'), 'w')
 swig = open(os.path.join(outdirname, 'swig/enums.i'), 'w')
 
-for file in (header, code):
+for file in (header, code, swig):
     print("/* Generated file - edit enums.py instead! */", file=file)
+
+print('%include "attribute.i"', file=swig)
 
 print("namespace sigrok {", file=header)
 


### PR DESCRIPTION
otherwise building sigrok fails with
bindings/swig/enums.i:1: Error: Unknown directive '%attribute'.

Also indicate that bindings/swig/enums.i is a generated file.