### PR TITLE
Master

### DIFF
--- a/src/hardware/rigol-dg/api.c
+++ b/src/hardware/rigol-dg/api.c
@@ -370,6 +370,14 @@ static const struct device_spec device_models[] = {
 		TRUE,
 	},
 	/* MSO5000 devices*/
+        { "Rigol Technologies", "MSO5504",
+                ARRAY_AND_SIZE(mso5000_devopts),
+                ARRAY_AND_SIZE(mso5000_devopts_cg),
+                ARRAY_AND_SIZE(mso5000_channels),
+                cmdset_mso5000,
+                FALSE,
+        },
+
 	{ "Rigol Technologies", "MSO5354",
 		ARRAY_AND_SIZE(mso5000_devopts),
 		ARRAY_AND_SIZE(mso5000_devopts_cg),

--- a/src/hardware/rigol-ds/api.c
+++ b/src/hardware/rigol-ds/api.c
@@ -289,6 +289,7 @@ static const struct rigol_ds_model supported_models[] = {
 	{SERIES(MSO5000), "MSO5104", {1, 1000000000}, CH_INFO(4, true), std_cmd},
 	{SERIES(MSO5000), "MSO5204", {1, 1000000000}, CH_INFO(4, true), std_cmd},
 	{SERIES(MSO5000), "MSO5354", {1, 1000000000}, CH_INFO(4, true), std_cmd},
+        {SERIES(MSO5000), "MSO5504", {1, 1000000000}, CH_INFO(4, true), std_cmd},
 	/* TODO: Digital channels are not yet supported on MSO7000A. */
 	{SERIES(MSO7000A), "MSO7034A", {2, 1000000000}, CH_INFO(4, false), mso7000a_cmd},
 };


### PR DESCRIPTION
Added support for Rigol MSO5504 as some owners of MSO5000 series has changed to the model designation to enable 500ps horizontal scale selection.