### PR TITLE
hardware/beaglelogic: Don't include incorrect header <sys/errno.h>

### DIFF
--- a/src/hardware/beaglelogic/beaglelogic.h
+++ b/src/hardware/beaglelogic/beaglelogic.h
@@ -23,7 +23,6 @@
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/types.h>
-#include <sys/errno.h>
 #include <sys/ioctl.h>
 #include <stdlib.h>
 #include <unistd.h>


### PR DESCRIPTION
The libc's errno API[^1] comes from <errno.h>, not <sys/errno.h>. On musl-libc, a warning is produced when the latter is used:

In file included from src/hardware/beaglelogic/beaglelogic.h:26,
                 from src/hardware/beaglelogic/protocol.c:33:
/usr/include/sys/errno.h:1:2: warning: #warning redirecting incorrect #include <sys/errno.h> to <errno.h> [-Wcpp]
    1 | #warning redirecting incorrect #include <sys/errno.h> to <errno.h>
      |  ^~~~~~~

Is it not necessary to change <sys/errno.h> to <errno.h>, because individual C files in the beaglelogic driver already include <errno.h>.

[^1]: https://en.cppreference.com/w/c/error/errno