### PR TITLE
raspberrypi-pico: Add link to firmware repo

### DIFF
--- a/README.devices
+++ b/README.devices
@@ -75,6 +75,11 @@ The following drivers/devices require a firmware upload upon connection:
 
      http://sigrok.org/wiki/LeCroy_LogicStudio#Firmware
 
+ - raspberrypi-pico: In order to use a Raspberry Pi Pico as a logic analyzer,
+   it must be flashed with special open-source firmware:
+
+     https://github.com/pico-coder/sigrok-pico
+
  - saleae-logic16: The Saleae Logic16 needs a firmware file for the
    Cypress FX2 chip in the device, as well as two FPGA bitstream files.
    These can be extracted from the vendor's Linux application using a tool

--- a/src/hardware/raspberrypi-pico/protocol.h
+++ b/src/hardware/raspberrypi-pico/protocol.h
@@ -20,6 +20,8 @@
 #ifndef LIBSIGROK_HARDWARE_RASPBERRYPI_PICO_PROTOCOL_H
 #define LIBSIGROK_HARDWARE_RASPBERRYPI_PICO_PROTOCOL_H
 
+/* Firmware: https://github.com/pico-coder/sigrok-pico */
+
 #include <stdint.h>
 #include <glib.h>
 #include <libsigrok/libsigrok.h>


### PR DESCRIPTION
Since the Raspberry Pi Pico is a programmable device with a myriad of use-cases, it needs specific firmware to implement the same protocol as the driver in src/hardware/raspberrypi-pico.

Add a link to make it easier to find the right firmware.

cc @pico-coder 