### PR TITLE
bindings/cxx: Include attribute.i for %attribute macro

### DIFF
--- a/bindings/cxx/enums.py
+++ b/bindings/cxx/enums.py
@@ -76,6 +76,9 @@ swig = open(os.path.join(outdirname, 'swig/enums.i'), 'w')
 for file in (header, code):
     print("/* Generated file - edit enums.py instead! */", file=file)
 
+# The %attribute macro is defined in attribute.i
+print('%include "attribute.i"', file=swig)
+
 print("namespace sigrok {", file=header)
 
 # Template for beginning of class declaration and public members.


### PR DESCRIPTION
With SWIG 4.3.0, the build fails with the following error:

  bindings/swig/enums.i:1: Error: Unknown directive '%attribute'.

According to the SWIG documentation[1], the %attribute macro is defined in attribute.i.

[1]: https://www.swig.org/Doc4.2/Library.html