### PR TITLE
dreamsourcelab-dslogic: V2 simple-trigger encoding (follow-up to #292)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -353,6 +353,9 @@ if HW_DREAMSOURCELAB_DSLOGIC
 src_libdrivers_la_SOURCES += \
 	src/hardware/dreamsourcelab-dslogic/protocol.h \
 	src/hardware/dreamsourcelab-dslogic/protocol.c \
+	src/hardware/dreamsourcelab-dslogic/protocol_v1.c \
+	src/hardware/dreamsourcelab-dslogic/protocol_v2.h \
+	src/hardware/dreamsourcelab-dslogic/protocol_v2.c \
 	src/hardware/dreamsourcelab-dslogic/api.c
 endif
 if HW_FLUKE_45

--- a/contrib/60-libsigrok.rules
+++ b/contrib/60-libsigrok.rules
@@ -110,6 +110,8 @@ ATTRS{idVendor}=="2a0e", ATTRS{idProduct}=="0003", ENV{ID_SIGROK}="1"
 ATTRS{idVendor}=="2a0e", ATTRS{idProduct}=="0002", ENV{ID_SIGROK}="1"
 # DreamSourceLab DSLogic Plus
 ATTRS{idVendor}=="2a0e", ATTRS{idProduct}=="0020", ENV{ID_SIGROK}="1"
+# DreamSourceLab DSLogic Plus (hardware revision)
+ATTRS{idVendor}=="2a0e", ATTRS{idProduct}=="0034", ENV{ID_SIGROK}="1"
 # DreamSourceLab DSLogic Basic
 ATTRS{idVendor}=="2a0e", ATTRS{idProduct}=="0021", ENV{ID_SIGROK}="1"
 

--- a/src/hardware/dreamsourcelab-dslogic/api.c
+++ b/src/hardware/dreamsourcelab-dslogic/api.c
@@ -26,23 +26,33 @@ static const struct dslogic_profile supported_device[] = {
 	/* DreamSourceLab DSLogic */
 	{ 0x2a0e, 0x0001, "DreamSourceLab", "DSLogic", NULL,
 		"dreamsourcelab-dslogic-fx2.fw",
-		0, "DreamSourceLab", "DSLogic", 256 * 1024 * 1024},
+		0, "DreamSourceLab", "DSLogic", 256 * 1024 * 1024,
+		DSL_PROTO_V1, &dslogic_v1_ops},
 	/* DreamSourceLab DSCope */
 	{ 0x2a0e, 0x0002, "DreamSourceLab", "DSCope", NULL,
 		"dreamsourcelab-dscope-fx2.fw",
-		0, "DreamSourceLab", "DSCope", 256 * 1024 * 1024},
+		0, "DreamSourceLab", "DSCope", 256 * 1024 * 1024,
+		DSL_PROTO_V1, &dslogic_v1_ops},
 	/* DreamSourceLab DSLogic Pro */
 	{ 0x2a0e, 0x0003, "DreamSourceLab", "DSLogic Pro", NULL,
 		"dreamsourcelab-dslogic-pro-fx2.fw",
-		0, "DreamSourceLab", "DSLogic", 256 * 1024 * 1024},
+		0, "DreamSourceLab", "DSLogic", 256 * 1024 * 1024,
+		DSL_PROTO_V1, &dslogic_v1_ops},
 	/* DreamSourceLab DSLogic Plus */
 	{ 0x2a0e, 0x0020, "DreamSourceLab", "DSLogic Plus", NULL,
 		"dreamsourcelab-dslogic-plus-fx2.fw",
-		0, "DreamSourceLab", "DSLogic", 256 * 1024 * 1024},
+		0, "DreamSourceLab", "DSLogic", 256 * 1024 * 1024,
+		DSL_PROTO_V1, &dslogic_v1_ops},
+	/* DreamSourceLab DSLogic Plus (hardware revision, PID 0x0034) */
+	{ 0x2a0e, 0x0034, "DreamSourceLab", "DSLogic Plus", NULL,
+		"dreamsourcelab-dslogic-plus-fx2.fw",
+		0, "DreamSourceLab", "DSLogic", 256 * 1024 * 1024,
+		DSL_PROTO_V2, &dslogic_v2_ops},
 	/* DreamSourceLab DSLogic Basic */
 	{ 0x2a0e, 0x0021, "DreamSourceLab", "DSLogic Basic", NULL,
 		"dreamsourcelab-dslogic-basic-fx2.fw",
-		0, "DreamSourceLab", "DSLogic", 256 * 1024},
+		0, "DreamSourceLab", "DSLogic", 256 * 1024,
+		DSL_PROTO_V1, &dslogic_v1_ops},
 
 	ALL_ZERO
 };
@@ -255,7 +265,8 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 
 		devc->samplerates = samplerates;
 		devc->num_samplerates = ARRAY_SIZE(samplerates);
-		has_firmware = usb_match_manuf_prod(devlist[i], "DreamSourceLab", "USB-based Instrument");
+		has_firmware = usb_match_manuf_prod(devlist[i], "DreamSourceLab", "USB-based Instrument")
+		            || usb_match_manuf_prod(devlist[i], "DreamSourceLab", "USB-based DSL Instrument v2");
 
 		if (has_firmware) {
 			/* Already has the firmware, so fix the new address. */
@@ -297,6 +308,8 @@ static int dev_open(struct sr_dev_inst *sdi)
 
 	devc = sdi->priv;
 	usb = sdi->conn;
+
+	devc->ops = devc->profile->ops;
 
 	/*
 	 * If the firmware was recently uploaded, wait up to MAX_RENUM_DELAY_MS
@@ -352,8 +365,15 @@ static int dev_open(struct sr_dev_inst *sdi)
 	}
 
 
-	if ((ret = dslogic_fpga_firmware_upload(sdi)) != SR_OK)
+	if ((ret = devc->ops->fpga_firmware_upload(sdi)) != SR_OK)
 		return ret;
+	if ((ret = devc->ops->security_check(sdi)) != SR_OK)
+		return ret;
+	/* DSView writes VTH_ADDR right after dsl_dev_open returns
+	 * (dslogic.c). Without this, the FPGA threshold DAC
+	 * is uninitialised and subsequent arm-sequence status polls may
+	 * stall. Use a sensible default (1.0V on 3.3V logic). */
+	(void)devc->ops->set_voltage_threshold(sdi, 1.0, 1.0);
 
 	if (devc->cur_samplerate == 0) {
 		/* Samplerate hasn't been set; default to the slowest one. */
@@ -362,7 +382,7 @@ static int dev_open(struct sr_dev_inst *sdi)
 
 	if (devc->cur_threshold == 0.0) {
 		devc->cur_threshold = thresholds[1][0];
-		return dslogic_set_voltage_threshold(sdi, devc->cur_threshold);
+		return devc->ops->set_voltage_threshold(sdi, devc->cur_threshold, devc->cur_threshold);
 	}
 
 	return SR_OK;
@@ -484,7 +504,7 @@ static int config_set(uint32_t key, GVariant *data,
 			return dslogic_fpga_firmware_upload(sdi);
 		} else {
 			g_variant_get(data, "(dd)", &low, &high);
-			return dslogic_set_voltage_threshold(sdi, (low + high) / 2.0);
+			return devc->ops->set_voltage_threshold(sdi, low, high);
 		}
 		break;
 	case SR_CONF_EXTERNAL_CLOCK:

--- a/src/hardware/dreamsourcelab-dslogic/api.c
+++ b/src/hardware/dreamsourcelab-dslogic/api.c
@@ -543,9 +543,15 @@ static int config_set(uint32_t key, GVariant *data,
 		devc->continuous_mode = g_variant_get_boolean(data);
 		if (devc->profile->protocol_version == DSL_PROTO_V2) {
 			/* Re-pick the channel mode for the new stream/buffer
-			 * choice; uses the current samplerate as the hint. */
+			 * choice; uses current samplerate + enabled-channel
+			 * count as hints. */
+			uint16_t m = enabled_channel_mask(sdi);
+			unsigned int hi = 0, i;
+			for (i = 0; i < 16; i++)
+				if (m & (1U << i)) hi = i + 1;
 			devc->ch_mode_id = dslogic_plus_auto_pick_mode_id(
-				devc->cur_samplerate, devc->continuous_mode);
+				devc->cur_samplerate, devc->continuous_mode,
+				hi ? hi : 1);
 		}
 		break;
 	case SR_CONF_CLOCK_EDGE:

--- a/src/hardware/dreamsourcelab-dslogic/api.c
+++ b/src/hardware/dreamsourcelab-dslogic/api.c
@@ -381,9 +381,9 @@ static int dev_open(struct sr_dev_inst *sdi)
 
 
 	if ((ret = devc->ops->fpga_firmware_upload(sdi)) != SR_OK)
-		return ret;
+		goto fail_release;
 	if ((ret = devc->ops->security_check(sdi)) != SR_OK)
-		return ret;
+		goto fail_release;
 	/* DSView writes VTH_ADDR right after dsl_dev_open returns
 	 * (dslogic.c). Without this, the FPGA threshold DAC
 	 * is uninitialised and subsequent arm-sequence status polls may
@@ -401,6 +401,19 @@ static int dev_open(struct sr_dev_inst *sdi)
 	}
 
 	return SR_OK;
+
+fail_release:
+	/*
+	 * dev_open failed AFTER we claimed the interface. libsigrok will not
+	 * call dev_close on a dev_open that returned non-OK, so we must
+	 * unwind the claim ourselves. Without this, the next dev_open's
+	 * libusb_claim_interface returns LIBUSB_ERROR_BUSY (the kernel
+	 * thinks the interface is still in use by us).
+	 */
+	libusb_release_interface(usb->devhdl, USB_INTERFACE);
+	libusb_close(usb->devhdl);
+	usb->devhdl = NULL;
+	return ret;
 }
 
 static int dev_close(struct sr_dev_inst *sdi)

--- a/src/hardware/dreamsourcelab-dslogic/api.c
+++ b/src/hardware/dreamsourcelab-dslogic/api.c
@@ -21,6 +21,7 @@
 #include <config.h>
 #include <math.h>
 #include "protocol.h"
+#include "protocol_v2.h"
 
 static const struct dslogic_profile supported_device[] = {
 	/* DreamSourceLab DSLogic */
@@ -540,6 +541,12 @@ static int config_set(uint32_t key, GVariant *data,
 		break;
 	case SR_CONF_CONTINUOUS:
 		devc->continuous_mode = g_variant_get_boolean(data);
+		if (devc->profile->protocol_version == DSL_PROTO_V2) {
+			/* Re-pick the channel mode for the new stream/buffer
+			 * choice; uses the current samplerate as the hint. */
+			devc->ch_mode_id = dslogic_plus_auto_pick_mode_id(
+				devc->cur_samplerate, devc->continuous_mode);
+		}
 		break;
 	case SR_CONF_CLOCK_EDGE:
 		if ((idx = std_str_idx(data, ARRAY_AND_SIZE(signal_edges))) < 0)

--- a/src/hardware/dreamsourcelab-dslogic/api.c
+++ b/src/hardware/dreamsourcelab-dslogic/api.c
@@ -76,6 +76,8 @@ static const uint32_t devopts[] = {
 	SR_CONF_CAPTURE_RATIO | SR_CONF_GET | SR_CONF_SET,
 	SR_CONF_EXTERNAL_CLOCK | SR_CONF_GET | SR_CONF_SET,
 	SR_CONF_CLOCK_EDGE | SR_CONF_GET | SR_CONF_SET | SR_CONF_LIST,
+	SR_CONF_RLE | SR_CONF_GET | SR_CONF_SET,
+	SR_CONF_FILTER | SR_CONF_GET | SR_CONF_SET,
 };
 
 static const int32_t trigger_matches[] = {
@@ -483,6 +485,12 @@ static int config_get(uint32_t key, GVariant **data,
 	case SR_CONF_EXTERNAL_CLOCK:
 		*data = g_variant_new_boolean(devc->external_clock);
 		break;
+	case SR_CONF_RLE:
+		*data = g_variant_new_boolean(devc->rle_mode);
+		break;
+	case SR_CONF_FILTER:
+		*data = g_variant_new_boolean(devc->filter);
+		break;
 	case SR_CONF_CONTINUOUS:
 		*data = g_variant_new_boolean(devc->continuous_mode);
 		break;
@@ -538,6 +546,12 @@ static int config_set(uint32_t key, GVariant *data,
 		break;
 	case SR_CONF_EXTERNAL_CLOCK:
 		devc->external_clock = g_variant_get_boolean(data);
+		break;
+	case SR_CONF_RLE:
+		devc->rle_mode = g_variant_get_boolean(data);
+		break;
+	case SR_CONF_FILTER:
+		devc->filter = g_variant_get_boolean(data);
 		break;
 	case SR_CONF_CONTINUOUS:
 		devc->continuous_mode = g_variant_get_boolean(data);

--- a/src/hardware/dreamsourcelab-dslogic/api.c
+++ b/src/hardware/dreamsourcelab-dslogic/api.c
@@ -345,7 +345,22 @@ static int dev_open(struct sr_dev_inst *sdi)
 		return SR_ERR;
 	}
 
-	ret = libusb_claim_interface(usb->devhdl, USB_INTERFACE);
+	/*
+	 * Retry claim on transient BUSY: after a close/reopen cycle (e.g.
+	 * pulseview "Stop" then "Run" again) the kernel-side endpoint state
+	 * can take a few ms to settle, during which claim returns BUSY even
+	 * though no other process holds the interface.
+	 */
+	{
+		int attempt;
+		ret = LIBUSB_ERROR_BUSY;
+		for (attempt = 0; attempt < 10; attempt++) {
+			ret = libusb_claim_interface(usb->devhdl, USB_INTERFACE);
+			if (ret != LIBUSB_ERROR_BUSY)
+				break;
+			g_usleep(50 * 1000);
+		}
+	}
 	if (ret != 0) {
 		switch (ret) {
 		case LIBUSB_ERROR_BUSY:

--- a/src/hardware/dreamsourcelab-dslogic/protocol.c
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.c
@@ -693,6 +693,8 @@ SR_PRIV struct dev_context *dslogic_dev_new(void)
 	devc->capture_ratio = 0;
 	devc->continuous_mode = FALSE;
 	devc->clock_edge = DS_EDGE_RISING;
+	/* DSLogic Plus default: 16 channels, buffered, max 100 MHz. */
+	devc->ch_mode_id = dslogic_plus_channel_mode_default()->id;
 
 	return devc;
 }

--- a/src/hardware/dreamsourcelab-dslogic/protocol.c
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.c
@@ -862,9 +862,18 @@ static void LIBUSB_CALL receive_transfer(struct libusb_transfer *transfer)
 		devc->empty_transfer_count = 0;
 	}
 
-	if (!devc->limit_samples || devc->sent_samples < devc->limit_samples) {
-		if (devc->limit_samples && devc->sent_samples + cur_sample_count > devc->limit_samples)
-			num_samples = devc->limit_samples - devc->sent_samples;
+	/*
+	 * The acquisition-stop budget is actual_samples (= limit_samples for
+	 * normal captures, possibly less under RLE). Falls back to limit_samples
+	 * if the trigger-position header has not arrived yet (actual_samples
+	 * still zero from dslogic_acquisition_start).
+	 */
+	const uint64_t budget = devc->actual_samples
+		? devc->actual_samples : devc->limit_samples;
+
+	if (!budget || devc->sent_samples < budget) {
+		if (budget && devc->sent_samples + cur_sample_count > budget)
+			num_samples = budget - devc->sent_samples;
 		else
 			num_samples = cur_sample_count;
 
@@ -906,7 +915,7 @@ static void LIBUSB_CALL receive_transfer(struct libusb_transfer *transfer)
 		}
 	}
 
-	if (devc->limit_samples && devc->sent_samples >= devc->limit_samples) {
+	if (budget && devc->sent_samples >= budget) {
 		abort_acquisition(devc);
 		free_transfer(transfer);
 	} else
@@ -1059,6 +1068,36 @@ static void LIBUSB_CALL trigger_receive(struct libusb_transfer *transfer)
 		sr_info("tpos real_pos %d ram_saddr %d cnt_h %d cnt_l %d", tpos->real_pos,
 			tpos->ram_saddr, tpos->remain_cnt_h, tpos->remain_cnt_l);
 		devc->trigger_pos = tpos->real_pos;
+		{
+			/*
+			 * In buffered (one-shot) mode with RLE the FPGA may have
+			 * captured fewer samples than requested (compressed buffer
+			 * exhausted). remain_cnt tells us by how much. Without this
+			 * adjustment the acquisition never reaches sent_samples >=
+			 * limit_samples and hangs. Matches DSView dsl.c
+			 * receive_header.
+			 *
+			 * In streaming (continuous) mode remain_cnt is an in-flight
+			 * "samples-remaining-to-send" counter that updates as the
+			 * FPGA streams; subtracting it from limit_samples gives a
+			 * meaningless tiny number that would stop the acquisition
+			 * almost immediately. Skip the shortening entirely for
+			 * streaming and let limit_samples be the stop budget.
+			 */
+			if (!devc->continuous_mode) {
+				uint64_t remain = ((uint64_t)tpos->remain_cnt_h << 32)
+					| (uint64_t)tpos->remain_cnt_l;
+				if (devc->limit_samples && remain < devc->limit_samples)
+					devc->actual_samples = devc->limit_samples - remain;
+				else
+					devc->actual_samples = devc->limit_samples;
+				if (devc->actual_samples != devc->limit_samples)
+					sr_info("RLE shortened capture: %" PRIu64 " of %" PRIu64 " samples",
+						devc->actual_samples, devc->limit_samples);
+			} else {
+				devc->actual_samples = devc->limit_samples;
+			}
+		}
 		g_free(tpos);
 		start_transfers(sdi);
 	}
@@ -1084,6 +1123,7 @@ SR_PRIV int dslogic_acquisition_start(const struct sr_dev_inst *sdi)
 
 	devc->ctx = drvc->sr_ctx;
 	devc->sent_samples = 0;
+	devc->actual_samples = 0;
 	devc->empty_transfer_count = 0;
 	devc->acq_aborted = FALSE;
 

--- a/src/hardware/dreamsourcelab-dslogic/protocol.c
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.c
@@ -313,7 +313,7 @@ SR_PRIV int dslogic_fpga_firmware_upload(const struct sr_dev_inst *sdi)
 	return result;
 }
 
-static unsigned int enabled_channel_count(const struct sr_dev_inst *sdi)
+SR_PRIV unsigned int enabled_channel_count(const struct sr_dev_inst *sdi)
 {
 	unsigned int count = 0;
 	for (const GSList *l = sdi->channels; l; l = l->next) {
@@ -324,7 +324,7 @@ static unsigned int enabled_channel_count(const struct sr_dev_inst *sdi)
 	return count;
 }
 
-static uint16_t enabled_channel_mask(const struct sr_dev_inst *sdi)
+SR_PRIV uint16_t enabled_channel_mask(const struct sr_dev_inst *sdi)
 {
 	unsigned int mask = 0;
 	for (const GSList *l = sdi->channels; l; l = l->next) {

--- a/src/hardware/dreamsourcelab-dslogic/protocol.c
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.c
@@ -24,6 +24,7 @@
 #include <glib.h>
 #include <glib/gstdio.h>
 #include "protocol.h"
+#include "protocol_v2.h"
 
 #define DS_CMD_GET_FW_VERSION		0xb0
 #define DS_CMD_GET_REVID_VERSION	0xb1
@@ -178,7 +179,7 @@ static int command_get_revid_version(struct sr_dev_inst *sdi, uint8_t *revid)
 	return SR_OK;
 }
 
-static int command_start_acquisition(const struct sr_dev_inst *sdi)
+SR_PRIV int command_start_acquisition(const struct sr_dev_inst *sdi)
 {
 	struct sr_usb_dev_inst *usb;
 	struct dslogic_mode mode;
@@ -199,7 +200,7 @@ static int command_start_acquisition(const struct sr_dev_inst *sdi)
 	return SR_OK;
 }
 
-static int command_stop_acquisition(const struct sr_dev_inst *sdi)
+SR_PRIV int command_stop_acquisition(const struct sr_dev_inst *sdi)
 {
 	struct sr_usb_dev_inst *usb;
 	struct dslogic_mode mode;
@@ -425,7 +426,7 @@ static bool set_trigger(const struct sr_dev_inst *sdi, struct fpga_config *cfg)
 	return num_trigger_stages != 0;
 }
 
-static int fpga_configure(const struct sr_dev_inst *sdi)
+SR_PRIV int fpga_configure(const struct sr_dev_inst *sdi)
 {
 	const struct dev_context *const devc = sdi->priv;
 	const struct sr_usb_dev_inst *const usb = sdi->conn;
@@ -601,29 +602,65 @@ SR_PRIV int dslogic_dev_open(struct sr_dev_inst *sdi, struct sr_dev_driver *di)
 			}
 		}
 
-		ret = command_get_fw_version(usb->devhdl, &vi);
-		if (ret != SR_OK) {
-			sr_err("Failed to get firmware version.");
-			break;
-		}
-
-		ret = command_get_revid_version(sdi, &revid);
-		if (ret != SR_OK) {
-			sr_err("Failed to get REVID.");
-			break;
-		}
-
 		/*
-		 * Changes in major version mean incompatible/API changes, so
-		 * bail out if we encounter an incompatible version.
-		 * Different minor versions are OK, they should be compatible.
+		 * The V1 firmware-version probe uses bRequest 0xb0, which
+		 * collides with the V2 envelope opcode CMD_CTL_WR. Only run
+		 * the V1 probe + version check for V1 devices.
 		 */
-		if (vi.major != DSLOGIC_REQUIRED_VERSION_MAJOR) {
-			sr_err("Expected firmware version %d.x, "
-			       "got %d.%d.", DSLOGIC_REQUIRED_VERSION_MAJOR,
-			       vi.major, vi.minor);
-			ret = SR_ERR;
-			break;
+		if (devc->profile->protocol_version == DSL_PROTO_V1) {
+			ret = command_get_fw_version(usb->devhdl, &vi);
+			if (ret != SR_OK) {
+				sr_err("Failed to get firmware version.");
+				break;
+			}
+
+			ret = command_get_revid_version(sdi, &revid);
+			if (ret != SR_OK) {
+				sr_err("Failed to get REVID.");
+				break;
+			}
+
+			/*
+			 * Changes in major version mean incompatible/API changes,
+			 * so bail out if we encounter an incompatible version.
+			 * Different minor versions are OK, they should be compatible.
+			 */
+			if (vi.major != DSLOGIC_REQUIRED_VERSION_MAJOR) {
+				sr_err("Expected firmware version %d.x, "
+				       "got %d.%d.", DSLOGIC_REQUIRED_VERSION_MAJOR,
+				       vi.major, vi.minor);
+				ret = SR_ERR;
+				break;
+			}
+		} else {
+			/*
+			 * V2 hello reads - DSView's hw_dev_open starts with
+			 * DSL_CTL_FW_VERSION read (dsl.c) and dsl_dev_open
+			 * follows with a DSL_CTL_HW_STATUS read (dsl.c).
+			 * These appear to prime the firmware's state machine; without
+			 * them, later HW_STATUS reads in the arm path stall. We
+			 * don't validate the values - just perform the reads.
+			 */
+			{
+				uint8_t v2_fw_ver[2] = {0, 0};
+				uint8_t v2_hw_status = 0;
+				struct ctl_rd_cmd v2_rd;
+
+				v2_rd.header.dest = DSL_CTL_FW_VERSION;
+				v2_rd.header.offset = 0;
+				v2_rd.header.size = 2;
+				v2_rd.data = v2_fw_ver;
+				if (command_ctl_rd_v2(usb->devhdl, v2_rd) == SR_OK)
+					sr_info("V2 firmware version: %u.%u",
+						v2_fw_ver[0], v2_fw_ver[1]);
+
+				v2_rd.header.dest = DSL_CTL_HW_STATUS;
+				v2_rd.header.offset = 0;
+				v2_rd.header.size = 1;
+				v2_rd.data = &v2_hw_status;
+				if (command_ctl_rd_v2(usb->devhdl, v2_rd) == SR_OK)
+					sr_dbg("V2 HW_STATUS: 0x%02x", v2_hw_status);
+			}
 		}
 
 		sr_info("Opened device on %d.%d (logical) / %s (physical), "
@@ -1050,13 +1087,15 @@ SR_PRIV int dslogic_acquisition_start(const struct sr_dev_inst *sdi)
 
 	usb_source_add(sdi->session, devc->ctx, timeout, receive_data, drvc);
 
-	if ((ret = command_stop_acquisition(sdi)) != SR_OK)
+	/* Stop any prior acquisition, then arm and start. Matches DSView's order
+	 * at dslogic.c (STOP -> arm -> START). */
+	if ((ret = devc->ops->acquisition_stop(sdi)) != SR_OK)
 		return ret;
 
-	if ((ret = fpga_configure(sdi)) != SR_OK)
+	if ((ret = devc->ops->fpga_config(sdi)) != SR_OK)
 		return ret;
 
-	if ((ret = command_start_acquisition(sdi)) != SR_OK)
+	if ((ret = devc->ops->acquisition_start(sdi)) != SR_OK)
 		return ret;
 
 	sr_dbg("Getting trigger.");
@@ -1086,7 +1125,9 @@ SR_PRIV int dslogic_acquisition_start(const struct sr_dev_inst *sdi)
 
 SR_PRIV int dslogic_acquisition_stop(struct sr_dev_inst *sdi)
 {
-	command_stop_acquisition(sdi);
+	struct dev_context *devc = sdi->priv;
+
+	devc->ops->acquisition_stop(sdi);
 	abort_acquisition(sdi->priv);
 	return SR_OK;
 }

--- a/src/hardware/dreamsourcelab-dslogic/protocol.h
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.h
@@ -166,6 +166,9 @@ struct dev_context {
 	uint16_t mode;
 	uint32_t trigger_pos;
 	gboolean external_clock;
+	/* V2 only: RLE compression + glitch filter toggles (DSLogic Plus). */
+	gboolean rle_mode;
+	gboolean filter;
 	gboolean continuous_mode;
 	int clock_edge;
 	double cur_threshold;

--- a/src/hardware/dreamsourcelab-dslogic/protocol.h
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.h
@@ -172,6 +172,8 @@ struct dev_context {
 };
 
 SR_PRIV int fpga_configure(const struct sr_dev_inst *sdi);
+SR_PRIV unsigned int enabled_channel_count(const struct sr_dev_inst *sdi);
+SR_PRIV uint16_t enabled_channel_mask(const struct sr_dev_inst *sdi);
 SR_PRIV int dslogic_fpga_firmware_upload(const struct sr_dev_inst *sdi);
 SR_PRIV int dslogic_set_voltage_threshold(const struct sr_dev_inst *sdi, double threshold);
 SR_PRIV int dslogic_dev_open(struct sr_dev_inst *sdi, struct sr_dev_driver *di);

--- a/src/hardware/dreamsourcelab-dslogic/protocol.h
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.h
@@ -149,6 +149,14 @@ struct dev_context {
 
 	uint64_t cur_samplerate;
 	uint64_t limit_samples;
+	/*
+	 * Number of samples the FPGA actually captured. Equals limit_samples
+	 * for normal captures; less when RLE is enabled and the FPGA's
+	 * compressed buffer ran out before reaching limit_samples (the
+	 * trigger-header packet's remain_cnt fields tell us by how much).
+	 * Set in trigger_receive; used by the acquisition stop check.
+	 */
+	uint64_t actual_samples;
 	uint64_t capture_ratio;
 
 	gboolean acq_aborted;

--- a/src/hardware/dreamsourcelab-dslogic/protocol.h
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.h
@@ -134,6 +134,8 @@ struct dslogic_profile {
 struct dev_context {
 	const struct dslogic_profile *profile;
 	const struct dslogic_protocol_ops *ops;
+	/* V2 only: stable ID of the active channel mode (DSLogic Plus presets). */
+	uint8_t ch_mode_id;
 	/*
 	 * Since we can't keep track of a DSLogic device after upgrading
 	 * the firmware (it renumerates into a different device address

--- a/src/hardware/dreamsourcelab-dslogic/protocol.h
+++ b/src/hardware/dreamsourcelab-dslogic/protocol.h
@@ -29,6 +29,29 @@
 #include <libsigrok/libsigrok.h>
 #include "libsigrok-internal.h"
 
+struct sr_dev_inst;    /* forward */
+
+enum dslogic_protocol_version {
+	DSL_PROTO_V1 = 0,  /* flat opcodes 0xb0-0xb8 (legacy DSLogic firmware) */
+	DSL_PROTO_V2 = 1,  /* envelope CMD_CTL_WR/RD with ctl_header (DSView 1.3.2-era firmware) */
+};
+
+struct dslogic_protocol_ops {
+	int (*fpga_firmware_upload)(const struct sr_dev_inst *sdi);
+	int (*fpga_config)(const struct sr_dev_inst *sdi);
+	int (*acquisition_start)(const struct sr_dev_inst *sdi);
+	int (*acquisition_stop)(const struct sr_dev_inst *sdi);
+	int (*set_samplerate)(const struct sr_dev_inst *sdi, uint64_t rate);
+	int (*set_voltage_threshold)(const struct sr_dev_inst *sdi, double low, double high);
+	int (*set_trigger)(const struct sr_dev_inst *sdi);
+	int (*set_external_clock)(const struct sr_dev_inst *sdi, gboolean ext);
+	int (*set_clock_edge)(const struct sr_dev_inst *sdi, int edge);
+	int (*security_check)(const struct sr_dev_inst *sdi);
+};
+
+extern const struct dslogic_protocol_ops dslogic_v1_ops;
+extern const struct dslogic_protocol_ops dslogic_v2_ops;
+
 #define LOG_PREFIX "dreamsourcelab-dslogic"
 
 #define USB_INTERFACE		0
@@ -103,10 +126,14 @@ struct dslogic_profile {
 
 	/* Memory depth in bits. */
 	uint64_t mem_depth;
+
+	enum dslogic_protocol_version protocol_version;
+	const struct dslogic_protocol_ops *ops;
 };
 
 struct dev_context {
 	const struct dslogic_profile *profile;
+	const struct dslogic_protocol_ops *ops;
 	/*
 	 * Since we can't keep track of a DSLogic device after upgrading
 	 * the firmware (it renumerates into a different device address
@@ -142,11 +169,14 @@ struct dev_context {
 	double cur_threshold;
 };
 
+SR_PRIV int fpga_configure(const struct sr_dev_inst *sdi);
 SR_PRIV int dslogic_fpga_firmware_upload(const struct sr_dev_inst *sdi);
 SR_PRIV int dslogic_set_voltage_threshold(const struct sr_dev_inst *sdi, double threshold);
 SR_PRIV int dslogic_dev_open(struct sr_dev_inst *sdi, struct sr_dev_driver *di);
 SR_PRIV struct dev_context *dslogic_dev_new(void);
 SR_PRIV int dslogic_acquisition_start(const struct sr_dev_inst *sdi);
 SR_PRIV int dslogic_acquisition_stop(struct sr_dev_inst *sdi);
+SR_PRIV int command_start_acquisition(const struct sr_dev_inst *sdi);
+SR_PRIV int command_stop_acquisition(const struct sr_dev_inst *sdi);
 
 #endif

--- a/src/hardware/dreamsourcelab-dslogic/protocol_v1.c
+++ b/src/hardware/dreamsourcelab-dslogic/protocol_v1.c
@@ -1,0 +1,93 @@
+/*
+ * This file is part of the libsigrok project.
+ *
+ * Copyright (C) 2026 Larry Hernandez <l.gr@dartmouth.edu>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+#include "protocol.h"
+
+static int v1_fpga_firmware_upload(const struct sr_dev_inst *sdi)
+{
+	return dslogic_fpga_firmware_upload(sdi);
+}
+
+static int v1_fpga_config(const struct sr_dev_inst *sdi)
+{
+	return fpga_configure(sdi);
+}
+
+static int v1_acquisition_start(const struct sr_dev_inst *sdi)
+{
+	return command_start_acquisition(sdi);
+}
+
+static int v1_acquisition_stop(const struct sr_dev_inst *sdi)
+{
+	return command_stop_acquisition(sdi);
+}
+
+static int v1_set_samplerate(const struct sr_dev_inst *sdi, uint64_t rate)
+{
+	struct dev_context *devc = sdi->priv;
+	devc->cur_samplerate = rate;
+	return SR_OK;  /* V1 applies samplerate via fpga_configure on next acq */
+}
+
+static int v1_set_voltage_threshold(const struct sr_dev_inst *sdi, double low, double high)
+{
+	(void)low;  /* V1 uses a single threshold midpoint */
+	return dslogic_set_voltage_threshold(sdi, high);
+}
+
+static int v1_set_trigger(const struct sr_dev_inst *sdi)
+{
+	(void)sdi;
+	return SR_OK;  /* V1 sets trigger inside fpga_configure */
+}
+
+static int v1_set_external_clock(const struct sr_dev_inst *sdi, gboolean ext)
+{
+	struct dev_context *devc = sdi->priv;
+	devc->external_clock = ext;
+	return SR_OK;
+}
+
+static int v1_set_clock_edge(const struct sr_dev_inst *sdi, int edge)
+{
+	struct dev_context *devc = sdi->priv;
+	devc->clock_edge = edge;
+	return SR_OK;
+}
+
+static int v1_security_check(const struct sr_dev_inst *sdi)
+{
+	(void)sdi;
+	return SR_OK;  /* V1 hardware has no security check */
+}
+
+SR_PRIV const struct dslogic_protocol_ops dslogic_v1_ops = {
+	.fpga_firmware_upload = v1_fpga_firmware_upload,
+	.fpga_config = v1_fpga_config,
+	.acquisition_start = v1_acquisition_start,
+	.acquisition_stop = v1_acquisition_stop,
+	.set_samplerate = v1_set_samplerate,
+	.set_voltage_threshold = v1_set_voltage_threshold,
+	.set_trigger = v1_set_trigger,
+	.set_external_clock = v1_set_external_clock,
+	.set_clock_edge = v1_set_clock_edge,
+	.security_check = v1_security_check,
+};

--- a/src/hardware/dreamsourcelab-dslogic/protocol_v2.c
+++ b/src/hardware/dreamsourcelab-dslogic/protocol_v2.c
@@ -431,6 +431,61 @@ static inline uint32_t div_round_up(uint64_t a, uint64_t b)
 }
 
 /*
+ * Channel-mode table for the DSLogic Plus family (PIDs 0x0020, 0x0034).
+ * Values mirror DSView's channel_modes[] entries for DSL_BUFFER100x16,
+ * DSL_BUFFER200x8, DSL_BUFFER400x4, DSL_STREAM20x16, DSL_STREAM25x12,
+ * DSL_STREAM50x6, DSL_STREAM100x3.
+ */
+static const struct dslogic_channel_mode dslogic_plus_modes[] = {
+	/* id    stream  ch  min_sr      max_sr      hw_max     pre  descr */
+	{   0,   FALSE,  16, SR_KHZ(50), SR_MHZ(100), SR_MHZ(100), 1,
+		"16 channels, buffered (max 100 MHz)" },
+	{   1,   FALSE,   8, SR_KHZ(50), SR_MHZ(200), SR_MHZ(100), 1,
+		"8 channels, buffered (max 200 MHz)" },
+	{   2,   FALSE,   4, SR_KHZ(50), SR_MHZ(400), SR_MHZ(100), 1,
+		"4 channels, buffered (max 400 MHz)" },
+	{   3,   TRUE,   16, SR_KHZ(50), SR_MHZ(20),  SR_MHZ(100), 1,
+		"16 channels, streaming (max 20 MHz)" },
+	{   4,   TRUE,   12, SR_KHZ(50), SR_MHZ(25),  SR_MHZ(100), 1,
+		"12 channels, streaming (max 25 MHz)" },
+	{   5,   TRUE,    6, SR_KHZ(50), SR_MHZ(50),  SR_MHZ(100), 1,
+		"6 channels, streaming (max 50 MHz)" },
+	{   6,   TRUE,    3, SR_KHZ(50), SR_MHZ(100), SR_MHZ(100), 1,
+		"3 channels, streaming (max 100 MHz)" },
+};
+
+#define DSLOGIC_PLUS_DEFAULT_CH_MODE_ID 0   /* matches DSView's DSL_BUFFER100x16 */
+
+SR_PRIV const struct dslogic_channel_mode *dslogic_plus_channel_modes(size_t *count)
+{
+	if (count)
+		*count = ARRAY_SIZE(dslogic_plus_modes);
+	return dslogic_plus_modes;
+}
+
+SR_PRIV const struct dslogic_channel_mode *dslogic_plus_channel_mode_default(void)
+{
+	return &dslogic_plus_modes[DSLOGIC_PLUS_DEFAULT_CH_MODE_ID];
+}
+
+SR_PRIV const struct dslogic_channel_mode *dslogic_plus_channel_mode_by_id(uint8_t id)
+{
+	size_t i;
+	for (i = 0; i < ARRAY_SIZE(dslogic_plus_modes); i++)
+		if (dslogic_plus_modes[i].id == id)
+			return &dslogic_plus_modes[i];
+	return NULL;
+}
+
+static const struct dslogic_channel_mode *v2_current_channel_mode(const struct dev_context *devc)
+{
+	const struct dslogic_channel_mode *m;
+
+	m = dslogic_plus_channel_mode_by_id(devc->ch_mode_id);
+	return m ? m : dslogic_plus_channel_mode_default();
+}
+
+/*
  * Build the struct DSL_setting that is bulk-written to the FPGA.
  *
  * Header field encoding: (register_index << 8) | word_count
@@ -448,12 +503,11 @@ static void v2_build_default_setting(const struct sr_dev_inst *sdi,
 				     struct DSL_setting *s)
 {
 	struct dev_context *devc = sdi->priv;
-	/* DSLogic Plus pgl12 (PID 0x0034) channel mode DSL_STREAM20x16_3DN2 */
-	const uint64_t hw_max_samplerate = SR_MHZ(500);
-	const uint32_t pre_div = 5;
+	const struct dslogic_channel_mode *cm = v2_current_channel_mode(devc);
 	uint32_t tmp_u32;
 	uint64_t cur_sr;
 	uint64_t count_units;
+	uint32_t ch_en_mask;
 	int i;
 
 	memset(s, 0, sizeof(*s));
@@ -473,8 +527,13 @@ static void v2_build_default_setting(const struct sr_dev_inst *sdi,
 	s->fgain_header     = 0x0c01;   /* reg 0xc,  1 word  */
 	s->trig_header      = 0x40a0;   /* reg 0x40, 0xa0 words */
 
-	/* mode = 0: logic capture, internal clock, no compression, no trigger. */
+	/*
+	 * mode = logic capture, no trigger; stream bit set in stream channel
+	 * modes (mirrors DSView's STREAM_MODE_BIT in dsl.c).
+	 */
 	s->mode = 0;
+	if (cm->stream)
+		s->mode |= (1 << DS_MODE_STREAM_MODE_BIT);
 
 	/*
 	 * Samplerate divider (dsl.c, LOGIC mode branch).
@@ -485,9 +544,9 @@ static void v2_build_default_setting(const struct sr_dev_inst *sdi,
 	 *   div_h  += tmp_u32 >> 16
 	 */
 	cur_sr = devc->cur_samplerate ? devc->cur_samplerate : SR_MHZ(1);
-	tmp_u32 = div_round_up(hw_max_samplerate, cur_sr);
-	s->div_h = ((tmp_u32 >= pre_div) ? (pre_div - 1) : (tmp_u32 - 1)) << 8;
-	tmp_u32 = div_round_up(tmp_u32, pre_div);
+	tmp_u32 = div_round_up(cm->hw_max_samplerate, cur_sr);
+	s->div_h = ((tmp_u32 >= cm->pre_div) ? (cm->pre_div - 1) : (tmp_u32 - 1)) << 8;
+	tmp_u32 = div_round_up(tmp_u32, cm->pre_div);
 	s->div_l = tmp_u32 & 0x0000ffff;
 	s->div_h = (uint16_t)(s->div_h + (tmp_u32 >> 16));
 
@@ -510,9 +569,17 @@ static void v2_build_default_setting(const struct sr_dev_inst *sdi,
 	s->dso_cnt_l = 0;
 	s->dso_cnt_h = 0;
 
-	/* All 16 logic channels enabled (dsl.c). */
-	s->ch_en_l = 0xffff;
-	s->ch_en_h = 0x0000;
+	/*
+	 * Enable the low-N channels for the active mode (mirrors DSView's
+	 * default "use channels 0..num_channels-1"). 16-bit mask, channels
+	 * 16..31 not present on DSLogic Plus so ch_en_h stays 0.
+	 */
+	if (cm->num_channels >= 16)
+		ch_en_mask = 0xffff;
+	else
+		ch_en_mask = (1U << cm->num_channels) - 1U;
+	s->ch_en_l = (uint16_t)ch_en_mask;
+	s->ch_en_h = 0;
 
 	/* fgain = 0 (no digital fine gain in logic mode). */
 	s->fgain = 0;

--- a/src/hardware/dreamsourcelab-dslogic/protocol_v2.c
+++ b/src/hardware/dreamsourcelab-dslogic/protocol_v2.c
@@ -486,6 +486,43 @@ static const struct dslogic_channel_mode *v2_current_channel_mode(const struct d
 }
 
 /*
+ * Pick the channel mode that fits cur_samplerate under continuous_mode.
+ * Buffered mode trades samplerate for channel count: 16/8/4 ch at
+ * 100/200/400 MHz. Streaming mode caps at 100 MHz and trades the same
+ * way: 16/12/6/3 ch at 20/25/50/100 MHz. The smallest mode whose
+ * max_samplerate covers the requested rate wins.
+ */
+SR_PRIV uint8_t dslogic_plus_auto_pick_mode_id(uint64_t samplerate, gboolean continuous)
+{
+	size_t i, n;
+	const struct dslogic_channel_mode *modes = dslogic_plus_channel_modes(&n);
+	const struct dslogic_channel_mode *best = NULL;
+
+	for (i = 0; i < n; i++) {
+		if (modes[i].stream != continuous)
+			continue;
+		if (samplerate > modes[i].max_samplerate)
+			continue;
+		/* Prefer the mode with the highest channel count that still
+		 * supports this samplerate. */
+		if (!best || modes[i].num_channels > best->num_channels)
+			best = &modes[i];
+	}
+	if (best)
+		return best->id;
+	/* No exact fit (rate too high for any stream/buffer mode): fall
+	 * back to the mode with the highest max_samplerate in this
+	 * stream/buffer category. */
+	for (i = 0; i < n; i++) {
+		if (modes[i].stream != continuous)
+			continue;
+		if (!best || modes[i].max_samplerate > best->max_samplerate)
+			best = &modes[i];
+	}
+	return best ? best->id : DSLOGIC_PLUS_DEFAULT_CH_MODE_ID;
+}
+
+/*
  * Build the struct DSL_setting that is bulk-written to the FPGA.
  *
  * Header field encoding: (register_index << 8) | word_count
@@ -499,16 +536,31 @@ static const struct dslogic_channel_mode *v2_current_channel_mode(const struct d
  *   is 16 samples (dsl.c: "hardware minimum unit 64" [sic; actually
  *   16 because >>4 == /16]).
  */
+/* Forward decl: defined later, used in v2_build_default_setting. */
+static unsigned int v2_max_enabled_plus_one(const struct sr_dev_inst *sdi);
+
 static void v2_build_default_setting(const struct sr_dev_inst *sdi,
 				     struct DSL_setting *s)
 {
 	struct dev_context *devc = sdi->priv;
-	const struct dslogic_channel_mode *cm = v2_current_channel_mode(devc);
+	const struct dslogic_channel_mode *cm;
 	uint32_t tmp_u32;
 	uint64_t cur_sr;
 	uint64_t count_units;
 	uint32_t ch_en_mask;
 	int i;
+
+	/*
+	 * Re-pick the channel mode here so it sees the FINAL enabled-channel
+	 * mask. sigrok-cli's -C and PulseView's channel checkboxes may
+	 * disable channels AFTER config_set has run for samplerate /
+	 * continuous, so the auto-pick at set-time may have used a stale
+	 * channel count.
+	 */
+	devc->ch_mode_id = dslogic_plus_auto_pick_mode_id(
+		devc->cur_samplerate, devc->continuous_mode,
+		v2_max_enabled_plus_one(sdi));
+	cm = v2_current_channel_mode(devc);
 
 	memset(s, 0, sizeof(*s));
 
@@ -544,8 +596,27 @@ static void v2_build_default_setting(const struct sr_dev_inst *sdi,
 	 *   div_h  += tmp_u32 >> 16
 	 */
 	cur_sr = devc->cur_samplerate ? devc->cur_samplerate : SR_MHZ(1);
+	/*
+	 * Clamp to the active mode's advertised max_samplerate. The FPGA
+	 * will otherwise accept a higher rate via the divider but the
+	 * USB IN endpoint can't sustain it, leading to empty-transfer
+	 * abort ("Device only sent N samples") a few seconds into
+	 * acquisition. Warn loudly so the user knows to either drop a
+	 * channel (to unlock a higher-rate stream mode) or switch off
+	 * continuous mode.
+	 */
+	if (cur_sr > cm->max_samplerate) {
+		sr_warn("Requested samplerate %" PRIu64 " Hz exceeds "
+			"%s's max of %" PRIu64 " Hz; clamping. "
+			"Drop a channel for a higher-rate mode or disable "
+			"continuous mode.",
+			cur_sr, cm->descr, cm->max_samplerate);
+		cur_sr = cm->max_samplerate;
+		devc->cur_samplerate = cur_sr;
+	}
 	tmp_u32 = div_round_up(cm->hw_max_samplerate, cur_sr);
-	s->div_h = ((tmp_u32 >= cm->pre_div) ? (cm->pre_div - 1) : (tmp_u32 - 1)) << 8;
+	s->div_h = ((tmp_u32 >= (uint32_t)cm->pre_div) ?
+		(uint32_t)(cm->pre_div - 1U) : (tmp_u32 - 1U)) << 8;
 	tmp_u32 = div_round_up(tmp_u32, cm->pre_div);
 	s->div_l = tmp_u32 & 0x0000ffff;
 	s->div_h = (uint16_t)(s->div_h + (tmp_u32 >> 16));
@@ -741,6 +812,10 @@ static int v2_set_samplerate(const struct sr_dev_inst *sdi, uint64_t rate)
 {
 	struct dev_context *devc = sdi->priv;
 	devc->cur_samplerate = rate;
+	/* Auto-pick the channel mode that fits this rate under the current
+	 * stream/buffer choice. The setting struct is rebuilt at arm time,
+	 * so updating ch_mode_id here is enough. */
+	devc->ch_mode_id = dslogic_plus_auto_pick_mode_id(rate, devc->continuous_mode);
 	return SR_OK;
 }
 

--- a/src/hardware/dreamsourcelab-dslogic/protocol_v2.c
+++ b/src/hardware/dreamsourcelab-dslogic/protocol_v2.c
@@ -1,0 +1,704 @@
+/*
+ * This file is part of the libsigrok project.
+ *
+ * Copyright (C) 2013 Bert Vermeulen <bert@biot.com>
+ * Copyright (C) 2013-2017 DreamSourceLab <support@dreamsourcelab.com>
+ * Copyright (C) 2026 Larry Hernandez <l.gr@dartmouth.edu>
+ *
+ * V2 (envelope) protocol implementation. Wire format mirrors DSView
+ * 1.3.2's libsigrok4DSL/hardware/DSL/command.c and dsl.c.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License v3.
+ */
+
+#include <config.h>
+#include <assert.h>
+#include <string.h>
+#include <glib.h>
+#include <libusb.h>
+#include "protocol.h"
+#include "protocol_v2.h"
+
+#define V2_USB_TIMEOUT_MS 3000
+
+SR_PRIV int command_ctl_wr_v2(libusb_device_handle *devhdl, struct ctl_wr_cmd cmd)
+{
+	int ret;
+
+	assert(devhdl);
+
+	ret = libusb_control_transfer(devhdl,
+		LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_ENDPOINT_OUT,
+		CMD_CTL_WR, 0x0000, 0x0000,
+		(unsigned char *)&cmd,
+		cmd.header.size + sizeof(struct ctl_header),
+		V2_USB_TIMEOUT_MS);
+	if (ret < 0) {
+		sr_err("CMD_CTL_WR failed (dest=%u offset=%u size=%u): %s",
+			cmd.header.dest, cmd.header.offset, cmd.header.size,
+			libusb_error_name(ret));
+		return SR_ERR;
+	}
+	return SR_OK;
+}
+
+SR_PRIV int command_ctl_rd_v2(libusb_device_handle *devhdl, struct ctl_rd_cmd cmd)
+{
+	int ret;
+
+	assert(devhdl);
+
+	/* Phase 1: write the header to set up the read. */
+	ret = libusb_control_transfer(devhdl,
+		LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_ENDPOINT_OUT,
+		CMD_CTL_RD_PRE, 0x0000, 0x0000,
+		(unsigned char *)&cmd, sizeof(struct ctl_header),
+		V2_USB_TIMEOUT_MS);
+	if (ret < 0) {
+		sr_err("CMD_CTL_RD_PRE failed (dest=%u offset=%u size=%u): %s",
+			cmd.header.dest, cmd.header.offset, cmd.header.size,
+			libusb_error_name(ret));
+		return SR_ERR;
+	}
+
+	g_usleep(10 * 1000);
+
+	/* Phase 2: read the requested bytes. */
+	ret = libusb_control_transfer(devhdl,
+		LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_ENDPOINT_IN,
+		CMD_CTL_RD, 0x0000, 0x0000,
+		(unsigned char *)cmd.data, cmd.header.size,
+		V2_USB_TIMEOUT_MS);
+	if (ret < 0) {
+		sr_err("CMD_CTL_RD failed: %s", libusb_error_name(ret));
+		return SR_ERR;
+	}
+	return SR_OK;
+}
+
+SR_PRIV int dsl_wr_reg_v2(const struct sr_dev_inst *sdi, uint16_t addr, uint8_t value)
+{
+	struct sr_usb_dev_inst *usb = sdi->conn;
+	struct ctl_wr_cmd wr_cmd;
+
+	wr_cmd.header.dest = DSL_CTL_I2C_REG;
+	wr_cmd.header.offset = addr;
+	wr_cmd.header.size = 1;
+	wr_cmd.data[0] = value;
+	return command_ctl_wr_v2(usb->devhdl, wr_cmd);
+}
+
+SR_PRIV int dsl_rd_reg_v2(const struct sr_dev_inst *sdi, uint16_t addr, uint8_t *value)
+{
+	struct sr_usb_dev_inst *usb = sdi->conn;
+	struct ctl_rd_cmd rd_cmd;
+
+	rd_cmd.header.dest = DSL_CTL_I2C_STATUS;
+	rd_cmd.header.offset = addr;
+	rd_cmd.header.size = 1;
+	rd_cmd.data = value;
+	return command_ctl_rd_v2(usb->devhdl, rd_cmd);
+}
+
+SR_PRIV int dsl_rd_nvm_v2(const struct sr_dev_inst *sdi, uint8_t *buf, uint16_t addr, uint8_t len)
+{
+	struct sr_usb_dev_inst *usb = sdi->conn;
+	struct ctl_rd_cmd rd_cmd;
+
+	rd_cmd.header.dest = DSL_CTL_NVM;
+	rd_cmd.header.offset = addr;
+	rd_cmd.header.size = len;
+	rd_cmd.data = buf;
+	return command_ctl_rd_v2(usb->devhdl, rd_cmd);
+}
+
+SR_PRIV int dsl_wait_hw_status_bit_v2(libusb_device_handle *hdl, uint8_t bit_mask, gboolean want_set, unsigned timeout_ms)
+{
+	uint8_t status;
+	struct ctl_rd_cmd rd_cmd;
+	gint64 deadline_us = g_get_monotonic_time() + (gint64)timeout_ms * 1000;
+
+	rd_cmd.header.dest = DSL_CTL_HW_STATUS;
+	rd_cmd.header.offset = 0;
+	rd_cmd.header.size = 1;
+	rd_cmd.data = &status;
+
+	for (;;) {
+		if (command_ctl_rd_v2(hdl, rd_cmd) != SR_OK)
+			return SR_ERR;
+		if (want_set && (status & bit_mask))
+			return SR_OK;
+		if (!want_set && !(status & bit_mask))
+			return SR_OK;
+		if (g_get_monotonic_time() >= deadline_us) {
+			sr_err("Timeout waiting for HW_STATUS bit 0x%02x (%s)",
+				bit_mask, want_set ? "set" : "clear");
+			return SR_ERR;
+		}
+		g_usleep(1000);
+	}
+}
+
+/* Security challenge-response helpers (mirror DSView dsl.c). */
+
+static int v2_secu_reset(const struct sr_dev_inst *sdi)
+{
+	if (dsl_wr_reg_v2(sdi, SEC_CTRL_ADDR, 0) != SR_OK) return SR_ERR;
+	if (dsl_wr_reg_v2(sdi, SEC_CTRL_ADDR + 1, 0) != SR_OK) return SR_ERR;
+	g_usleep(10 * 1000);
+	if (dsl_wr_reg_v2(sdi, SEC_CTRL_ADDR, 1) != SR_OK) return SR_ERR;
+	if (dsl_wr_reg_v2(sdi, SEC_CTRL_ADDR + 1, 0) != SR_OK) return SR_ERR;
+	return SR_OK;
+}
+
+static int v2_secu_write(const struct sr_dev_inst *sdi, uint16_t cmd, uint16_t din)
+{
+	if (dsl_wr_reg_v2(sdi, SEC_DATA_ADDR,     din & 0xff) != SR_OK) return SR_ERR;
+	if (dsl_wr_reg_v2(sdi, SEC_DATA_ADDR + 1, (din >> 8) & 0xff) != SR_OK) return SR_ERR;
+	if (dsl_wr_reg_v2(sdi, SEC_CTRL_ADDR,     cmd & 0xff) != SR_OK) return SR_ERR;
+	if (dsl_wr_reg_v2(sdi, SEC_CTRL_ADDR + 1, (cmd >> 8) & 0xff) != SR_OK) return SR_ERR;
+	return SR_OK;
+}
+
+static gboolean v2_secu_is_ready(const struct sr_dev_inst *sdi)
+{
+	uint8_t t = 0;
+	if (dsl_rd_reg_v2(sdi, SEC_CTRL_ADDR, &t) != SR_OK)
+		return FALSE;
+	return (t & bmSECU_READY) ? TRUE : FALSE;
+}
+
+static gboolean v2_secu_is_pass(const struct sr_dev_inst *sdi)
+{
+	uint8_t t = 0;
+	if (dsl_rd_reg_v2(sdi, SEC_CTRL_ADDR, &t) != SR_OK)
+		return FALSE;
+	return (t & bmSECU_PASS) ? TRUE : FALSE;
+}
+
+static uint16_t v2_secu_read(const struct sr_dev_inst *sdi)
+{
+	uint8_t hi = 0, lo = 0;
+	if (dsl_rd_reg_v2(sdi, SEC_DATA_ADDR + 1, &hi) != SR_OK) return 0;
+	if (dsl_rd_reg_v2(sdi, SEC_DATA_ADDR,     &lo) != SR_OK) return 0;
+	return ((uint16_t)hi << 8) | lo;
+}
+
+static int v2_security_check(const struct sr_dev_inst *sdi)
+{
+	uint16_t encryption[SECU_STEPS];
+	int i;
+	int try_cnt;
+
+	/* "Dessert clear" - DSView writes CTR0_ADDR=0x70 to 0 before the
+	 * encryption read (dsl.c). Without this the FPGA can be left in
+	 * a state where subsequent HW_STATUS reads stall. */
+	if (dsl_wr_reg_v2(sdi, 0x70, 0x00) != SR_OK) {
+		sr_err("Failed CTR0_ADDR dessert-clear.");
+		return SR_ERR;
+	}
+
+	if (dsl_rd_nvm_v2(sdi, (uint8_t *)encryption, SECU_EEP_ADDR, SECU_STEPS * 2) != SR_OK) {
+		sr_err("Failed to read encryption blob from device NVM at 0x%04x.", SECU_EEP_ADDR);
+		return SR_ERR;
+	}
+
+	if (v2_secu_reset(sdi) != SR_OK) {
+		sr_err("Security reset failed.");
+		return SR_ERR;
+	}
+
+	if (v2_secu_is_pass(sdi)) {
+		sr_err("Security state is already 'pass' before challenge; rejected.");
+		return SR_ERR;
+	}
+
+	if (v2_secu_write(sdi, SECU_START, 0) != SR_OK) {
+		sr_err("Security start command failed.");
+		return SR_ERR;
+	}
+
+	/* Step counts down from SECU_STEPS-1 to 0, mirrors DSView dsl.c. */
+	for (i = SECU_STEPS - 1; i >= 0; i--) {
+		if (v2_secu_is_pass(sdi)) {
+			sr_err("Security passed prematurely at step %d.", i);
+			return SR_ERR;
+		}
+		try_cnt = SECU_TRY_CNT;
+		while (!v2_secu_is_ready(sdi)) {
+			if (try_cnt-- == 0) {
+				sr_err("Security ready timeout at step %d.", i);
+				return SR_ERR;
+			}
+		}
+		if (v2_secu_read(sdi) != 0) {
+			sr_err("Security read non-zero at step %d.", i);
+			return SR_ERR;
+		}
+		if (v2_secu_write(sdi, SECU_CHECK, encryption[i]) != SR_OK) {
+			sr_err("Security check write failed at step %d.", i);
+			return SR_ERR;
+		}
+	}
+
+	sr_info("Security check pass!");
+	return SR_OK;
+}
+
+/* FPGA arm sequence (mirrors DSView dsl_fpga_arm at dsl.c). */
+
+/*
+ * V2 FPGA bitstream upload (mirrors DSView dsl_fpga_config at dsl.c).
+ *
+ * V1 uses a single DS_CMD_CONFIG (0xb3) control transfer + bulk write of the
+ * bitstream. V2 firmware does not recognise 0xb3 and stalls. The V2 sequence:
+ *   1) DSL_CTL_PROG_B := ~bmWR_PROG_B (PROG_B low)
+ *   2) DSL_CTL_LED    := off
+ *   3) DSL_CTL_PROG_B := bmWR_PROG_B  (PROG_B high)
+ *   4) poll HW_STATUS until bmFPGA_INIT_B is set
+ *   5) DSL_CTL_INTRDY := ~bmWR_INTRDY (INTRDY low)
+ *   6) DSL_CTL_BULK_WR with 3-byte bitstream-size announce
+ *   7) bulk transfer the bitstream on ep2 OUT
+ *   8) DSL_CTL_INTRDY := bmWR_INTRDY  (INTRDY high → data end)
+ *   9) poll HW_STATUS until bmGPIF_DONE is set
+ */
+static int v2_fpga_firmware_upload(const struct sr_dev_inst *sdi)
+{
+	struct drv_context *drvc = sdi->driver->context;
+	struct sr_usb_dev_inst *usb = sdi->conn;
+	libusb_device_handle *hdl = usb->devhdl;
+	struct dev_context *devc = sdi->priv;
+	struct sr_resource bitstream;
+	struct ctl_wr_cmd wr;
+	unsigned char *buf;
+	int transferred;
+	int result, ret;
+	const char *name = NULL;
+
+	if (!strcmp(devc->profile->model, "DSLogic Plus")) {
+		name = "dreamsourcelab-dslogic-plus-fpga.fw";
+	} else {
+		sr_err("v2: no FPGA firmware for model '%s'.", devc->profile->model);
+		return SR_ERR;
+	}
+
+	sr_dbg("Uploading FPGA bitstream '%s' via V2 envelope protocol.", name);
+	if ((result = sr_resource_open(drvc->sr_ctx, &bitstream,
+			SR_RESOURCE_FIRMWARE, name)) != SR_OK)
+		return result;
+
+	/* 1) PROG_B low */
+	wr.header.dest = DSL_CTL_PROG_B;
+	wr.header.offset = 0;
+	wr.header.size = 1;
+	wr.data[0] = (uint8_t)~bmWR_PROG_B;
+	if ((ret = command_ctl_wr_v2(hdl, wr)) != SR_OK) goto fail;
+
+	/* 2) LEDs off */
+	wr.header.dest = DSL_CTL_LED;
+	wr.header.size = 1;
+	wr.data[0] = (uint8_t)(~bmLED_GREEN & ~bmLED_RED);
+	if ((ret = command_ctl_wr_v2(hdl, wr)) != SR_OK) goto fail;
+
+	/* 3) PROG_B high */
+	wr.header.dest = DSL_CTL_PROG_B;
+	wr.header.size = 1;
+	wr.data[0] = bmWR_PROG_B;
+	if ((ret = command_ctl_wr_v2(hdl, wr)) != SR_OK) goto fail;
+
+	/* 4) Wait bmFPGA_INIT_B set */
+	if ((ret = dsl_wait_hw_status_bit_v2(hdl, bmFPGA_INIT_B, TRUE, 3000)) != SR_OK)
+		goto fail;
+
+	/* 5) INTRDY low */
+	wr.header.dest = DSL_CTL_INTRDY;
+	wr.header.size = 1;
+	wr.data[0] = (uint8_t)~bmWR_INTRDY;
+	if ((ret = command_ctl_wr_v2(hdl, wr)) != SR_OK) goto fail;
+
+	/* 6) BULK_WR announce: 3-byte file size */
+	wr.header.dest = DSL_CTL_BULK_WR;
+	wr.header.size = 3;
+	wr.data[0] = (uint8_t)bitstream.size;
+	wr.data[1] = (uint8_t)(bitstream.size >> 8);
+	wr.data[2] = (uint8_t)(bitstream.size >> 16);
+	if ((ret = command_ctl_wr_v2(hdl, wr)) != SR_OK) goto fail;
+
+	/* 7) bulk-transfer the bitstream */
+	buf = g_malloc(bitstream.size);
+	if (!buf) { ret = SR_ERR; goto fail; }
+	{
+		uint64_t sum = 0;
+		ssize_t chunk;
+		while ((chunk = sr_resource_read(drvc->sr_ctx, &bitstream,
+				buf + sum, bitstream.size - sum)) > 0)
+			sum += chunk;
+		if ((int64_t)sum != (int64_t)bitstream.size) {
+			sr_err("v2 fpga: short read of bitstream (%" PRIu64 "/%" PRIu64 ").",
+				sum, bitstream.size);
+			g_free(buf);
+			ret = SR_ERR;
+			goto fail;
+		}
+	}
+	ret = libusb_bulk_transfer(hdl, 2 | LIBUSB_ENDPOINT_OUT,
+		buf, (int)bitstream.size, &transferred, V2_USB_TIMEOUT_MS);
+	g_free(buf);
+	if (ret < 0) {
+		sr_err("v2 fpga: bitstream bulk write failed: %s", libusb_error_name(ret));
+		ret = SR_ERR;
+		goto fail;
+	}
+	if (transferred != (int)bitstream.size) {
+		sr_err("v2 fpga: bitstream short transfer (%d/%" PRIu64 ").",
+			transferred, bitstream.size);
+		ret = SR_ERR;
+		goto fail;
+	}
+
+	/* 8) INTRDY high (signal data end) */
+	wr.header.dest = DSL_CTL_INTRDY;
+	wr.header.size = 1;
+	wr.data[0] = bmWR_INTRDY;
+	if ((ret = command_ctl_wr_v2(hdl, wr)) != SR_OK) goto fail;
+
+	/* 9) Wait GPIF_DONE */
+	if ((ret = dsl_wait_hw_status_bit_v2(hdl, bmGPIF_DONE, TRUE, 3000)) != SR_OK)
+		goto fail;
+
+	/* 10) INTRDY low (dsl.c) */
+	wr.header.dest = DSL_CTL_INTRDY;
+	wr.header.size = 1;
+	wr.data[0] = (uint8_t)~bmWR_INTRDY;
+	if ((ret = command_ctl_wr_v2(hdl, wr)) != SR_OK) goto fail;
+
+	/* 11) Wait FPGA_DONE - confirms the FPGA bitstream is live (dsl.c) */
+	if ((ret = dsl_wait_hw_status_bit_v2(hdl, bmFPGA_DONE, TRUE, 3000)) != SR_OK)
+		goto fail;
+
+	/* 12) Turn on the green LED (dsl.c) */
+	wr.header.dest = DSL_CTL_LED;
+	wr.header.size = 1;
+	wr.data[0] = bmLED_GREEN;
+	if ((ret = command_ctl_wr_v2(hdl, wr)) != SR_OK) goto fail;
+
+	/* 13) Re-assert WORDWIDE high (dsl.c) */
+	wr.header.dest = DSL_CTL_WORDWIDE;
+	wr.header.size = 1;
+	wr.data[0] = bmWR_WORDWIDE;
+	if ((ret = command_ctl_wr_v2(hdl, wr)) != SR_OK) goto fail;
+
+	sr_info("FPGA configure done: %" PRIu64 " bytes.", bitstream.size);
+	sr_resource_close(drvc->sr_ctx, &bitstream);
+	return SR_OK;
+
+fail:
+	sr_resource_close(drvc->sr_ctx, &bitstream);
+	return SR_ERR;
+}
+
+/*
+ * Integer ceiling division helper - avoids pulling in <math.h>.
+ * Returns ceil(a / b) as uint32_t.
+ */
+static inline uint32_t div_round_up(uint64_t a, uint64_t b)
+{
+	return (uint32_t)((a + b - 1) / b);
+}
+
+/*
+ * Build the struct DSL_setting that is bulk-written to the FPGA.
+ *
+ * Header field encoding: (register_index << 8) | word_count
+ *   mirrors dsl.c.
+ *
+ * Samplerate divider uses hw_max_samplerate = 500 MHz and pre_div = 5,
+ *   which are the correct values for the DSLogic Plus pgl12 16-channel
+ *   mode (DSL_STREAM20x16_3DN2) as confirmed in dsl.h.
+ *
+ * Sample count is shifted right by 4 because the FPGA's minimum unit
+ *   is 16 samples (dsl.c: "hardware minimum unit 64" [sic; actually
+ *   16 because >>4 == /16]).
+ */
+static void v2_build_default_setting(const struct sr_dev_inst *sdi,
+				     struct DSL_setting *s)
+{
+	struct dev_context *devc = sdi->priv;
+	/* DSLogic Plus pgl12 (PID 0x0034) channel mode DSL_STREAM20x16_3DN2 */
+	const uint64_t hw_max_samplerate = SR_MHZ(500);
+	const uint32_t pre_div = 5;
+	uint32_t tmp_u32;
+	uint64_t cur_sr;
+	uint64_t count_units;
+	int i;
+
+	memset(s, 0, sizeof(*s));
+
+	/* Sync markers (dsl.c, 1046). */
+	s->sync     = DSL_SETTING_SYNC;
+	s->end_sync = DSL_SETTING_END_SYNC;
+
+	/* Header values encode (register_index << 8) | word_count. */
+	s->mode_header      = 0x0001;   /* reg 0,    1 word  */
+	s->divider_header   = 0x0102;   /* reg 1,    2 words */
+	s->count_header     = 0x0302;   /* reg 3,    2 words */
+	s->trig_pos_header  = 0x0502;   /* reg 5,    2 words */
+	s->trig_glb_header  = 0x0701;   /* reg 7,    1 word  */
+	s->dso_count_header = 0x0802;   /* reg 8,    2 words */
+	s->ch_en_header     = 0x0a02;   /* reg 0xa,  2 words */
+	s->fgain_header     = 0x0c01;   /* reg 0xc,  1 word  */
+	s->trig_header      = 0x40a0;   /* reg 0x40, 0xa0 words */
+
+	/* mode = 0: logic capture, internal clock, no compression, no trigger. */
+	s->mode = 0;
+
+	/*
+	 * Samplerate divider (dsl.c, LOGIC mode branch).
+	 *   tmp_u32 = ceil(hw_max / cur_sr)
+	 *   div_h   = ((tmp_u32 >= pre_div) ? (pre_div-1) : (tmp_u32-1)) << 8
+	 *   tmp_u32 = ceil(tmp_u32 / pre_div)
+	 *   div_l   = tmp_u32 & 0xffff
+	 *   div_h  += tmp_u32 >> 16
+	 */
+	cur_sr = devc->cur_samplerate ? devc->cur_samplerate : SR_MHZ(1);
+	tmp_u32 = div_round_up(hw_max_samplerate, cur_sr);
+	s->div_h = ((tmp_u32 >= pre_div) ? (pre_div - 1) : (tmp_u32 - 1)) << 8;
+	tmp_u32 = div_round_up(tmp_u32, pre_div);
+	s->div_l = tmp_u32 & 0x0000ffff;
+	s->div_h = (uint16_t)(s->div_h + (tmp_u32 >> 16));
+
+	/*
+	 * Capture counter (dsl.c, LOGIC mode branch).
+	 * The FPGA's minimum unit is 16 samples (>>4).
+	 */
+	count_units = devc->limit_samples >> 4;
+	s->cnt_l = count_units & 0xffff;
+	s->cnt_h = (count_units >> 16) & 0xffff;
+
+	/* trig_pos = 0 (no pre-trigger). */
+	s->tpos_l = 0;
+	s->tpos_h = 0;
+
+	/* trig_glb = 0 (no trigger). */
+	s->trig_glb = 0;
+
+	/* dso_cnt = 0 (unused in logic mode). */
+	s->dso_cnt_l = 0;
+	s->dso_cnt_h = 0;
+
+	/* All 16 logic channels enabled (dsl.c). */
+	s->ch_en_l = 0xffff;
+	s->ch_en_h = 0x0000;
+
+	/* fgain = 0 (no digital fine gain in logic mode). */
+	s->fgain = 0;
+
+	/*
+	 * Trigger arrays - "no trigger" defaults, mirroring dsl.c
+	 * (the i >= 1 loop in the SIMPLE_TRIGGER branch; we apply it to all
+	 * stages since we have no active trigger stage).
+	 *
+	 * memset already zeroed value/edge/count; set mask and logic explicitly.
+	 */
+	for (i = 0; i < NUM_TRIGGER_STAGES; i++) {
+		s->trig_mask0[i]  = 0xffff;
+		s->trig_mask1[i]  = 0xffff;
+		s->trig_value0[i] = 0;
+		s->trig_value1[i] = 0;
+		s->trig_edge0[i]  = 0;
+		s->trig_edge1[i]  = 0;
+		s->trig_logic0[i] = 2;   /* "always" per DSView */
+		s->trig_logic1[i] = 2;
+		s->trig_count[i]  = 0;
+	}
+}
+
+/*
+ * Arm the FPGA by sending struct DSL_setting over bulk endpoint 2.
+ *
+ * Sequence (dsl.c):
+ *   DSL_CTL_WORDWIDE → DSL_CTL_BULK_WR (3-byte word count) →
+ *   poll bmSYS_CLR → bulk write setting blob on ep2 OUT →
+ *   DSL_CTL_INTRDY → read HW_STATUS once, check bmGPIF_DONE.
+ *
+ * No DSL_CTL_STOP is issued here; DSView does not include it in the
+ * arm sequence.
+ */
+static int v2_fpga_config(const struct sr_dev_inst *sdi)
+{
+	struct sr_usb_dev_inst *usb = sdi->conn;
+	libusb_device_handle *hdl = usb->devhdl;
+	struct ctl_wr_cmd wr;
+	struct ctl_rd_cmd rd;
+	struct DSL_setting setting;
+	uint32_t arm_size;
+	uint8_t rd_data;
+	int ret, transferred;
+
+	/* 1) Set GPIF to word-wide (16-bit) mode (dsl.c). */
+	wr.header.dest   = DSL_CTL_WORDWIDE;
+	wr.header.offset = 0;
+	wr.header.size   = 1;
+	wr.data[0]       = bmWR_WORDWIDE;
+	if ((ret = command_ctl_wr_v2(hdl, wr)) != SR_OK) {
+		sr_err("DSL_CTL_WORDWIDE failed.");
+		return SR_ERR;
+	}
+
+	/*
+	 * 2) Send bulk-write control command with 3-byte word count
+	 *    (dsl.c).  arm_size is in uint16_t words.
+	 */
+	arm_size = sizeof(struct DSL_setting) / sizeof(uint16_t);
+	wr.header.dest   = DSL_CTL_BULK_WR;
+	wr.header.offset = 0;
+	wr.header.size   = 3;
+	wr.data[0] = (uint8_t)arm_size;
+	wr.data[1] = (uint8_t)(arm_size >> 8);
+	wr.data[2] = (uint8_t)(arm_size >> 16);
+	if ((ret = command_ctl_wr_v2(hdl, wr)) != SR_OK) {
+		sr_err("DSL_CTL_BULK_WR (arm announce) failed.");
+		return SR_ERR;
+	}
+
+	/*
+	 * 3) Poll bmSYS_CLR until the firmware asserts it
+	 *    (dsl.c) - DSView polls immediately after BULK_WR with
+	 *    no delay; the firmware appears to expect this fast cadence.
+	 */
+	if (dsl_wait_hw_status_bit_v2(hdl, bmSYS_CLR, TRUE, 3000) != SR_OK)
+		return SR_ERR;
+
+	/* 4) Build the settings blob and bulk-write it (dsl.c). */
+	v2_build_default_setting(sdi, &setting);
+	transferred = 0;
+	ret = libusb_bulk_transfer(hdl, 2 | LIBUSB_ENDPOINT_OUT,
+				   (unsigned char *)&setting,
+				   sizeof(struct DSL_setting),
+				   &transferred, V2_USB_TIMEOUT_MS);
+	if (ret < 0) {
+		sr_err("Arm FPGA bulk write failed: %s.", libusb_error_name(ret));
+		return SR_ERR;
+	}
+	if (transferred != (int)sizeof(struct DSL_setting)) {
+		sr_err("Arm FPGA bulk write short: %d/%zu.",
+		       transferred, sizeof(struct DSL_setting));
+		return SR_ERR;
+	}
+
+	/* 5) Assert INTRDY high to signal end of data (dsl.c). */
+	wr.header.dest   = DSL_CTL_INTRDY;
+	wr.header.offset = 0;
+	wr.header.size   = 1;
+	wr.data[0]       = bmWR_INTRDY;
+	if ((ret = command_ctl_wr_v2(hdl, wr)) != SR_OK) {
+		sr_err("DSL_CTL_INTRDY failed.");
+		return SR_ERR;
+	}
+
+	/*
+	 * 6) Read HW_STATUS once and check bmGPIF_DONE (dsl.c).
+	 *    DSView does NOT poll - a single read is the spec.
+	 */
+	rd.header.dest   = DSL_CTL_HW_STATUS;
+	rd.header.offset = 0;
+	rd.header.size   = 1;
+	rd_data          = 0;
+	rd.data          = &rd_data;
+	if (command_ctl_rd_v2(hdl, rd) != SR_OK)
+		return SR_ERR;
+	if (rd_data & bmGPIF_DONE) {
+		sr_info("Arm FPGA done.");
+		return SR_OK;
+	}
+	sr_err("Arm FPGA: bmGPIF_DONE not set after INTRDY (HW_STATUS=0x%02x).", rd_data);
+	return SR_ERR;
+}
+
+static int v2_acquisition_start(const struct sr_dev_inst *sdi)
+{
+	struct sr_usb_dev_inst *usb = sdi->conn;
+	struct ctl_wr_cmd wr;
+
+	wr.header.dest = DSL_CTL_START;
+	wr.header.offset = 0;
+	wr.header.size = 0;
+	return command_ctl_wr_v2(usb->devhdl, wr);
+}
+
+static int v2_acquisition_stop(const struct sr_dev_inst *sdi)
+{
+	struct sr_usb_dev_inst *usb = sdi->conn;
+	struct ctl_wr_cmd wr;
+
+	/*
+	 * DSView's dsl_dev_acquisition_stop is two-stage (dsl.c):
+	 * write CTR0_ADDR := bmFORCE_RDY first (soft FPGA abort that releases
+	 * the GPIF capture engine and resets the green LED), then send
+	 * DSL_CTL_STOP. Without bmFORCE_RDY, the FPGA stays in capture state
+	 * and the LED flashes after a "completed" acquisition.
+	 */
+	(void)dsl_wr_reg_v2(sdi, CTR0_ADDR, bmFORCE_RDY);
+
+	wr.header.dest = DSL_CTL_STOP;
+	wr.header.offset = 0;
+	wr.header.size = 0;
+	return command_ctl_wr_v2(usb->devhdl, wr);
+}
+
+static int v2_set_samplerate(const struct sr_dev_inst *sdi, uint64_t rate)
+{
+	struct dev_context *devc = sdi->priv;
+	devc->cur_samplerate = rate;
+	return SR_OK;
+}
+
+static int v2_set_voltage_threshold(const struct sr_dev_inst *sdi, double low, double high)
+{
+	/* DSLogic exposes a single threshold via VTH_ADDR; use the midpoint. */
+	double mid = (low + high) / 2.0;
+	uint8_t dac;
+
+	if (mid < 0.0) mid = 0.0;
+	if (mid > 3.3) mid = 3.3;
+	dac = (uint8_t)(mid / 3.3 * (1.5 / 2.5) * 255.0);
+
+	return dsl_wr_reg_v2(sdi, VTH_ADDR, dac);
+}
+
+static int v2_set_trigger(const struct sr_dev_inst *sdi)
+{
+	/* Triggers are encoded into struct DSL_setting at arm time
+	 * (see v2_build_default_setting). Nothing to do at config time. */
+	(void)sdi;
+	return SR_OK;
+}
+
+static int v2_set_external_clock(const struct sr_dev_inst *sdi, gboolean ext)
+{
+	struct dev_context *devc = sdi->priv;
+	devc->external_clock = ext;
+	/* Applied at next arm via the mode bitfield in DSL_setting. */
+	return SR_OK;
+}
+
+static int v2_set_clock_edge(const struct sr_dev_inst *sdi, int edge)
+{
+	struct dev_context *devc = sdi->priv;
+	devc->clock_edge = edge;
+	return SR_OK;
+}
+
+SR_PRIV const struct dslogic_protocol_ops dslogic_v2_ops = {
+	.fpga_firmware_upload  = v2_fpga_firmware_upload,
+	.fpga_config           = v2_fpga_config,
+	.acquisition_start     = v2_acquisition_start,
+	.acquisition_stop      = v2_acquisition_stop,
+	.set_samplerate        = v2_set_samplerate,
+	.set_voltage_threshold = v2_set_voltage_threshold,
+	.set_trigger           = v2_set_trigger,
+	.set_external_clock    = v2_set_external_clock,
+	.set_clock_edge        = v2_set_clock_edge,
+	.security_check        = v2_security_check,
+};

--- a/src/hardware/dreamsourcelab-dslogic/protocol_v2.c
+++ b/src/hardware/dreamsourcelab-dslogic/protocol_v2.c
@@ -596,12 +596,26 @@ static void v2_build_default_setting(const struct sr_dev_inst *sdi,
 	s->trig_header      = 0x40a0;   /* reg 0x40, 0xa0 words */
 
 	/*
-	 * mode = logic capture, no trigger; stream bit set in stream channel
-	 * modes (mirrors DSView's STREAM_MODE_BIT in dsl.c).
+	 * mode bitfield. Mirrors DSView dsl.c (LOGIC mode branch):
+	 *   bit 1  CLK_TYPE   - external clock if set
+	 *   bit 2  CLK_EDGE   - falling edge if set
+	 *   bit 3  RLE_MODE   - run-length encoding
+	 *   bit 8  FILTER     - 1T glitch filter
+	 *   bit 12 STREAM_MODE - streaming vs buffered
+	 * The DSLogic Plus has no DSO/ANALOG/HALF/QUAR modes so those bits
+	 * stay zero. Trigger bits stay zero until trigger support lands.
 	 */
 	s->mode = 0;
 	if (cm->stream)
 		s->mode |= (1 << DS_MODE_STREAM_MODE_BIT);
+	if (devc->external_clock)
+		s->mode |= (1 << DS_MODE_CLK_TYPE_BIT);
+	if (devc->clock_edge == DS_EDGE_FALLING)
+		s->mode |= (1 << DS_MODE_CLK_EDGE_BIT);
+	if (devc->rle_mode)
+		s->mode |= (1 << DS_MODE_RLE_MODE_BIT);
+	if (devc->filter)
+		s->mode |= (1 << DS_MODE_FILTER_BIT);
 
 	/*
 	 * Samplerate divider (dsl.c, LOGIC mode branch).

--- a/src/hardware/dreamsourcelab-dslogic/protocol_v2.c
+++ b/src/hardware/dreamsourcelab-dslogic/protocol_v2.c
@@ -271,7 +271,9 @@ static int v2_fpga_firmware_upload(const struct sr_dev_inst *sdi)
 	struct dev_context *devc = sdi->priv;
 	struct sr_resource bitstream;
 	struct ctl_wr_cmd wr;
+	struct ctl_rd_cmd rd;
 	unsigned char *buf;
+	uint8_t hw_status = 0;
 	int transferred;
 	int result, ret;
 	const char *name = NULL;
@@ -281,6 +283,27 @@ static int v2_fpga_firmware_upload(const struct sr_dev_inst *sdi)
 	} else {
 		sr_err("v2: no FPGA firmware for model '%s'.", devc->profile->model);
 		return SR_ERR;
+	}
+
+	/*
+	 * If the FPGA is already configured (PulseView Stop+Run or quick
+	 * sigrok-cli reopen on the same device), skip the bitstream upload
+	 * and do the same dessert-clear write DSView does in its
+	 * already-configured branch (dsl_dev_open at dsl.c). Re-running
+	 * the full PROG_B cycle on a live FPGA wedges the post-INTRDY
+	 * FPGA_DONE poll because the previous capture engine has not been
+	 * torn down on the host side.
+	 */
+	rd.header.dest   = DSL_CTL_HW_STATUS;
+	rd.header.offset = 0;
+	rd.header.size   = 1;
+	rd.data          = &hw_status;
+	if (command_ctl_rd_v2(hdl, rd) == SR_OK && (hw_status & bmFPGA_DONE)) {
+		sr_info("FPGA already configured (HW_STATUS=0x%02x); skipping bitstream upload.",
+			hw_status);
+		if (dsl_wr_reg_v2(sdi, CTR0_ADDR, 0) != SR_OK)
+			sr_warn("CTR0_ADDR dessert-clear failed on warm path.");
+		return SR_OK;
 	}
 
 	sr_dbg("Uploading FPGA bitstream '%s' via V2 envelope protocol.", name);

--- a/src/hardware/dreamsourcelab-dslogic/protocol_v2.c
+++ b/src/hardware/dreamsourcelab-dslogic/protocol_v2.c
@@ -492,29 +492,45 @@ static const struct dslogic_channel_mode *v2_current_channel_mode(const struct d
  * way: 16/12/6/3 ch at 20/25/50/100 MHz. The smallest mode whose
  * max_samplerate covers the requested rate wins.
  */
-SR_PRIV uint8_t dslogic_plus_auto_pick_mode_id(uint64_t samplerate, gboolean continuous)
+/*
+ * Pick the channel mode that fits the requested samplerate and the
+ * smallest channel-count >= `need_channels` (max-enabled-channel-index+1)
+ * under continuous_mode. Smaller channel counts use less USB bandwidth,
+ * letting higher sample rates fit USB 2.0 HS's ~50 MB/s ceiling.
+ */
+SR_PRIV uint8_t dslogic_plus_auto_pick_mode_id(uint64_t samplerate,
+		gboolean continuous, unsigned int need_channels)
 {
 	size_t i, n;
 	const struct dslogic_channel_mode *modes = dslogic_plus_channel_modes(&n);
 	const struct dslogic_channel_mode *best = NULL;
 
+	if (need_channels == 0)
+		need_channels = 1;
+
 	for (i = 0; i < n; i++) {
 		if (modes[i].stream != continuous)
 			continue;
+		if (modes[i].num_channels < need_channels)
+			continue;
 		if (samplerate > modes[i].max_samplerate)
 			continue;
-		/* Prefer the mode with the highest channel count that still
-		 * supports this samplerate. */
-		if (!best || modes[i].num_channels > best->num_channels)
+		/*
+		 * Prefer the mode with the SMALLEST num_channels that still
+		 * fits — minimises USB bandwidth so high samplerates can
+		 * stream cleanly.
+		 */
+		if (!best || modes[i].num_channels < best->num_channels)
 			best = &modes[i];
 	}
 	if (best)
 		return best->id;
-	/* No exact fit (rate too high for any stream/buffer mode): fall
-	 * back to the mode with the highest max_samplerate in this
-	 * stream/buffer category. */
+	/* No exact fit: fall back to the mode with the most channels at
+	 * the highest max_samplerate that satisfies need_channels. */
 	for (i = 0; i < n; i++) {
 		if (modes[i].stream != continuous)
+			continue;
+		if (modes[i].num_channels < need_channels)
 			continue;
 		if (!best || modes[i].max_samplerate > best->max_samplerate)
 			best = &modes[i];
@@ -641,14 +657,23 @@ static void v2_build_default_setting(const struct sr_dev_inst *sdi,
 	s->dso_cnt_h = 0;
 
 	/*
-	 * Enable the low-N channels for the active mode (mirrors DSView's
-	 * default "use channels 0..num_channels-1"). 16-bit mask, channels
-	 * 16..31 not present on DSLogic Plus so ch_en_h stays 0.
+	 * Channel enable mask = sigrok's enabled channels AND the active
+	 * mode's capability cap. This drops bandwidth on the FPGA->host
+	 * link to only what the user asked to see, letting high samplerates
+	 * fit USB 2.0 HS's ~50 MB/s ceiling. If no channels are enabled
+	 * (degenerate), fall back to ch0.
 	 */
-	if (cm->num_channels >= 16)
-		ch_en_mask = 0xffff;
-	else
-		ch_en_mask = (1U << cm->num_channels) - 1U;
+	{
+		uint16_t cap_mask;
+		uint16_t user_mask = enabled_channel_mask(sdi);
+		if (cm->num_channels >= 16)
+			cap_mask = 0xffff;
+		else
+			cap_mask = (uint16_t)((1U << cm->num_channels) - 1U);
+		ch_en_mask = user_mask & cap_mask;
+		if (ch_en_mask == 0)
+			ch_en_mask = 1;
+	}
 	s->ch_en_l = (uint16_t)ch_en_mask;
 	s->ch_en_h = 0;
 
@@ -808,14 +833,28 @@ static int v2_acquisition_stop(const struct sr_dev_inst *sdi)
 	return command_ctl_wr_v2(usb->devhdl, wr);
 }
 
+/* Compute "need_channels" as max_enabled_index + 1, so contiguous-low
+ * channels (0..N-1) trigger a small mode while sparse selections fall
+ * back to a wider mode that covers the highest index in use. */
+static unsigned int v2_max_enabled_plus_one(const struct sr_dev_inst *sdi)
+{
+	uint16_t mask = enabled_channel_mask(sdi);
+	unsigned int hi = 0, i;
+	for (i = 0; i < 16; i++) {
+		if (mask & (1U << i))
+			hi = i + 1;
+	}
+	return hi ? hi : 1;
+}
+
 static int v2_set_samplerate(const struct sr_dev_inst *sdi, uint64_t rate)
 {
 	struct dev_context *devc = sdi->priv;
 	devc->cur_samplerate = rate;
-	/* Auto-pick the channel mode that fits this rate under the current
-	 * stream/buffer choice. The setting struct is rebuilt at arm time,
-	 * so updating ch_mode_id here is enough. */
-	devc->ch_mode_id = dslogic_plus_auto_pick_mode_id(rate, devc->continuous_mode);
+	/* Auto-pick the channel mode that fits this rate + enabled-channel
+	 * count under the current stream/buffer choice. */
+	devc->ch_mode_id = dslogic_plus_auto_pick_mode_id(rate,
+		devc->continuous_mode, v2_max_enabled_plus_one(sdi));
 	return SR_OK;
 }
 

--- a/src/hardware/dreamsourcelab-dslogic/protocol_v2.c
+++ b/src/hardware/dreamsourcelab-dslogic/protocol_v2.c
@@ -555,6 +555,114 @@ SR_PRIV uint8_t dslogic_plus_auto_pick_mode_id(uint64_t samplerate,
 /* Forward decl: defined later, used in v2_build_default_setting. */
 static unsigned int v2_max_enabled_plus_one(const struct sr_dev_inst *sdi);
 
+/*
+ * Encode the libsigrok session trigger (if any) into the DSL_setting
+ * trig_* fields and return the number of trigger stages (0 = no trigger).
+ *
+ * Field semantics (mirrors DSView trigger.c bit packing):
+ *   trig_mask  bit i = 1 -> "don't care" or edge-trigger on channel i
+ *   trig_value bit i   = expected level when mask bit is 0
+ *   trig_edge  bit i = 1 -> require edge transition on channel i
+ *   trig_logic   = (stage_logic << 1) + invert    [stage active]
+ *                = 2 ("always true")             [unused stages]
+ *
+ * SR match types map per channel as:
+ *   ZERO    -> mask=0,  value=0, edge=0
+ *   ONE     -> mask=0,  value=1, edge=0
+ *   FALLING -> mask=0,  value=0, edge=1
+ *   RISING  -> mask=0,  value=1, edge=1
+ *   EDGE    -> mask=1,  value=0, edge=1   (either edge)
+ *
+ * Mirroring trig_mask0/value0/edge0 to trig_mask1/value1/edge1 means
+ * the same condition must hold for both halves of the FPGA's
+ * comparator network; that's what DSView SIMPLE_TRIGGER does.
+ */
+static int v2_encode_trigger(const struct sr_dev_inst *sdi,
+			     struct DSL_setting *s)
+{
+	struct sr_trigger *trigger;
+	struct sr_trigger_stage *stage;
+	struct sr_trigger_match *match;
+	const GSList *l, *m;
+	int num_stages = 0;
+	int i;
+
+	for (i = 0; i < NUM_TRIGGER_STAGES; i++) {
+		s->trig_mask0[i]  = 0xffff;
+		s->trig_mask1[i]  = 0xffff;
+		s->trig_value0[i] = 0;
+		s->trig_value1[i] = 0;
+		s->trig_edge0[i]  = 0;
+		s->trig_edge1[i]  = 0;
+		s->trig_logic0[i] = 2;
+		s->trig_logic1[i] = 2;
+		s->trig_count[i]  = 0;
+	}
+
+	if (!(trigger = sr_session_trigger_get(sdi->session)))
+		return 0;
+
+	for (l = trigger->stages; l; l = l->next) {
+		stage = l->data;
+		num_stages++;
+		for (m = stage->matches; m; m = m->next) {
+			uint16_t bit;
+			match = m->data;
+			if (!match->channel->enabled)
+				continue;
+			if (match->channel->index >= 16)
+				continue;
+			bit = (uint16_t)(1U << match->channel->index);
+			switch (match->match) {
+			case SR_TRIGGER_ONE:
+				s->trig_mask0[0]  = (uint16_t)(s->trig_mask0[0]  & ~bit);
+				s->trig_mask1[0]  = (uint16_t)(s->trig_mask1[0]  & ~bit);
+				s->trig_value0[0] = (uint16_t)(s->trig_value0[0] |  bit);
+				s->trig_value1[0] = (uint16_t)(s->trig_value1[0] |  bit);
+				break;
+			case SR_TRIGGER_ZERO:
+				s->trig_mask0[0]  = (uint16_t)(s->trig_mask0[0]  & ~bit);
+				s->trig_mask1[0]  = (uint16_t)(s->trig_mask1[0]  & ~bit);
+				break;
+			case SR_TRIGGER_FALLING:
+				s->trig_mask0[0]  = (uint16_t)(s->trig_mask0[0]  & ~bit);
+				s->trig_mask1[0]  = (uint16_t)(s->trig_mask1[0]  & ~bit);
+				s->trig_edge0[0]  = (uint16_t)(s->trig_edge0[0]  |  bit);
+				s->trig_edge1[0]  = (uint16_t)(s->trig_edge1[0]  |  bit);
+				break;
+			case SR_TRIGGER_RISING:
+				s->trig_mask0[0]  = (uint16_t)(s->trig_mask0[0]  & ~bit);
+				s->trig_mask1[0]  = (uint16_t)(s->trig_mask1[0]  & ~bit);
+				s->trig_value0[0] = (uint16_t)(s->trig_value0[0] |  bit);
+				s->trig_value1[0] = (uint16_t)(s->trig_value1[0] |  bit);
+				s->trig_edge0[0]  = (uint16_t)(s->trig_edge0[0]  |  bit);
+				s->trig_edge1[0]  = (uint16_t)(s->trig_edge1[0]  |  bit);
+				break;
+			case SR_TRIGGER_EDGE:
+				s->trig_edge0[0]  = (uint16_t)(s->trig_edge0[0]  |  bit);
+				s->trig_edge1[0]  = (uint16_t)(s->trig_edge1[0]  |  bit);
+				break;
+			default:
+				break;
+			}
+		}
+	}
+
+	if (num_stages > 0) {
+		/* Active stage uses AND-of-conditions, non-inverted. */
+		s->trig_logic0[0] = 0;
+		s->trig_logic1[0] = 0;
+		/*
+		 * Enable the FPGA's trigger comparator. Without this bit the
+		 * trig_* fields are ignored and the capture starts immediately
+		 * on arm. (DSView dsl.c:1060 packs trigger_en into this bit.)
+		 */
+		s->mode |= (uint16_t)(1U << DS_MODE_TRIG_EN_BIT);
+	}
+
+	return num_stages;
+}
+
 static void v2_build_default_setting(const struct sr_dev_inst *sdi,
 				     struct DSL_setting *s)
 {
@@ -564,7 +672,6 @@ static void v2_build_default_setting(const struct sr_dev_inst *sdi,
 	uint64_t cur_sr;
 	uint64_t count_units;
 	uint32_t ch_en_mask;
-	int i;
 
 	/*
 	 * Re-pick the channel mode here so it sees the FINAL enabled-channel
@@ -659,12 +766,27 @@ static void v2_build_default_setting(const struct sr_dev_inst *sdi,
 	s->cnt_l = count_units & 0xffff;
 	s->cnt_h = (count_units >> 16) & 0xffff;
 
-	/* trig_pos = 0 (no pre-trigger). */
-	s->tpos_l = 0;
-	s->tpos_h = 0;
-
-	/* trig_glb = 0 (no trigger). */
-	s->trig_glb = 0;
+	/*
+	 * Trigger position. capture_ratio is a percentage of limit_samples
+	 * that should sit BEFORE the trigger fires (pre-trigger memory).
+	 * The FPGA buffer is divided in 64-sample atomic blocks; align to
+	 * that. Clamp to 10% in streaming mode (DSView dsl.c:1101-1104)
+	 * and 90% in buffered mode (DSL_MAX_TRIG_PERCENT, dsl.c:1104).
+	 */
+	{
+		uint32_t mem_depth = (uint32_t)devc->profile->mem_depth;
+		uint32_t tpos = (uint32_t)((devc->capture_ratio *
+				devc->limit_samples) / 100U);
+		uint32_t cap = devc->continuous_mode ? (mem_depth * 10U / 100U)
+						     : (mem_depth * 90U / 100U);
+		if (tpos < 64U)
+			tpos = 64U;
+		if (tpos > cap)
+			tpos = cap;
+		tpos &= ~63U;   /* align down to 64-sample boundary */
+		s->tpos_l = (uint16_t)(tpos & 0xffff);
+		s->tpos_h = (uint16_t)(tpos >> 16);
+	}
 
 	/* dso_cnt = 0 (unused in logic mode). */
 	s->dso_cnt_l = 0;
@@ -695,22 +817,19 @@ static void v2_build_default_setting(const struct sr_dev_inst *sdi,
 	s->fgain = 0;
 
 	/*
-	 * Trigger arrays - "no trigger" defaults, mirroring dsl.c
-	 * (the i >= 1 loop in the SIMPLE_TRIGGER branch; we apply it to all
-	 * stages since we have no active trigger stage).
-	 *
-	 * memset already zeroed value/edge/count; set mask and logic explicitly.
+	 * Trigger encoding. Reads sr_session_trigger_get() and packs
+	 * channel-level conditions into stage 0; remaining stages are
+	 * filled with "always true" defaults. trig_glb mirrors DSView
+	 * dsl.c:1109 - upper 5 bits are enabled-channel count, low byte
+	 * is the encoded stage count (0 = SIMPLE_TRIGGER single stage).
 	 */
-	for (i = 0; i < NUM_TRIGGER_STAGES; i++) {
-		s->trig_mask0[i]  = 0xffff;
-		s->trig_mask1[i]  = 0xffff;
-		s->trig_value0[i] = 0;
-		s->trig_value1[i] = 0;
-		s->trig_edge0[i]  = 0;
-		s->trig_edge1[i]  = 0;
-		s->trig_logic0[i] = 2;   /* "always" per DSView */
-		s->trig_logic1[i] = 2;
-		s->trig_count[i]  = 0;
+	{
+		int num_stages = v2_encode_trigger(sdi, s);
+		unsigned int ch_num = enabled_channel_count(sdi);
+		unsigned int stage_field =
+			(num_stages > 0) ? (unsigned int)(num_stages - 1) : 0U;
+		s->trig_glb = (uint16_t)(((ch_num & 0x1fU) << 8) |
+					 (stage_field & 0xffU));
 	}
 }
 

--- a/src/hardware/dreamsourcelab-dslogic/protocol_v2.h
+++ b/src/hardware/dreamsourcelab-dslogic/protocol_v2.h
@@ -133,6 +133,44 @@ struct DSL_setting {
 #define DSL_SETTING_SYNC      0xf5a5f5a5
 #define DSL_SETTING_END_SYNC  0xfa5afa5a
 
+/*
+ * Bit positions within DSL_setting.mode (mirrors DSView dsl.c).
+ * Only the ones the V2 LOGIC path actually uses are listed here.
+ */
+#define DS_MODE_TRIG_EN_BIT     0
+#define DS_MODE_CLK_TYPE_BIT    1
+#define DS_MODE_CLK_EDGE_BIT    2
+#define DS_MODE_RLE_MODE_BIT    3
+#define DS_MODE_HALF_MODE_BIT   5
+#define DS_MODE_QUAR_MODE_BIT   6
+#define DS_MODE_FILTER_BIT      8
+#define DS_MODE_STRIG_MODE_BIT 11
+#define DS_MODE_STREAM_MODE_BIT 12
+
+/*
+ * Channel-mode table. One entry per DSLogic Plus channel-count /
+ * samplerate preset that the FPGA supports. Mirrors DSView's
+ * struct DSL_channels with only the fields the LOGIC capture path needs.
+ *
+ * `id` is a stable numeric handle exposed via SR_CONF_CHANNEL_MODE so
+ * the user can pick "16 channels buffered at up to 100 MHz" vs
+ * "3 channels streamed at up to 100 MHz", etc.
+ */
+struct dslogic_channel_mode {
+	uint8_t  id;
+	gboolean stream;
+	uint16_t num_channels;
+	uint64_t min_samplerate;
+	uint64_t max_samplerate;
+	uint64_t hw_max_samplerate;
+	uint8_t  pre_div;
+	const char *descr;
+};
+
+SR_PRIV const struct dslogic_channel_mode *dslogic_plus_channel_modes(size_t *count);
+SR_PRIV const struct dslogic_channel_mode *dslogic_plus_channel_mode_default(void);
+SR_PRIV const struct dslogic_channel_mode *dslogic_plus_channel_mode_by_id(uint8_t id);
+
 /* Transport primitives. */
 SR_PRIV int command_ctl_wr_v2(libusb_device_handle *devhdl, struct ctl_wr_cmd cmd);
 SR_PRIV int command_ctl_rd_v2(libusb_device_handle *devhdl, struct ctl_rd_cmd cmd);

--- a/src/hardware/dreamsourcelab-dslogic/protocol_v2.h
+++ b/src/hardware/dreamsourcelab-dslogic/protocol_v2.h
@@ -1,0 +1,148 @@
+/*
+ * This file is part of the libsigrok project.
+ *
+ * Copyright (C) 2013 Bert Vermeulen <bert@biot.com>
+ * Copyright (C) 2013-2017 DreamSourceLab <support@dreamsourcelab.com>
+ * Copyright (C) 2026 Larry Hernandez <l.gr@dartmouth.edu>
+ *
+ * Constants, structs, and prototypes for the DSLogic envelope (v2)
+ * protocol used by newer-firmware DSLogic hardware (PID 2a0e:0034
+ * and any later device tagged DSL_PROTO_V2).
+ *
+ * Wire format mirrors DSView 1.3.2's libsigrok4DSL/hardware/DSL/.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License v3.
+ */
+
+#ifndef LIBSIGROK_HARDWARE_DREAMSOURCELAB_DSLOGIC_PROTOCOL_V2_H
+#define LIBSIGROK_HARDWARE_DREAMSOURCELAB_DSLOGIC_PROTOCOL_V2_H
+
+#include <stdint.h>
+#include <libusb.h>
+#include "protocol.h"
+
+/* Envelope opcodes (carried in libusb_control_transfer's bRequest). */
+#define CMD_CTL_WR              0xb0
+#define CMD_CTL_RD_PRE          0xb1
+#define CMD_CTL_RD              0xb2
+
+/* DSL_CTL destination codes (selector in ctl_header.dest). */
+#define DSL_CTL_FW_VERSION      0
+#define DSL_CTL_REVID_VERSION   1
+#define DSL_CTL_HW_STATUS       2
+#define DSL_CTL_PROG_B          3
+#define DSL_CTL_SYS             4
+#define DSL_CTL_LED             5
+#define DSL_CTL_INTRDY          6
+#define DSL_CTL_WORDWIDE        7
+#define DSL_CTL_START           8
+#define DSL_CTL_STOP            9
+#define DSL_CTL_BULK_WR        10
+#define DSL_CTL_REG            11
+#define DSL_CTL_NVM            12
+#define DSL_CTL_I2C_REG        14
+#define DSL_CTL_I2C_STATUS     15
+
+/* Status bits in DSL_CTL_HW_STATUS read byte. */
+#define bmGPIF_DONE     (1 << 7)
+#define bmFPGA_DONE     (1 << 6)
+#define bmFPGA_INIT_B   (1 << 5)
+#define bmSYS_OVERFLOW  (1 << 4)
+#define bmSYS_CLR       (1 << 3)
+#define bmSYS_EN        (1 << 2)
+
+/* Bits written via DSL_CTL_INTRDY / DSL_CTL_WORDWIDE / DSL_CTL_PROG_B. */
+#define bmWR_INTRDY     (1 << 7)
+#define bmWR_WORDWIDE   (1 << 0)
+#define bmWR_PROG_B     (1 << 2)
+
+/* Bits written via DSL_CTL_LED. */
+#define bmLED_GREEN     (1 << 0)
+#define bmLED_RED       (1 << 1)
+
+/* I2C-mapped FPGA register addresses. */
+#define VTH_ADDR        0x78
+#define SEC_DATA_ADDR   0x75
+#define SEC_CTRL_ADDR   0x73
+#define CTR0_ADDR       0x70
+
+/* CTR0_ADDR bits (mirrors DSView command.h). */
+#define bmFORCE_RDY     (1 << 1)
+
+/* Security check (mirrors DSView command.c). */
+#define bmSECU_READY    (1 << 3)
+#define bmSECU_PASS     (1 << 4)
+#define SECU_STEPS      8
+#define SECU_START      0x0513
+#define SECU_CHECK      0x0219
+#define SECU_EEP_ADDR   0x3C00
+#define SECU_TRY_CNT    8
+
+/* Trigger / setting blob (mirrors DSView dsl.h). */
+#ifndef NUM_TRIGGER_STAGES
+#define NUM_TRIGGER_STAGES   16
+#endif
+
+#pragma pack(push, 1)
+
+struct ctl_header {
+	uint8_t dest;
+	uint16_t offset;
+	uint8_t size;
+};
+
+struct ctl_wr_cmd {
+	struct ctl_header header;
+	uint8_t data[60];
+};
+
+struct ctl_rd_cmd {
+	struct ctl_header header;
+	uint8_t *data;
+};
+
+struct DSL_setting {
+	uint32_t sync;
+	uint16_t mode_header;       uint16_t mode;
+	uint16_t divider_header;    uint16_t div_l, div_h;
+	uint16_t count_header;      uint16_t cnt_l, cnt_h;
+	uint16_t trig_pos_header;   uint16_t tpos_l, tpos_h;
+	uint16_t trig_glb_header;   uint16_t trig_glb;
+	uint16_t dso_count_header;  uint16_t dso_cnt_l, dso_cnt_h;
+	uint16_t ch_en_header;      uint16_t ch_en_l, ch_en_h;
+	uint16_t fgain_header;      uint16_t fgain;
+
+	uint16_t trig_header;
+	uint16_t trig_mask0[NUM_TRIGGER_STAGES];
+	uint16_t trig_mask1[NUM_TRIGGER_STAGES];
+	uint16_t trig_value0[NUM_TRIGGER_STAGES];
+	uint16_t trig_value1[NUM_TRIGGER_STAGES];
+	uint16_t trig_edge0[NUM_TRIGGER_STAGES];
+	uint16_t trig_edge1[NUM_TRIGGER_STAGES];
+	uint16_t trig_logic0[NUM_TRIGGER_STAGES];
+	uint16_t trig_logic1[NUM_TRIGGER_STAGES];
+	uint32_t trig_count[NUM_TRIGGER_STAGES];
+
+	uint32_t end_sync;
+};
+
+#pragma pack(pop)
+
+/* Sync markers used by DSL_setting (mirrors DSView dsl.c constants). */
+#define DSL_SETTING_SYNC      0xf5a5f5a5
+#define DSL_SETTING_END_SYNC  0xfa5afa5a
+
+/* Transport primitives. */
+SR_PRIV int command_ctl_wr_v2(libusb_device_handle *devhdl, struct ctl_wr_cmd cmd);
+SR_PRIV int command_ctl_rd_v2(libusb_device_handle *devhdl, struct ctl_rd_cmd cmd);
+
+/* Register / NVM access (envelope wrappers). */
+SR_PRIV int dsl_wr_reg_v2(const struct sr_dev_inst *sdi, uint16_t addr, uint8_t value);
+SR_PRIV int dsl_rd_reg_v2(const struct sr_dev_inst *sdi, uint16_t addr, uint8_t *value);
+SR_PRIV int dsl_rd_nvm_v2(const struct sr_dev_inst *sdi, uint8_t *buf, uint16_t addr, uint8_t len);
+
+/* HW status polling helper. */
+SR_PRIV int dsl_wait_hw_status_bit_v2(libusb_device_handle *hdl, uint8_t bit_mask, gboolean want_set, unsigned timeout_ms);
+
+#endif

--- a/src/hardware/dreamsourcelab-dslogic/protocol_v2.h
+++ b/src/hardware/dreamsourcelab-dslogic/protocol_v2.h
@@ -170,7 +170,8 @@ struct dslogic_channel_mode {
 SR_PRIV const struct dslogic_channel_mode *dslogic_plus_channel_modes(size_t *count);
 SR_PRIV const struct dslogic_channel_mode *dslogic_plus_channel_mode_default(void);
 SR_PRIV const struct dslogic_channel_mode *dslogic_plus_channel_mode_by_id(uint8_t id);
-SR_PRIV uint8_t dslogic_plus_auto_pick_mode_id(uint64_t samplerate, gboolean continuous);
+SR_PRIV uint8_t dslogic_plus_auto_pick_mode_id(uint64_t samplerate,
+		gboolean continuous, unsigned int need_channels);
 
 /* Transport primitives. */
 SR_PRIV int command_ctl_wr_v2(libusb_device_handle *devhdl, struct ctl_wr_cmd cmd);

--- a/src/hardware/dreamsourcelab-dslogic/protocol_v2.h
+++ b/src/hardware/dreamsourcelab-dslogic/protocol_v2.h
@@ -170,6 +170,7 @@ struct dslogic_channel_mode {
 SR_PRIV const struct dslogic_channel_mode *dslogic_plus_channel_modes(size_t *count);
 SR_PRIV const struct dslogic_channel_mode *dslogic_plus_channel_mode_default(void);
 SR_PRIV const struct dslogic_channel_mode *dslogic_plus_channel_mode_by_id(uint8_t id);
+SR_PRIV uint8_t dslogic_plus_auto_pick_mode_id(uint64_t samplerate, gboolean continuous);
 
 /* Transport primitives. */
 SR_PRIV int command_ctl_wr_v2(libusb_device_handle *devhdl, struct ctl_wr_cmd cmd);


### PR DESCRIPTION
## Summary

Adds real trigger encoding to the V2 (DSLogic Plus Pango) path. Before this, `v2_set_trigger` was a no-op stub and the `DSL_setting` `trig_*` fields were hardcoded to "always true" — so `-t` flags on V2 devices were silently dropped and captures started immediately on arm. With this, `sigrok-cli -t '3=f'` (CS-falling-edge) works the same way it does in DSView.

**Stacked on #292** (and transitively #291). The diff here will narrow to one commit once the bases land.

## What's in this PR (1 commit)

**V2 simple-trigger encoding** — walks `sr_session_trigger_get()`'s stages, packs per-channel matches (ZERO / ONE / RISING / FALLING / EDGE) into stage 0 of the `DSL_setting`'s `trig_mask0/value0/edge0` (mirrored to `mask1/value1/edge1`), and enables the FPGA's trigger comparator via mode bit 0 (`TRIG_EN`). Without `TRIG_EN`, the FPGA ignores the `trig_*` fields entirely; this was the missing piece behind the first iteration looking like the encoding was wrong.

Trigger position from `capture_ratio`, aligned to the FPGA's 64-sample atomic unit, clamped to 10% in streaming mode and 90% in buffered mode (matches DSView's `DS_MAX_TRIG_PERCENT`). `trig_glb` packs the enabled-channel count + stage count per DSView's layout.

Encoding mirrors DSView's `SIMPLE_TRIGGER` path: only stage 0 carries the user condition; remaining stages stay as `mask=0xffff` / `logic=2` ("always true"). Sufficient for the single-condition / single-channel triggers `sigrok-cli`'s `-t` exposes (`SR_TRIGGER_MATCH` list in the driver advertises ZERO / ONE / RISING / FALLING / EDGE).

## Verification

End-to-end: 100 MHz buffered RLE on channels 0..3 with `-t '3=f'` (CS-falling) captures the actual SPI traffic on a live SX1276 bus. With a plain `spi` decoder downstream, transactions decode cleanly — burst register reads/writes and FIFO accesses across the post-trigger window.

## Test plan

- [ ] `make` builds clean
- [ ] `sigrok-cli -d dreamsourcelab-dslogic -C 0,1,2,3 -c samplerate=100000000 -c rle=on --samples 10000000 -t '3=f' -O bits` waits for the trigger then captures
- [ ] Captures **without** a trigger still start immediately (no behaviour change for untriggered runs)
- [ ] `-t '0=r'`, `-t '0=f'`, `-t '0=0'`, `-t '0=1'`, `-t '0=e'` each gate correctly on the corresponding edge / level / change