### PR TITLE
Fix data aquisition and Rohde & Schwarz support in hameg-hmo

### DIFF
--- a/src/hardware/hameg-hmo/protocol.h
+++ b/src/hardware/hameg-hmo/protocol.h
@@ -77,6 +77,8 @@ struct scope_config {
 	const unsigned int num_ydivs;
 
 	const char *(*scpi_dialect)[];
+
+	const uint32_t internal_flags;
 };
 
 struct analog_channel_state {
@@ -131,6 +133,13 @@ struct dev_context {
 
 	size_t pod_count;
 	GByteArray *logic_data;
+};
+
+enum internal_flags {
+	INTERN_NO_LOGIC_STATE_GET_SUPPORT	= (1 << 0),
+	INTERN_NO_LOGIC_STATE_SET_SUPPORT	= (1 << 1),
+	INTERN_NO_POD_STATE_GET_SUPPORT		= (1 << 2),
+	INTERN_NO_POD_STATE_SET_SUPPORT		= (1 << 3),
 };
 
 SR_PRIV int hmo_init_device(struct sr_dev_inst *sdi);


### PR DESCRIPTION
Right now, the `sr_analog_init`-function is called after the data is transferred to the struct, which overwrites it with zeros again. As a result, data aquisition is not possible with this driver. This PR moves the `sr_analog_init`-call to before the data transfer.

Also, R&S oscilloscopes don't support enabling or disabling individual logic channels, some don't even support enabling or disabling PODs. I implemented a flag system that allows disabling of such capabilities per device, let me know if you think this should be solved differently though.

Finally, i changed the data output format to `MAX`, which allows to transfer the entire oscilloscope memory contents (otherwise, data is downsampled according to the horizontal zoom settings). This only works while aquisition is stopped on the device, otherwise it falls back to the default output format. This way, data aquisition is still just as fast while the scope is in RUN mode, but is also able to aquire large data blocks while it's stopped (much slower).